### PR TITLE
Smaller layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6668,7 +6668,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6689,12 +6690,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6709,17 +6712,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -6836,7 +6842,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -6848,6 +6855,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -6862,6 +6870,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -6869,12 +6878,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -6893,6 +6904,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -6973,7 +6985,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -6985,6 +6998,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7070,7 +7084,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7106,6 +7121,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7125,6 +7141,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7168,12 +7185,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9333,7 +9352,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -9354,12 +9374,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -9374,17 +9396,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -9501,7 +9526,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -9513,6 +9539,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -9527,6 +9554,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -9534,12 +9562,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -9558,6 +9588,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -9638,7 +9669,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -9650,6 +9682,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -9735,7 +9768,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -9771,6 +9805,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -9790,6 +9825,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -9833,12 +9869,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },
@@ -10380,7 +10418,7 @@
       "integrity": "sha1-DHv71+9qU8wbO6FtkGtji/CFUhQ=",
       "requires": {
         "acorn": "^4.0.11",
-        "clone": "github:aminmarashi/clone#d97b4f0ff3d3afebcaaf4a2ecc9c50fbce914900"
+        "clone": "github:aminmarashi/clone#d97b4f"
       },
       "dependencies": {
         "acorn": {
@@ -12922,16 +12960,6 @@
         "tinycolor2": "^1.4.1"
       }
     },
-    "react-container-dimensions": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/react-container-dimensions/-/react-container-dimensions-1.4.1.tgz",
-      "integrity": "sha512-f5WXYpsL0vAuT9hD6bSTqRYOJXFbU9JzjSZfscNT77PbdCUReLv2/aSvYBgkXyALtOBVdS/nwO5RVZgBxxWDnw==",
-      "requires": {
-        "element-resize-detector": "^1.1.10",
-        "invariant": "^2.2.2",
-        "prop-types": "^15.5.8"
-      }
-    },
     "react-compound-slider": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/react-compound-slider/-/react-compound-slider-2.0.0.tgz",
@@ -12956,6 +12984,16 @@
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
           "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
         }
+      }
+    },
+    "react-container-dimensions": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/react-container-dimensions/-/react-container-dimensions-1.4.1.tgz",
+      "integrity": "sha512-f5WXYpsL0vAuT9hD6bSTqRYOJXFbU9JzjSZfscNT77PbdCUReLv2/aSvYBgkXyALtOBVdS/nwO5RVZgBxxWDnw==",
+      "requires": {
+        "element-resize-detector": "^1.1.10",
+        "invariant": "^2.2.2",
+        "prop-types": "^15.5.8"
       }
     },
     "react-dat-gui": {
@@ -14913,7 +14951,7 @@
     },
     "tar": {
       "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3416,6 +3416,11 @@
       "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
       "dev": true
     },
+    "batch-processor": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/batch-processor/-/batch-processor-1.0.0.tgz",
+      "integrity": "sha1-dclcMrdI4IUNEMKxaPa9vpiRrOg="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -5418,6 +5423,14 @@
       "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
+    },
+    "element-resize-detector": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/element-resize-detector/-/element-resize-detector-1.1.15.tgz",
+      "integrity": "sha512-16/5avDegXlUxytGgaumhjyQoM6hpp5j3+L79sYq5hlXfTNRy5WMMuTVWkZU3egp/CokCmTmvf18P3KeB57Iog==",
+      "requires": {
+        "batch-processor": "^1.0.0"
+      }
     },
     "elliptic": {
       "version": "6.4.1",
@@ -8293,7 +8306,6 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.0.0"
       }
@@ -12908,6 +12920,16 @@
         "prop-types": "^15.5.10",
         "reactcss": "^1.2.0",
         "tinycolor2": "^1.4.1"
+      }
+    },
+    "react-container-dimensions": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/react-container-dimensions/-/react-container-dimensions-1.4.1.tgz",
+      "integrity": "sha512-f5WXYpsL0vAuT9hD6bSTqRYOJXFbU9JzjSZfscNT77PbdCUReLv2/aSvYBgkXyALtOBVdS/nwO5RVZgBxxWDnw==",
+      "requires": {
+        "element-resize-detector": "^1.1.10",
+        "invariant": "^2.2.2",
+        "prop-types": "^15.5.8"
       }
     },
     "react-compound-slider": {

--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "prop-types": "^15.7.2",
     "query-string": "^6.2.0",
     "react": "^16.8.6",
+    "react-container-dimensions": "^1.4.1",
     "react-compound-slider": "^2.0.0",
     "react-dat-gui": "^3.0.0",
     "react-dom": "^16.8.6",

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -307,7 +307,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
               }
               </Simulation>
             </Row>
