### PR TITLE
FIx unit conversion error in column height

### DIFF
--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -195,7 +195,7 @@ export class Controls extends BaseComponent<IProps, IState> {
       stagingWindDirection,
       stagingParticleSize,
       stagingMass,
-      stagingColHeight,
+      stagingColHeight, // in meters
       stagingWindSpeed
     } = this.stores;
 
@@ -411,8 +411,8 @@ export class Controls extends BaseComponent<IProps, IState> {
     this.stores.setWindSpeed(speed);
   }
 
-  private changeColumnHeight = (height: number) => {
-    this.stores.setColumnHeight(height * 1000);
+  private changeColumnHeight = (heightInKilometers: number) => {
+    this.stores.setColumnHeight(heightInKilometers);
   }
 
   private changeMass = (vei: number) => {

--- a/src/stores/simulation-store.ts
+++ b/src/stores/simulation-store.ts
@@ -345,8 +345,8 @@ export const SimulationStore = types
       setVolcanoLng(lng: number) {
         self.volcanoLng = lng;
       },
-      setColumnHeight(height: number) {
-        self.stagingColHeight = height * 1000;      // km to m
+      setColumnHeight(heightInKilometers: number) {
+        self.stagingColHeight = heightInKilometers * 1000;      // km to m
         if (!self.requireEruption) {
           self.erupt();
         }


### PR DESCRIPTION
We had a simple meters vs. kilometers units error that broke the column height slider.  Error is resolved, and I changed a few variable names to hopefully prevent future error. 