### PR TITLE
Author url params

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -27,7 +27,7 @@ export interface SimulationAuthoringOptions {
 }
 
 interface IState {
-  showOptionsDialog: boolean;
+  expandOptionsDialog: boolean;
   simulationOptions: SimulationAuthoringOptions;
 }
 
@@ -61,7 +61,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     super(props);
 
     const initialState: IState = {
-      showOptionsDialog: false,
+      expandOptionsDialog: false,
       simulationOptions: {
         requireEruption: true,
         requirePainting: true,
@@ -119,7 +119,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     } = this.stores;
 
     const {
-      showOptionsDialog,
+      expandOptionsDialog,
       simulationOptions
     } = this.state;
 
@@ -186,7 +186,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
 
         <DatGui data={simulationOptions} onUpdate={this.handleUpdate}>
           <DatButton label="Model options" onClick={this.toggleShowOptions} />
-          { showOptionsDialog &&
+          { expandOptionsDialog &&
             [
               <DatBoolean path="requireEruption" label="Require eruption?" key="requireEruption" />,
               <DatBoolean path="requirePainting" label="Require painting?" key="requirePainting" />,
@@ -205,7 +205,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     );
   }
 
-  private toggleShowOptions = () => this.setState({showOptionsDialog: !this.state.showOptionsDialog});
+  private toggleShowOptions = () => this.setState({expandOptionsDialog: !this.state.expandOptionsDialog});
 
   private handleUpdate = (simulationOptions: any) => this.setState({ simulationOptions });
 

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -18,6 +18,7 @@ import RunButtons from "./run-buttons";
 interface IProps extends IBaseProps {}
 
 export interface SimulationAuthoringOptions {
+  [key: string]: any;
   requireEruption: boolean;
   requirePainting: boolean;
   map: string;
@@ -55,16 +56,40 @@ const Code = styled.div`
 @inject("stores")
 @observer
 export class AppComponent extends BaseComponent<IProps, IState> {
-  public state: IState = {
-    showOptionsDialog: false,
-    simulationOptions: {
-      requireEruption: true,
-      requirePainting: true,
-      map: "Mt Redoubt",
-      toolbox: "Everything",
-      initialCode: "Basic",
+
+  public constructor(props: IProps) {
+    super(props);
+
+    const initialState: IState = {
+      showOptionsDialog: false,
+      simulationOptions: {
+        requireEruption: true,
+        requirePainting: true,
+        map: "Mt Redoubt",
+        toolbox: "Everything",
+        initialCode: "Basic",
+      }
+    };
+
+    // load in url params, if any, to state
+    let urlParams: any = {};
+    try {
+      const queryString = location.search.length > 1 ? decodeURIComponent(location.search.substring(1)) : "{}";
+      urlParams = JSON.parse(queryString);
+    } catch (e) {
+      // leave params empty
     }
-  };
+
+    // set simulationOptions while making no assumptions about urlParams object
+    const simulationOptionsKeys = Object.keys(initialState.simulationOptions);
+    simulationOptionsKeys.forEach(option => {
+      if (urlParams.hasOwnProperty(option)) {
+        initialState.simulationOptions[option] = urlParams[option];
+      }
+    });
+
+    this.state = initialState;
+  }
 
   public componentDidUpdate() {
     this.stores.setAuthoringOptions(this.state.simulationOptions);

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -169,7 +169,9 @@ export class AppComponent extends BaseComponent<IProps, IState> {
               <DatSelect path="toolbox" label="Code toolbox"
                 options={Object.keys(BlocklyAuthoring.toolbox)} key="toolbox" />,
               <DatSelect path="initialCode" label="Initial code"
-                options={Object.keys(BlocklyAuthoring.code)} key="code" />
+                options={Object.keys(BlocklyAuthoring.code)} key="code" />,
+              // submit button. Should remain at bottom
+              <DatButton label="Generate authored model" onClick={this.generateAndOpenAuthoredUrl} key="generate" />
             ]
           }
         </DatGui>
@@ -181,5 +183,10 @@ export class AppComponent extends BaseComponent<IProps, IState> {
   private toggleShowOptions = () => this.setState({showOptionsDialog: !this.state.showOptionsDialog});
 
   private handleUpdate = (simulationOptions: any) => this.setState({ simulationOptions });
+
+  private generateAndOpenAuthoredUrl = () => {
+    const encodedParams = encodeURIComponent(JSON.stringify(this.state.simulationOptions));
+    window.open(`${location.origin}${location.pathname}?${encodedParams}`, "geocode-app");
+  }
 
 }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -27,6 +27,7 @@ export interface SimulationAuthoringOptions {
 }
 
 interface IState {
+  showOptionsDialog: boolean;
   expandOptionsDialog: boolean;
   simulationOptions: SimulationAuthoringOptions;
 }
@@ -61,6 +62,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     super(props);
 
     const initialState: IState = {
+      showOptionsDialog: true,
       expandOptionsDialog: false,
       simulationOptions: {
         requireEruption: true,
@@ -87,6 +89,11 @@ export class AppComponent extends BaseComponent<IProps, IState> {
         initialState.simulationOptions[option] = urlParams[option];
       }
     });
+
+    // for now, assume that if we've loaded from params that we don't want settings dialog
+    if (Object.keys(urlParams).length > 0) {
+      initialState.showOptionsDialog = false;
+    }
 
     this.state = initialState;
   }
@@ -119,6 +126,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     } = this.stores;
 
     const {
+      showOptionsDialog,
       expandOptionsDialog,
       simulationOptions
     } = this.state;
@@ -184,22 +192,24 @@ export class AppComponent extends BaseComponent<IProps, IState> {
 
         </Simulation>
 
-        <DatGui data={simulationOptions} onUpdate={this.handleUpdate}>
-          <DatButton label="Model options" onClick={this.toggleShowOptions} />
-          { expandOptionsDialog &&
-            [
-              <DatBoolean path="requireEruption" label="Require eruption?" key="requireEruption" />,
-              <DatBoolean path="requirePainting" label="Require painting?" key="requirePainting" />,
-              <DatSelect path="map" label="Map background" options={Object.keys(Maps)} key="background" />,
-              <DatSelect path="toolbox" label="Code toolbox"
-                options={Object.keys(BlocklyAuthoring.toolbox)} key="toolbox" />,
-              <DatSelect path="initialCode" label="Initial code"
-                options={Object.keys(BlocklyAuthoring.code)} key="code" />,
-              // submit button. Should remain at bottom
-              <DatButton label="Generate authored model" onClick={this.generateAndOpenAuthoredUrl} key="generate" />
-            ]
-          }
-        </DatGui>
+        { showOptionsDialog &&
+          <DatGui data={simulationOptions} onUpdate={this.handleUpdate}>
+            <DatButton label="Model options" onClick={this.toggleShowOptions} />
+            { expandOptionsDialog &&
+              [
+                <DatBoolean path="requireEruption" label="Require eruption?" key="requireEruption" />,
+                <DatBoolean path="requirePainting" label="Require painting?" key="requirePainting" />,
+                <DatSelect path="map" label="Map background" options={Object.keys(Maps)} key="background" />,
+                <DatSelect path="toolbox" label="Code toolbox"
+                  options={Object.keys(BlocklyAuthoring.toolbox)} key="toolbox" />,
+                <DatSelect path="initialCode" label="Initial code"
+                  options={Object.keys(BlocklyAuthoring.code)} key="code" />,
+                // submit button. Should remain at bottom
+                <DatButton label="Generate authored model" onClick={this.generateAndOpenAuthoredUrl} key="generate" />
+              ]
+            }
+          </DatGui>
+        }
 
       </App>
     );


### PR DESCRIPTION
This allows an author to set up a model using the settings dialog, hit the button at the bottom of the dialog, and get a url to a model with those options. The settings dialog will no longer be visible in the authored model.

http://geocode-app.concord.org/branch/author-url-params/index.html