### PR TITLE
fixed wind direction offset and mirror issue

### DIFF
--- a/src/tephra2.ts
+++ b/src/tephra2.ts
@@ -111,7 +111,7 @@ const gridTephraCalc = (
   const modelY = gridY * dScale;
   const coneX = coneGridX * dScale;
   const coneY = coneGridY * dScale;
-  const rotated = rotateGridPoint({x: modelX, y: modelY}, windDirection, {x: coneX, y: coneY});
+  const rotated = rotateGridPoint({x: modelX, y: modelY}, (360 - windDirection) + 90, {x: coneX, y: coneY});
   return tephraCalc2(
     rotated.x, rotated.y,
     coneX, coneY,


### PR DESCRIPTION
The wind parameter is off by 90 degrees and mirrored from what it should have been. 

Should be demo-able here: http://geocode-app.concord.org/branch/wind-direction-bug/index.html