-          );}
+          ); }
         }
       </ContainerDimensions>
     </App>

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -235,260 +235,81 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                     map={ mapPath }
                     isErupting={isErupting}
                   />
-                </Simulation>
-              </Row>
-            ); }
-          }
-                </Simulation>
-              </Row>
-            ); }
-          }
-          { showCode &&
-            <FixWidthTabPanel width={820}>
-              <Code>
-                <SyntaxHighlighter>
-                  {js_beautify(code)}
-                </SyntaxHighlighter>
-              </Code>
-            </FixWidthTabPanel>
-          }
-          { showControls &&
-            <FixWidthTabPanel width={820}>
-              <Controls />
-            </FixWidthTabPanel>
-          }
-        </Tabs>
+                   { showCrossSection &&
+                <CrossSectionComponent
+                  data={ data }
+                  height={ 100 }
+                  numCols={ numCols }
+                  numRows={ numRows }
+                  width={ mapWidth }
+                  volcanoX={ volcanoX }
+                />
+              }
+              { showChart &&
+                <LineChart width={mapWidth} height={200} data={plotData.chartData}>
+                  <Line type="linear" dataKey={plotData.yAxis} stroke="red" strokeWidth={2} />
+                  <CartesianGrid stroke="#ddd" strokeDasharray="5 5" />
+                  <XAxis
+                    type="number"
+                    domain={[0, "auto"]}
+                    allowDecimals={false}
+                    dataKey={plotData.xAxis}
+                    label={{ value: plotData.xAxis, offset: -5, position: "insideBottom" }}
+                  />
+                  <YAxis
+                    type="number"
+                    domain={[0, "auto"]}
+                    label={{ value: plotData.yAxis, angle: -90, offset: 12, position: "insideBottomLeft" }}
+                  />
+                </LineChart>
+              }
 
