### PR TITLE
Set VEI

### DIFF
--- a/src/assets/blockly-authoring/toolbox/full-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/full-toolbox.xml
@@ -13,6 +13,7 @@
           <block type="setWindSpeed"></block>
           <block type="setEruptionHeight"></block>
           <block type="setEruptionMass"></block>
+          <block type="setVEI"></block>
           <block type="erupt"></block>
           <block type="outputPaintGrid"></block>
           <block type="redrawMap"></block>

--- a/src/public/blocks.js
+++ b/src/public/blocks.js
@@ -377,6 +377,33 @@ Blockly.JavaScript['setEruptionMass'] = function(block) {
   return code;
 };
 
+/************************** VEI: ***********************************/
+Blockly.Blocks['setVEI'] = {
+  init: function() {
+    this.appendValueInput("vei")
+        .setCheck("Number")
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("Set VEI");
+    this.appendDummyInput();
+    this.setInputsInline(true);
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(150);
+    this.setTooltip("Volcanic Explosivity Index");
+    this.setHelpUrl("Volcanic Explosivity Index");
+  }
+};
+
+Blockly.JavaScript['setVEI'] = function(block) {
+  var value_vei = Blockly.JavaScript.valueToCode(block, 'vei', Blockly.JavaScript.ORDER_ATOMIC);
+  // TODO: Assemble JavaScript into code variable.
+  var code = `
+    setVEI(${value_vei});
+
+  `;
+  return code;
+};
+
 
 
 /************************** Erupt : ***********************************/

--- a/src/public/blocks.js
+++ b/src/public/blocks.js
@@ -383,7 +383,7 @@ Blockly.Blocks['setVEI'] = {
     this.appendValueInput("vei")
         .setCheck("Number")
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendField("Set VEI");
+        .appendField("Set VEI (0-8)");
     this.appendDummyInput();
     this.setInputsInline(true);
     this.setPreviousStatement(true, null);

--- a/src/stores/simulation-store.ts
+++ b/src/stores/simulation-store.ts
@@ -133,6 +133,15 @@ export const SimulationStore = types
           self.erupt();
         }
       },
+      setVEI(vei: number) {
+        // for now this is just setting the mass
+        // we want vei 1 = 1e8, vei 8 = 1e15
+        const mass = Math.pow(10, vei + 7);
+        self.mass = mass;
+        if (!self.requireEruption) {
+          self.erupt();
+        }
+      },
       setParticleSize(size: number) {
         self.particleSize = size;
         if (!self.requireEruption) {

--- a/src/stores/simulation-store.ts
+++ b/src/stores/simulation-store.ts
@@ -134,9 +134,10 @@ export const SimulationStore = types
         }
       },
       setVEI(vei: number) {
+        const clippedVEI = Math.max(0, Math.min(vei, 8));
         // for now this is just setting the mass
         // we want vei 1 = 1e8, vei 8 = 1e15
-        const mass = Math.pow(10, vei + 7);
+        const mass = Math.pow(10, clippedVEI + 7);
         self.mass = mass;
         if (!self.requireEruption) {
           self.erupt();

--- a/src/utilities/interpreter.ts
+++ b/src/utilities/interpreter.ts
@@ -13,7 +13,7 @@ const makeInterperterFunc = (simulation: SimulationModelType, workspace: IBlockl
 
     const unwrap = (args: any[]) => {
       const modifiedArgs = args.map( (a) => {
-        if (a.data) {return a.data; }
+        if (a.data !== undefined && a.data !== null) {return a.data; }
         if (a.properties) {
           const returnObject: { [key: string]: any } = {};
           const keys = Object.keys(a.properties);

--- a/src/utilities/interpreter.ts
+++ b/src/utilities/interpreter.ts
@@ -55,6 +55,10 @@ const makeInterperterFunc = (simulation: SimulationModelType, workspace: IBlockl
       simulation.setMass(mass);
     });
 
+    addFunc("setVEI", (vei: number) => {
+      simulation.setVEI(vei);
+    });
+
     addFunc("setVolcano", (params: {x: number, y: number}) => {
       simulation.setVolcano(params.x, params.y);
     });


### PR DESCRIPTION
Unfortunately there is no way of enforcing a specific range for `Number` inputs, if we are allowing variable inputs. (We could enforce a range with a `FieldNumber`, but then the user couldn't loop through values.)

Therefore this just notes the range on the block itself, and then clips in the code.

See e.g. Blockly's own color function, which accepts r, g, b values as variables and then does its own clipping under the hood: https://github.com/google/blockly/blob/d12374b3fbbc2b45579d738c2360856aa74000e6/generators/javascript/colour.js#L50