### PR TITLE
Save and load authored blockly code

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,23 +15,25 @@ ReactDOM.render(
   document.getElementById("reactApp")
 );
 
-export interface UserSaveDataType {
+export interface SerializedStateDataType {
   version?: number;
   blocklyXmlCode?: string;
 }
+type Mode = "student" | "author";
 
 // *** LARA Data-Saving ***
 
 /**
  * Load saved student data into the store. (Currently just the xml)
  */
-const loadStudentData = (studentData: UserSaveDataType) => {
-  if (studentData.blocklyXmlCode) {
-    simulation.setInitialXmlCode(studentData.blocklyXmlCode);
+const loadStateData = (state: SerializedStateDataType) => {
+  if (state.blocklyXmlCode) {
+    simulation.setInitialXmlCode(state.blocklyXmlCode);
   }
 };
 
 const phone = iframePhone.getIFrameEndpoint();
+let mode: Mode = "student";
 
 // If we are embedded in LARA, wait for `initInteractive` and initialize model with any student data
 phone.addListener("initInteractive", (data: {
@@ -39,14 +41,28 @@ phone.addListener("initInteractive", (data: {
     authoredState: any,
     interactiveState: any,
     linkedState: any}) => {
+
+  const authorState: SerializedStateDataType = data && data.authoredState || {};
   // student data may be in either the current interactive's saved state, or a previous model's linked state
-  const studentData: UserSaveDataType = data && (data.interactiveState || data.linkedState) || {};
-  loadStudentData(studentData);
+  const studentState: SerializedStateDataType = data && (data.interactiveState || data.linkedState) || {};
+
+  if (data.mode === "authoring") {
+    mode = "author";
+    loadStateData(authorState);
+  } else {
+    // student state overwrites authored state
+    const mergedState = {...authorState, ...studentState};
+    loadStateData(mergedState);
+  }
 });
 
 // Save data everytime stores change
 const saveUserData = () => {
-  phone.post("interactiveState", simulation.userSnapshot);
+  if (mode === "student") {
+    phone.post("interactiveState", simulation.userSnapshot);
+  } else {
+    phone.post("authoredState", simulation.userSnapshot);
+  }
 };
 onSnapshot(simulation, saveUserData);       // MobX function called on every store change
 
@@ -60,6 +76,7 @@ phone.initialize();
 phone.post("supportedFeatures", {
   apiVersion: 1,
   features: {
+    authoredState: true,
     interactiveState: true
   }
 });

--- a/src/stores/simulation-store.ts
+++ b/src/stores/simulation-store.ts
@@ -1,7 +1,7 @@
 import { types, getSnapshot } from "mobx-state-tree";
 import { IInterpreterController, makeInterpreterController } from "../utilities/interpreter";
 import { SimulationAuthoringOptions } from "../components/app";
-import { UserSaveDataType } from "..";
+import { SerializedStateDataType } from "..";
 
 let _cityCounter = 0;
 const genCityId = () => `city_${_cityCounter++}`;
@@ -442,7 +442,7 @@ export const SimulationStore = types
         return self.cities.reduce( (pre, cur) => `${pre}-${cur.name}${cur.x}${cur.y}`, "");
       },
       // returns values we need to save to LARA
-      get userSnapshot(): UserSaveDataType {
+      get userSnapshot(): SerializedStateDataType {
         return {
           version: 1,
           blocklyXmlCode: self.xmlCode


### PR DESCRIPTION
This is a small addition to save the authored blockly xml, using the available LARA features, and piggybacking off the student save-data model.

I was going to include the authoring support for the rest of the model parameters, but that is becoming a much bigger commit so I thought it wise to get the small one out first.