+              { showSidebar &&
+                <MapSidebarComponent
+                  width={ mapWidth }
+                  height={ 100 }
+                  windSpeed={ windSpeed }
+                  windDirection={ windDirection }
+                  colHeight={ colHeight }
+                  vei={ vei }
+                  mass={ mass }
+                  particleSize={ particleSize }
+                />
+              }
+              { showOptionsDialog &&
+                 <DatGui data={simulationOptions} onUpdate={this.handleUpdate}>
+                  <DatButton label="Model options" onClick={this.toggleShowOptions} />
+                  { expandOptionsDialog &&
+                    [
+                      <DatBoolean path="requireEruption" label="Require eruption?" key="requireEruption" />,
+                      <DatBoolean path="requirePainting" label="Require painting?" key="requirePainting" />,
+                      <DatSelect path="map" label="Map background" options={Object.keys(Maps)} key="background" />,
+                      <DatSelect path="toolbox" label="Code toolbox"
+                        options={Object.keys(BlocklyAuthoring.toolbox)} key="toolbox" />,
+                      <DatSelect path="initialCode" label="Initial code"
+                        options={Object.keys(BlocklyAuthoring.code)} key="code" />,
+                      <DatBoolean path="showCrossSection" label="Show cross section?"
+                        key="showCrossSection" />,
+                      <DatBoolean path="showChart" label="Show chart?"
+                        key="showChart" />,
 
-        <Simulation >
-          <MapComponent
-            windDirection={ windDirection }
-            windSpeed={ windSpeed }
-            mass={ mass }
-            colHeight={ colHeight }
-            particleSize={ particleSize }
-            numCols={ numCols }
-            numRows={ numRows }
-            width={ 500 }
-            height={ 500 }
-            gridColors={ gridColors }
-            cities={ cities }
-            volcanoX={ volcanoX }
-            volcanoY={ volcanoY }
-            map={ mapPath }
-            isErupting={isErupting}
-          />
-                  { showCrossSection &&
-                    <CrossSectionComponent
-                      data={ data }
-                      height={ 100 }
-                      numCols={ numCols }
-                      numRows={ numRows }
-                      width={ mapWidth }
-                      volcanoX={ volcanoX }
-                    />
+                      <DatBoolean path="showCrossSection" label="Show cross section?" key="showCrossSection" />,
+                      <DatBoolean path="showChart" label="Show chart?" key="showChart" />,
+                      <DatBoolean path="showSidebar" label="Show sidebar?" key="showSidebar" />,
+                      // submit button. Should remain at bottom
+                      <DatButton
+                        label="Generate authored model"
+                        onClick={this.generateAndOpenAuthoredUrl}
+                        key="generate" />
+                    ]
                   }
-                  { showChart &&
-                    <LineChart width={mapWidth} height={200} data={plotData.chartData}>
-                      <Line type="linear" dataKey={plotData.yAxis} stroke="red" strokeWidth={2} />
-                      <CartesianGrid stroke="#ddd" strokeDasharray="5 5" />
-                      <XAxis
-                        type="number"
-                        domain={[0, "auto"]}
-                        allowDecimals={false}
-                        dataKey={plotData.xAxis}
-                        label={{ value: plotData.xAxis, offset: -5, position: "insideBottom" }}
-                      />
-                      <YAxis
-                        type="number"
-                        domain={[0, "auto"]}
-                        label={{ value: plotData.yAxis, angle: -90, offset: 12, position: "insideBottomLeft" }}
-                      />
-                    </LineChart>
-                  }
-          { showCode &&
-            <FixWidthTabPanel width={820}>
-              <Code>
-                <SyntaxHighlighter>
-                  {js_beautify(code)}
-                </SyntaxHighlighter>
-              </Code>
-            </FixWidthTabPanel>
-          }
-          { showControls &&
-            <FixWidthTabPanel width={820}>
-              <Controls />
-            </FixWidthTabPanel>
-          }
-        </Tabs>
-        <Simulation >
-          <MapComponent
-            windDirection={ windDirection }
-            windSpeed={ windSpeed }
-            mass={ mass }
-            colHeight={ colHeight }
-            particleSize={ particleSize }
-            numCols={ numCols }
-            numRows={ numRows }
-            width={ 500 }
-            height={ 500 }
-            gridColors={ gridColors }
-            cities={ cities }
-            volcanoX={ volcanoX }
-            volcanoY={ volcanoY }
-            map={ mapPath }
-            isErupting={isErupting}
-          />
-
-          { showCrossSection &&
-            <CrossSectionComponent
-              data={ data }
-              height={ 100 }
-              numCols={ numCols }
-              numRows={ numRows }
-              width={ 500 }
-              volcanoX={ volcanoX }
-            />
-          }
-          { showChart &&
-            <LineChart width={500} height={200} data={plotData.chartData}>
-              <Line type="linear" dataKey={plotData.yAxis} stroke="red" strokeWidth={2} />
-              <CartesianGrid stroke="#ddd" strokeDasharray="5 5" />
-              <XAxis
-                type="number"
-                domain={[0, "auto"]}
-                allowDecimals={false}
-                dataKey={plotData.xAxis}
-                label={{ value: plotData.xAxis, offset: -5, position: "insideBottom" }}
-              />
-              <YAxis
-                type="number"
-                domain={[0, "auto"]}
-                label={{ value: plotData.yAxis, angle: -90, offset: 12, position: "insideBottomLeft" }}
-              />
-            </LineChart>
-          }
-                { showOptionsDialog &&
-                  <DatGui data={simulationOptions} onUpdate={this.handleUpdate}>
-                    <DatButton label="Model options" onClick={this.toggleShowOptions} />
-                    { expandOptionsDialog &&
-                      [
-                        <DatBoolean path="requireEruption" label="Require eruption?" key="requireEruption" />,
-                        <DatBoolean path="requirePainting" label="Require painting?" key="requirePainting" />,
-                        <DatSelect path="map" label="Map background" options={Object.keys(Maps)} key="background" />,
-                        <DatSelect path="toolbox" label="Code toolbox"
-                          options={Object.keys(BlocklyAuthoring.toolbox)} key="toolbox" />,
-                        <DatSelect path="initialCode" label="Initial code"
-                          options={Object.keys(BlocklyAuthoring.code)} key="code" />,
-          { showSidebar &&
-            <MapSidebarComponent
-              width={ 500 }
-              height={ 100 }
-              windSpeed={ windSpeed }
-              windDirection={ windDirection }
-              colHeight={ colHeight }
-              vei={ vei }
-              mass={ mass }
-              particleSize={ particleSize }
-            />
-          }
-          { showCrossSection &&
-            <CrossSectionComponent
-              data={ data }
-              height={ 100 }
-              numCols={ numCols }
-              numRows={ numRows }
-              width={ 500 }
-              volcanoX={ volcanoX }
-            />
-          }
-          { showChart &&
-            <LineChart width={500} height={200} data={plotData.chartData}>
-              <Line type="linear" dataKey={plotData.yAxis} stroke="red" strokeWidth={2} />
-              <CartesianGrid stroke="#ddd" strokeDasharray="5 5" />
-              <XAxis
-                type="number"
-                domain={[0, "auto"]}
-                allowDecimals={false}
-                dataKey={plotData.xAxis}
-                label={{ value: plotData.xAxis, offset: -5, position: "insideBottom" }}
-              />
-              <YAxis
-                type="number"
-                domain={[0, "auto"]}
-                label={{ value: plotData.yAxis, angle: -90, offset: 12, position: "insideBottomLeft" }}
-              />
-            </LineChart>
-          }
-        </Simulation>
-
-        { showOptionsDialog &&
-          <DatGui data={simulationOptions} onUpdate={this.handleUpdate}>
-            <DatButton label="Model options" onClick={this.toggleShowOptions} />
-            { expandOptionsDialog &&
-              [
-                <DatBoolean path="requireEruption" label="Require eruption?" key="requireEruption" />,
-                <DatBoolean path="requirePainting" label="Require painting?" key="requirePainting" />,
-                <DatSelect path="map" label="Map background" options={Object.keys(Maps)} key="background" />,
-                <DatSelect path="toolbox" label="Code toolbox"
-                  options={Object.keys(BlocklyAuthoring.toolbox)} key="toolbox" />,
-                <DatSelect path="initialCode" label="Initial code"
-                  options={Object.keys(BlocklyAuthoring.code)} key="code" />,
-                        <DatBoolean path="showBlocks" label="Show blocks?" key="showBlocks" />,
-                        <DatBoolean path="showCode" label="Show code?" key="showCode" />,
-                        <DatBoolean path="showControls" label="Show controls?" key="showControls" />,
-        </Simulation>
-        { showOptionsDialog &&
-          <DatGui data={simulationOptions} onUpdate={this.handleUpdate}>
-            <DatButton label="Model options" onClick={this.toggleShowOptions} />
-            { expandOptionsDialog &&
-              [
-                <DatBoolean path="requireEruption" label="Require eruption?" key="requireEruption" />,
-                <DatBoolean path="requirePainting" label="Require painting?" key="requirePainting" />,
-                <DatSelect path="map" label="Map background" options={Object.keys(Maps)} key="background" />,
-                <DatSelect path="toolbox" label="Code toolbox"
-                  options={Object.keys(BlocklyAuthoring.toolbox)} key="toolbox" />,
-                <DatSelect path="initialCode" label="Initial code"
-                  options={Object.keys(BlocklyAuthoring.code)} key="code" />,
-
-                        <DatBoolean path="showCrossSection" label="Show cross section?" key="showCrossSection" />,
-                        <DatBoolean path="showChart" label="Show chart?" key="showChart" />,
-
-                <DatBoolean path="showCrossSection" label="Show cross section?" key="showCrossSection" />,
-                <DatBoolean path="showChart" label="Show chart?" key="showChart" />,
-
-                // submit button. Should remain at bottom
-                <DatButton label="Generate authored model" onClick={this.generateAndOpenAuthoredUrl} key="generate" />
-              ]
-            }
-          </DatGui>
-        }
-      </Simulation>
-                        // submit button. Should remain at bottom
-                        <DatButton
-                          label="Generate authored model"
-                          onClick={this.generateAndOpenAuthoredUrl}
-                          key="generate" />
-                      ]
-                    }
-                  </DatGui>
-                }
+                </DatGui>
+              }
               </Simulation>
-              </Row>
-            ); }
-          }
-          </ContainerDimensions>
-                <DatBoolean path="showCrossSection" label="Show cross section?" key="showCrossSection" />,
-                <DatBoolean path="showChart" label="Show chart?" key="showChart" />,
-                <DatBoolean path="showSidebar" label="Show sidebar?" key="showSidebar" />,
-
-                // submit button. Should remain at bottom
-                <DatButton label="Generate authored model" onClick={this.generateAndOpenAuthoredUrl} key="generate" />
-              ]
-            }
-          </DatGui>
+            </Row>
+          );}
         }
