### PR TITLE
Save code to LARA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7418,6 +7418,11 @@
       "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
       "dev": true
     },
+    "iframe-phone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/iframe-phone/-/iframe-phone-1.2.0.tgz",
+      "integrity": "sha1-6RP79PeWTu7My3u5rLqtVWIeHGQ="
+    },
     "ignore": {
       "version": "3.3.10",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "color": "^3.1.0",
     "d3": "^5.9.7",
     "d3-contour": "^1.3.2",
+    "iframe-phone": "^1.2.0",
     "immutable": "^3.8.2",
     "js-beautify": "^1.9.1",
     "js-interpreter": "^1.4.6",

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -377,7 +377,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                   width={blocklyWidth}
                   height={blocklyHeight}
                   toolboxPath={toolboxPath}
-                  initialCodeSetupPath={codePath}
+                  initialCodePath={codePath}
                   setBlocklyCode={setBlocklyCode} />
                 <RunButtons {...{run, stop, step, reset, running}} />
                 { showLog &&

--- a/src/components/blockly-container.tsx
+++ b/src/components/blockly-container.tsx
@@ -4,7 +4,8 @@ import "../blockly-blocks/blocks.js";
 
 interface IProps {
   toolboxPath: string;
-  initialCodePath: string;
+  initialCode?: string;
+  initialCodePath?: string;
   setBlocklyCode: (code: string, workspace: any) => void;
   width: number;
   height: number;
@@ -48,6 +49,7 @@ export default class BlocklyContainer extends React.Component<IProps, IState> {
 
   public componentDidUpdate(prevProps: IProps) {
     if ((prevProps.toolboxPath !== this.props.toolboxPath) ||
+        prevProps.initialCode !== this.props.initialCode ||
         prevProps.initialCodePath !== this.props.initialCodePath) {
           this.initializeBlockly();
         }
@@ -70,10 +72,13 @@ export default class BlocklyContainer extends React.Component<IProps, IState> {
     if (this.workSpaceRef.current) {
       this.workSpaceRef.current.innerHTML = "";
     }
-    const {toolboxPath, initialCodePath, setBlocklyCode} = this.props;
+    const {toolboxPath, initialCode, initialCodePath, setBlocklyCode} = this.props;
 
-    const intialCodeResp = await fetch(initialCodePath);
-    const codeString = await intialCodeResp.text();
+    let codeString = initialCode;
+    if (!codeString && initialCodePath) {
+      const intialCodeResp = await fetch(initialCodePath);
+      codeString = await intialCodeResp.text();
+    }
 
     const toolboxResp = await fetch(toolboxPath);
     const toolbox = await toolboxResp.text();

--- a/src/components/blockly-container.tsx
+++ b/src/components/blockly-container.tsx
@@ -15,7 +15,6 @@ interface IState {}
 
 const Wrapper = styled.div``;
 const StartBlocks = styled.div``;
-let lastTimeout: number | null  = null;
 interface WorkspaceProps {
   width: number;
   height: number;
@@ -51,21 +50,8 @@ export default class BlocklyContainer extends React.Component<IProps, IState> {
     if ((prevProps.toolboxPath !== this.props.toolboxPath) ||
         prevProps.initialCode !== this.props.initialCode ||
         prevProps.initialCodePath !== this.props.initialCodePath) {
-          this.initializeBlockly();
-        }
-
-    // TODO: This should eventually be removed. We save the XML to local storage.
-    // We don't ever restore this at the moment, but its used by developers to
-    // Save the initial program.
-    if (lastTimeout) {
-      clearTimeout(lastTimeout);
+      this.initializeBlockly();
     }
-    lastTimeout = window.setTimeout(this.toXml, 500);
-  }
-
-  private toXml = () => {
-    const xml = Blockly.Xml.workspaceToDom(this.workSpace);
-    localStorage.setItem("blockly-workspace", Blockly.Xml.domToPrettyText(xml));
   }
 
   private initializeBlockly = async () => {

--- a/src/components/blockly-container.tsx
+++ b/src/components/blockly-container.tsx
@@ -94,9 +94,7 @@ export default class BlocklyContainer extends React.Component<IProps, IState> {
     };
 
     this.workSpace = Blockly.inject(this.workSpaceRef.current, blockOpts);
-    const startBlocks = this.startBlockRef.current;
 
-    Blockly.Xml.domToWorkspace(startBlocks, this.workSpace);
     Blockly.JavaScript.STATEMENT_PREFIX = "startStep(%1);\n";
     Blockly.JavaScript.STATEMENT_SUFFIX = "endStep();\n";
     Blockly.JavaScript.addReservedWords("highlightBlock");

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,8 +2,11 @@ import { Provider } from "mobx-react";
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 
+import * as iframePhone from "iframe-phone";
+
 import { AppComponent } from "./components/app";
 import { simulation } from "./stores/simulation-store";
+import { onSnapshot } from "mobx-state-tree";
 
 ReactDOM.render(
   <Provider stores={simulation}>
@@ -11,3 +14,52 @@ ReactDOM.render(
   </Provider>,
   document.getElementById("reactApp")
 );
+
+export interface UserSaveDataType {
+  version?: number;
+  blocklyXmlCode?: string;
+}
+
+// *** LARA Data-Saving ***
+
+/**
+ * Load saved student data into the store. (Currently just the xml)
+ */
+const loadStudentData = (studentData: UserSaveDataType) => {
+  if (studentData.blocklyXmlCode) {
+    simulation.setInitialXmlCode(studentData.blocklyXmlCode);
+  }
+};
+
+const phone = iframePhone.getIFrameEndpoint();
+
+// If we are embedded in LARA, wait for `initInteractive` and initialize model with any student data
+phone.addListener("initInteractive", (data: {
+    mode: any,
+    authoredState: any,
+    interactiveState: any,
+    linkedState: any}) => {
+  // student data may be in either the current interactive's saved state, or a previous model's linked state
+  const studentData: UserSaveDataType = data && (data.interactiveState || data.linkedState) || {};
+  loadStudentData(studentData);
+});
+
+// Save data everytime stores change
+const saveUserData = () => {
+  phone.post("interactiveState", simulation.userSnapshot);
+};
+onSnapshot(simulation, saveUserData);       // MobX function called on every store change
+
+// When we exit page and LARA asks for student data, tell it it's already up-to-date
+phone.addListener("getInteractiveState", () => {
+  phone.post("interactiveState", "nochange");
+});
+
+phone.initialize();
+
+phone.post("supportedFeatures", {
+  apiVersion: 1,
+  features: {
+    interactiveState: true
+  }
+});

--- a/src/public/css/react-dat-gui.css
+++ b/src/public/css/react-dat-gui.css
@@ -80,7 +80,9 @@
 .react-dat-gui .cr.button {
   border-left: 5px solid #e61d5f; }
   .react-dat-gui .cr.button:hover {
-    background: #111; }
+    background: #2FA1D6; }
+  .react-dat-gui .cr.button:active {
+    background: #0b7bb0; }
   .react-dat-gui .cr.button .label-text {
     display: block;
     width: 100%;

--- a/src/stores/simulation-store.ts
+++ b/src/stores/simulation-store.ts
@@ -1,6 +1,7 @@
 import { types, getSnapshot } from "mobx-state-tree";
 import { IInterpreterController, makeInterpreterController } from "../utilities/interpreter";
 import { SimulationAuthoringOptions } from "../components/app";
+import { UserSaveDataType } from "..";
 
 let _cityCounter = 0;
 const genCityId = () => `city_${_cityCounter++}`;
@@ -439,6 +440,13 @@ export const SimulationStore = types
     return {
       get cityHash() {
         return self.cities.reduce( (pre, cur) => `${pre}-${cur.name}${cur.x}${cur.y}`, "");
+      },
+      // returns values we need to save to LARA
+      get userSnapshot(): UserSaveDataType {
+        return {
+          version: 1,
+          blocklyXmlCode: self.xmlCode
+        };
       }
     };
   });

--- a/src/stores/simulation-store.ts
+++ b/src/stores/simulation-store.ts
@@ -115,7 +115,9 @@ export const SimulationStore = types
     viewportCenterLat: 0,
     viewportCenterLng: 0,
     cities: types.array(City),
-    code: "",
+    code: "",                   // current blockly JS code
+    xmlCode: "",                // current blockly xml code
+    initialXmlCode: "",         // initial blockly xml code
     log: "",
     plotData: types.optional(PlotData, getSnapshot(plotData)),
     isErupting: false,
@@ -154,6 +156,8 @@ export const SimulationStore = types
   .actions((self) => ({
     setBlocklyCode(code: string, workspace: any) {
       self.code = code;
+      self.xmlCode = Blockly.Xml.domToPrettyText(Blockly.Xml.workspaceToDom(workspace));
+
       if (interpreterController) {
         interpreterController.stop();
         workspace.highlightBlock(null);
@@ -161,6 +165,9 @@ export const SimulationStore = types
       self.running = false;
       cachedBlocklyWorkspace = workspace;
       interpreterController = makeInterpreterController(code, simulation, workspace);
+    },
+    setInitialXmlCode(xmlCode: string) {
+      self.initialXmlCode = xmlCode;
     },
     setViewportParameters(zoom: number, viewportCenterLat: number, viewportCenterLng: number) {
       self.viewportZoom = zoom;

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -1,0 +1,1 @@
+declare module "iframe-phone";


### PR DESCRIPTION
This can be demo'd at http://authoring.concord.org/activities/10028/pages/127921/

As part of this (as it kind of came along for free) I also added Save and Load from local state to the authoring popup menu, since this is something we had wanted before. This is probably more of a gimmick than a useful feature right now, but there is no reason we couldn't expand it to save to multiple file names, and/or go for the download/upload file route, if a non-LARA authoring solution is still desired.

The authoring buttons can be tested here: http://geocode-app.concord.org/branch/save-code-to-lara/index.html