### PR TITLE
Fix grid rotation

### DIFF
--- a/src/components/pixi-tephra-cross-section.tsx
+++ b/src/components/pixi-tephra-cross-section.tsx
@@ -46,7 +46,7 @@ const Bar =  PixiComponent<IBarProps, PIXI.Graphics>("Bar", {
 export const PixiTephraCrossSection = (props: IProps) => {
   const { canvasMetrics, data } = props;
   const { numCols, numRows, gridSize, height } = canvasMetrics;
-  const getData = (x: number, y: number) => data[x + y * numCols];
+  const getData = (x: number, y: number) => data[y + x * numRows];
   const cells = [];
   const maxTephra = 1;
   for (let gridX = 0; gridX < numCols; gridX++) {

--- a/src/components/pixi-tephra-cross-section.tsx
+++ b/src/components/pixi-tephra-cross-section.tsx
@@ -5,6 +5,7 @@ import { PixiComponent } from "@inlet/react-pixi";
 import { ICanvasShape } from "../interfaces";
 import * as PIXI from "pixi.js";
 import * as Color from "color";
+import { getGridIndexForLocation } from "../stores/simulation-store";
 
 interface IProps {
   canvasMetrics: ICanvasShape;
@@ -46,7 +47,7 @@ const Bar =  PixiComponent<IBarProps, PIXI.Graphics>("Bar", {
 export const PixiTephraCrossSection = (props: IProps) => {
   const { canvasMetrics, data } = props;
   const { numCols, numRows, gridSize, height } = canvasMetrics;
-  const getData = (x: number, y: number) => data[y + x * numRows];
+  const getData = (x: number, y: number) => data[getGridIndexForLocation(x, y, numRows)];
   const cells = [];
   const maxTephra = 1;
   for (let gridX = 0; gridX < numCols; gridX++) {

--- a/src/components/pixi-tephra-map.tsx
+++ b/src/components/pixi-tephra-map.tsx
@@ -39,7 +39,7 @@ export const PixiTephraMap = (props: IProps) => {
   const { canvasMetrics, gridColors, toCanvasCoords } = props;
   const { numCols, numRows, gridSize } = canvasMetrics;
   const getColor = (x: number, y: number) =>
-    gridColors[x + y * numCols] || "hsla(0, 0%, 100%, 0)";
+    gridColors[y + x * numRows] || "hsla(0, 0%, 100%, 0)";
   const cells = [];
   for (let gridX = 0; gridX < numCols; gridX++) {
     for (let gridY = 0; gridY < numRows; gridY++) {

--- a/src/components/pixi-tephra-map.tsx
+++ b/src/components/pixi-tephra-map.tsx
@@ -5,6 +5,7 @@ import { PixiComponent } from "@inlet/react-pixi";
 import { ICanvasShape, Ipoint } from "../interfaces";
 import * as PIXI from "pixi.js";
 import * as Color from "color";
+import { getGridIndexForLocation } from "../stores/simulation-store";
 
 interface IProps {
   canvasMetrics: ICanvasShape;
@@ -39,7 +40,7 @@ export const PixiTephraMap = (props: IProps) => {
   const { canvasMetrics, gridColors, toCanvasCoords } = props;
   const { numCols, numRows, gridSize } = canvasMetrics;
   const getColor = (x: number, y: number) =>
-    gridColors[y + x * numRows] || "hsla(0, 0%, 100%, 0)";
+    gridColors[getGridIndexForLocation(x, y, numRows)] || "hsla(0, 0%, 100%, 0)";
   const cells = [];
   for (let gridX = 0; gridX < numCols; gridX++) {
     for (let gridY = 0; gridY < numRows; gridY++) {

--- a/src/stores/simulation-store.ts
+++ b/src/stores/simulation-store.ts
@@ -46,6 +46,10 @@ export interface SimulationAuthoringOptions {
   map: string;
 }
 
+export function getGridIndexForLocation(x: number, y: number, numRows: number) {
+  return y + x * numRows;
+}
+
 export const SimulationStore = types
   .model("simulation", {
     numRows: 14,
@@ -97,7 +101,7 @@ export const SimulationStore = types
             self.mass,
             self.particleSize
           );
-          self.data.push( {thickness: simResults});
+          self.data[getGridIndexForLocation(x, y, rows)] = {thickness: simResults};
         }
       }
 

--- a/src/stores/simulation-store.ts
+++ b/src/stores/simulation-store.ts
@@ -90,7 +90,7 @@ export const SimulationStore = types
       for (let x = 0; x < rows; x ++) {
         for (let y = 0; y < cols; y++) {
           const simResults = gridTephraCalc(
-            x, y, vY, vX,   // TODO: Why are vX and vY inverted?
+            x, y, vX, vY,
             self.windSpeed,
             self.windDirection,
             self.colHeight,

--- a/src/tephra2.ts
+++ b/src/tephra2.ts
@@ -36,9 +36,10 @@ const tephraCalc = (
 // calculates the mass loading of tephra at a point x,y (meters)
 // from a volcanic vent located at xvent, yvent (m)
 // mass (kg) is released from a height localColHeight (m)
-// into a windfield with velocity wind_speed (m/s) blowing toward the positive x direction
+// into a windfield with velocity wind_speed (m/s) blowing toward the positive y direction
 // particles have a settling_speed (m/s) and diffusion (m**2/s)
 // updated on 2019-04-23
+// edited 2019-04-2 from the provided calc to make assume windspeed is in the positive y direction
 const tephraCalc2 = (
   x: number,
   y: number,
@@ -68,9 +69,9 @@ const tephraCalc2 = (
     for (i = 1; i <= colSteps; i++){
         localColHeight = i * colInterval;
 
-        term1 = ( x - (xvent + windSpeed * localColHeight / settlingSpeed) );
+        term1 = ( y - (yvent + windSpeed * localColHeight / settlingSpeed) );
         term1 = Math.pow(term1, 2);
-        term2 = Math.pow(y - yvent, 2);
+        term2 = Math.pow(x - xvent, 2);
         term3 = settlingSpeed * colMassInterval / (4 * Math.PI * localColHeight * diffusion);
         term4 = 4 * diffusion * localColHeight / settlingSpeed;
         masLoading += term3 * Math.exp( -term1 / term4 - term2 / term4);

--- a/src/utilities/grid-transform.tsx
+++ b/src/utilities/grid-transform.tsx
@@ -5,7 +5,7 @@ export const makeRotMatrix = (angleDeg: number, center: Ipoint) => {
   const angleRad = (angleDeg / 360) * 2 * Math.PI;
   return transform(
     translate(center.x, center.y),
-    rotate(-angleRad),
+    rotate(angleRad),
     translate(-center.x, -center.y),
   );
 };


### PR DESCRIPTION
This fixes the underlying problem, which was there from the beginning, which is that the tephra map painted grid cells in the wrong locations, flipped along the x=y axis.

This then masked two other problems (or made us work around them) which is that the tephra calculations assume that the wind is blowing along the x axis, and that the rotation transformation was being applied in the negative direction.