-      </Simulation>
+      </ContainerDimensions>
     </App>
     );
   }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -10,6 +10,7 @@ import * as Maps from "./../assets/maps/maps.json";
 import * as BlocklyAuthoring from "./../assets/blockly-authoring/index.json";
 
 import BlocklyContianer from "./blockly-container";
+import ContainerDimensions from "react-container-dimensions";
 import styled from "styled-components";
 import { Tab, Tabs, TabList, TabPanel, FixWidthTabPanel } from "./tabs";
 import { js_beautify } from "js-beautify";
@@ -42,10 +43,18 @@ interface IState {
 
 const App = styled.div`
     display: flex;
-    justify-content: space-around;
+    justify-content: flex-start;
     align-items: flex-start;
     flex-direction: row;
-    margin-top: 50px;
+    height: 100vh;
+`;
+
+const Row = styled.div`
+  display: flex;
+  width: 100%;
+  justify-content: space-between;
+  align-items: center;
+  flex-direction: row;
 `;
 
 const Simulation = styled.div`
@@ -56,8 +65,7 @@ const Simulation = styled.div`
 `;
 
 const Code = styled.div`
-  width: 800px;
-  max-height: 600px;
+  max-height: 400px;
   overflow: auto;
   padding: 1em;
 `;
@@ -166,23 +174,88 @@ export class AppComponent extends BaseComponent<IProps, IState> {
 
     return (
       <App className="app" >
-        <Tabs>
-          <TabList>
-            { showBlocks && <Tab>Blocks</Tab>}
-            { showCode && <Tab>Code</Tab>}
-            { showControls && <Tab>Controls</Tab>}
-          </TabList>
-          { showBlocks &&
+        <ContainerDimensions>
+          { props => {
+            const {width, height} = props;
+            const margin = 10;
+            const tabWidth = Math.floor(width * .6);
+            const mapWidth = Math.floor(width * .4) - margin;
+            const blocklyWidth = tabWidth - (margin * 2);
+            const blocklyHeight = Math.floor(height * .7);
+            return(
+              <Row>
+                <Tabs>
+                  <TabList>
+                    { showBlocks && <Tab>Blocks</Tab>}
+                    { showCode && <Tab>Code</Tab>}
+                    { showControls && <Tab>Controls</Tab>}
+                  </TabList>
+                  { showBlocks &&
+                    <FixWidthTabPanel width={`${tabWidth}px`}>
+                      <BlocklyContianer
+                        width={blocklyWidth}
+                        height={blocklyHeight}
+                        toolboxPath={toolboxPath}
+                        initialCodeSetupPath={codePath}
+                        setBlocklyCode={ setBlocklyCode} />
+                      <RunButtons {...{run, stop, step, reset, running}} />
+                    </FixWidthTabPanel>
+                  }
+                  { showCode &&
+                    <FixWidthTabPanel width={`${tabWidth}px`}>
+                      <Code>
+                        <SyntaxHighlighter>
+                          {js_beautify(code)}
+                        </SyntaxHighlighter>
+                      </Code>
+                    </FixWidthTabPanel>
+                  }
+                  { showControls &&
+                    <FixWidthTabPanel width={`${tabWidth}px`}>
+                      <Controls />
+                    </FixWidthTabPanel>
+                  }
+                </Tabs>
+
+                <Simulation >
+                  <MapComponent
+                    windDirection={ windDirection }
+                    windSpeed={ windSpeed }
+                    mass={ mass }
+                    colHeight={ colHeight }
+                    particleSize={ particleSize }
+                    numCols={ numCols }
+                    numRows={ numRows }
+                    width={ mapWidth }
+                    height={ mapWidth }
+                    gridColors={ gridColors }
+                    cities={ cities }
+                    volcanoX={ volcanoX }
+                    volcanoY={ volcanoY }
+                    map={ mapPath }
+                  />
+                </Simulation>
+              </Row>
+            ); }
+          }
+          { showCode &&
             <FixWidthTabPanel width={820}>
-              <BlocklyContianer
-                width={800}
-                height={600}
-                toolboxPath={toolboxPath}
-                initialCodeSetupPath={codePath}
-                setBlocklyCode={ setBlocklyCode} />
-                <RunButtons {...{run, stop, step, reset, running}} />
+              <Code>
+                <SyntaxHighlighter>
+                  {js_beautify(code)}
+                </SyntaxHighlighter>
+              </Code>
             </FixWidthTabPanel>
           }
+          { showControls &&
+            <FixWidthTabPanel width={820}>
+              <Controls />
+            </FixWidthTabPanel>
+          }
+        </Tabs>
+
+          </ContainerDimensions>
+
           { showCode &&
             <FixWidthTabPanel width={820}>
               <Code>
@@ -256,6 +329,12 @@ export class AppComponent extends BaseComponent<IProps, IState> {
               />
             </LineChart>
           }
+        </Simulation>
+
+                  <DatBoolean path="showBlocks" label="Show blocks?" key="showBlocks" />,
+                  <DatBoolean path="showCode" label="Show code?" key="showCode" />,
+                  <DatBoolean path="showControls" label="Show controls?" key="showControls" />,
+
         </Simulation>
         { showOptionsDialog &&
           <DatGui data={simulationOptions} onUpdate={this.handleUpdate}>

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -233,7 +233,12 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                     volcanoX={ volcanoX }
                     volcanoY={ volcanoY }
                     map={ mapPath }
+                    isErupting={isErupting}
                   />
+                </Simulation>
+              </Row>
+            ); }
+          }
                 </Simulation>
               </Row>
             ); }
@@ -254,8 +259,53 @@ export class AppComponent extends BaseComponent<IProps, IState> {
           }
         </Tabs>
 
-          </ContainerDimensions>
 
+        <Simulation >
+          <MapComponent
+            windDirection={ windDirection }
+            windSpeed={ windSpeed }
+            mass={ mass }
+            colHeight={ colHeight }
+            particleSize={ particleSize }
+            numCols={ numCols }
+            numRows={ numRows }
+            width={ 500 }
+            height={ 500 }
+            gridColors={ gridColors }
+            cities={ cities }
+            volcanoX={ volcanoX }
+            volcanoY={ volcanoY }
+            map={ mapPath }
+            isErupting={isErupting}
+          />
+                  { showCrossSection &&
+                    <CrossSectionComponent
+                      data={ data }
+                      height={ 100 }
+                      numCols={ numCols }
+                      numRows={ numRows }
+                      width={ mapWidth }
+                      volcanoX={ volcanoX }
+                    />
+                  }
+                  { showChart &&
+                    <LineChart width={mapWidth} height={200} data={plotData.chartData}>
+                      <Line type="linear" dataKey={plotData.yAxis} stroke="red" strokeWidth={2} />
+                      <CartesianGrid stroke="#ddd" strokeDasharray="5 5" />
+                      <XAxis
+                        type="number"
+                        domain={[0, "auto"]}
+                        allowDecimals={false}
+                        dataKey={plotData.xAxis}
+                        label={{ value: plotData.xAxis, offset: -5, position: "insideBottom" }}
+                      />
+                      <YAxis
+                        type="number"
+                        domain={[0, "auto"]}
+                        label={{ value: plotData.yAxis, angle: -90, offset: 12, position: "insideBottomLeft" }}
+                      />
+                    </LineChart>
+                  }
           { showCode &&
             <FixWidthTabPanel width={820}>
               <Code>
@@ -290,6 +340,46 @@ export class AppComponent extends BaseComponent<IProps, IState> {
             isErupting={isErupting}
           />
 
+          { showCrossSection &&
+            <CrossSectionComponent
+              data={ data }
+              height={ 100 }
+              numCols={ numCols }
+              numRows={ numRows }
+              width={ 500 }
+              volcanoX={ volcanoX }
+            />
+          }
+          { showChart &&
+            <LineChart width={500} height={200} data={plotData.chartData}>
+              <Line type="linear" dataKey={plotData.yAxis} stroke="red" strokeWidth={2} />
+              <CartesianGrid stroke="#ddd" strokeDasharray="5 5" />
+              <XAxis
+                type="number"
+                domain={[0, "auto"]}
+                allowDecimals={false}
+                dataKey={plotData.xAxis}
+                label={{ value: plotData.xAxis, offset: -5, position: "insideBottom" }}
+              />
+              <YAxis
+                type="number"
+                domain={[0, "auto"]}
+                label={{ value: plotData.yAxis, angle: -90, offset: 12, position: "insideBottomLeft" }}
+              />
+            </LineChart>
+          }
+                { showOptionsDialog &&
+                  <DatGui data={simulationOptions} onUpdate={this.handleUpdate}>
+                    <DatButton label="Model options" onClick={this.toggleShowOptions} />
+                    { expandOptionsDialog &&
+                      [
+                        <DatBoolean path="requireEruption" label="Require eruption?" key="requireEruption" />,
+                        <DatBoolean path="requirePainting" label="Require painting?" key="requirePainting" />,
+                        <DatSelect path="map" label="Map background" options={Object.keys(Maps)} key="background" />,
+                        <DatSelect path="toolbox" label="Code toolbox"
+                          options={Object.keys(BlocklyAuthoring.toolbox)} key="toolbox" />,
+                        <DatSelect path="initialCode" label="Initial code"
+                          options={Object.keys(BlocklyAuthoring.code)} key="code" />,
           { showSidebar &&
             <MapSidebarComponent
               width={ 500 }
@@ -332,6 +422,21 @@ export class AppComponent extends BaseComponent<IProps, IState> {
           }
         </Simulation>
 
+        { showOptionsDialog &&
+          <DatGui data={simulationOptions} onUpdate={this.handleUpdate}>
+            <DatButton label="Model options" onClick={this.toggleShowOptions} />
+            { expandOptionsDialog &&
+              [
+                <DatBoolean path="requireEruption" label="Require eruption?" key="requireEruption" />,
+                <DatBoolean path="requirePainting" label="Require painting?" key="requirePainting" />,
+                <DatSelect path="map" label="Map background" options={Object.keys(Maps)} key="background" />,
+                <DatSelect path="toolbox" label="Code toolbox"
+                  options={Object.keys(BlocklyAuthoring.toolbox)} key="toolbox" />,
+                <DatSelect path="initialCode" label="Initial code"
+                  options={Object.keys(BlocklyAuthoring.code)} key="code" />,
+                        <DatBoolean path="showBlocks" label="Show blocks?" key="showBlocks" />,
+                        <DatBoolean path="showCode" label="Show code?" key="showCode" />,
+                        <DatBoolean path="showControls" label="Show controls?" key="showControls" />,
         </Simulation>
         { showOptionsDialog &&
           <DatGui data={simulationOptions} onUpdate={this.handleUpdate}>
@@ -346,10 +451,33 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                 <DatSelect path="initialCode" label="Initial code"
                   options={Object.keys(BlocklyAuthoring.code)} key="code" />,
 
-                <DatBoolean path="showBlocks" label="Show blocks?" key="showBlocks" />,
-                <DatBoolean path="showCode" label="Show code?" key="showCode" />,
-                <DatBoolean path="showControls" label="Show controls?" key="showControls" />,
+                        <DatBoolean path="showCrossSection" label="Show cross section?" key="showCrossSection" />,
+                        <DatBoolean path="showChart" label="Show chart?" key="showChart" />,
 
+                <DatBoolean path="showCrossSection" label="Show cross section?" key="showCrossSection" />,
+                <DatBoolean path="showChart" label="Show chart?" key="showChart" />,
+
+                // submit button. Should remain at bottom
+                <DatButton label="Generate authored model" onClick={this.generateAndOpenAuthoredUrl} key="generate" />
+              ]
+            }
+          </DatGui>
+        }
+      </Simulation>
+                        // submit button. Should remain at bottom
+                        <DatButton
+                          label="Generate authored model"
+                          onClick={this.generateAndOpenAuthoredUrl}
+                          key="generate" />
+                      ]
+                    }
+                  </DatGui>
+                }
+              </Simulation>
+              </Row>
+            ); }
+          }
+          </ContainerDimensions>
                 <DatBoolean path="showCrossSection" label="Show cross section?" key="showCrossSection" />,
                 <DatBoolean path="showChart" label="Show chart?" key="showChart" />,
                 <DatBoolean path="showSidebar" label="Show sidebar?" key="showSidebar" />,

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -289,6 +289,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
             map={ mapPath }
             isErupting={isErupting}
           />
+
           { showSidebar &&
             <MapSidebarComponent
               width={ 500 }
@@ -331,10 +332,6 @@ export class AppComponent extends BaseComponent<IProps, IState> {
           }
         </Simulation>
 
-                  <DatBoolean path="showBlocks" label="Show blocks?" key="showBlocks" />,
-                  <DatBoolean path="showCode" label="Show code?" key="showCode" />,
-                  <DatBoolean path="showControls" label="Show controls?" key="showControls" />,
-
         </Simulation>
         { showOptionsDialog &&
           <DatGui data={simulationOptions} onUpdate={this.handleUpdate}>
@@ -363,8 +360,8 @@ export class AppComponent extends BaseComponent<IProps, IState> {
             }
           </DatGui>
         }
-
-      </App>
+      </Simulation>
+    </App>
     );
   }
 

--- a/src/components/blockly-container.tsx
+++ b/src/components/blockly-container.tsx
@@ -23,10 +23,6 @@ const WorkSpace = styled.div`
   width: ${(p: WorkspaceProps) => `${p.width}px`};
   height: ${(p: WorkspaceProps) => `${p.height}px`};
   margin: 1em;
-  /* position: relative;
-  border: 2px solid gray;
-  border-radius: 0.5em; */
-  /* padding: 1em; */
 `;
 
 export default class BlocklyContainer extends React.Component<IProps, IState> {
@@ -77,7 +73,12 @@ export default class BlocklyContainer extends React.Component<IProps, IState> {
       r.text().then( (data) => {
         const blockOpts = {
           media: "blockly/media/",
-          toolbox: data
+          toolbox: data,
+          zoom: {
+            startScale: 0.8,
+            maxScale: 2,
+            minScale: 0.2
+          }
         };
         this.workSpace = Blockly.inject(this.workSpaceRef.current, blockOpts);
         const startBlocks = this.startBlockRef.current;

--- a/src/components/cross-section-component.tsx
+++ b/src/components/cross-section-component.tsx
@@ -10,7 +10,6 @@ import { BaseComponent, IBaseProps } from "./base";
 
 const CanvDiv = styled.div`
   border: 0px solid black; border-radius: 0px;
-  margin: 1em;
 `;
 
 interface IState {}

--- a/src/components/map-component.tsx
+++ b/src/components/map-component.tsx
@@ -18,7 +18,6 @@ import { EmitterConfig } from "pixi-particles";
 
 const CanvDiv = styled.div`
   border: 0px solid black; border-radius: 0px;
-  margin: 1em;
 `;
 
 interface IState {}

--- a/src/components/map-sidebar-component.tsx
+++ b/src/components/map-sidebar-component.tsx
@@ -11,7 +11,6 @@ import { observer, inject } from "mobx-react";
 
 const CanvDiv = styled.div`
   border: 0px solid black; border-radius: 0px;
-  margin: 1em;
 `;
 
 const style = new PIXI.TextStyle({

--- a/src/components/pixi-axis.tsx
+++ b/src/components/pixi-axis.tsx
@@ -12,7 +12,7 @@ interface IProps {
 const GridLabel = (props: {position: Ipoint, title: string, xAxis: boolean, size: number}) => {
   const style = new TextStyle({fill: "black", fontSize: "12px", align: "center"});
   const { position, size, title, xAxis } = props;
-  const x = position.x * size + (xAxis ? size / 2 : 0);
+  const x = position.x * size + (xAxis ? size / 2 : size / 2);
   const y = position.y * size + size / 2;
   return (
     <Container position={[x, y]} >
@@ -42,7 +42,7 @@ export const PixiAxis = (props: IProps) => {
       />);
   }
   x = 0;
-  for (y = 0; y < numRows; y++) {
+  for (y = 1; y < numRows; y++) {
     labels.push(
       <GridLabel
         key={`y:${y}`}

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -49,14 +49,15 @@ const Tab = styled(UnstyledTab).attrs({
 
 const TabPanel = styled(UnstyledTabPanel).attrs({ selectedClassName: "selected" })`
   display: none;
-  padding: 10px 20px;
+  padding: 0px 0;
+  border: none;
   &.selected {
     display: block;
   }
 `;
 
 const FixWidthTabPanel = styled(TabPanel)`
-  width: ${ (p: {width?: number}) => p.width ? p.width : 800}px;
+  width: ${ (p: {width?: string}) => p.width ? p.width : "300px"};
 `;
 
 (Tab as any).tabsRole = "Tab";

--- a/src/stores/simulation-store.ts
+++ b/src/stores/simulation-store.ts
@@ -91,8 +91,8 @@ export function getGridIndexForLocation(x: number, y: number, numRows: number) {
 
 export const SimulationStore = types
   .model("simulation", {
-    numRows: 14,
-    numCols: 14,
+    numRows: 10,
+    numCols: 10,
     windSpeed: 6,
     windDirection: 45,
     mass: 20000000,


### PR DESCRIPTION
First pass at shrinking real-estate requirements.

* Remove unhelpful cross-section view
* Reduce padding in tabs
* Scale Blockly to 80% of its default size.
* Use react-container-dimensions to resize Blockly area and sim.
* Some other misc style changes

[#165575535]

https://www.pivotaltracker.com/story/show/165575535