### PR TITLE
Remove particle size from controls, sidebar, and options

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -43,7 +43,6 @@ export interface SimulationAuthoringOptions {
   initialEruptionMass: number;
   showColumnHeight: boolean;
   initialColumnHeight: number;
-  showParticleSize: boolean;
   initialParticleSize: number;
   showCrossSection: boolean;
   showChart: boolean;
@@ -157,7 +156,6 @@ export class AppComponent extends BaseComponent<IProps, IState> {
         initialEruptionMass: 10000000000000,
         showColumnHeight: true,
         initialColumnHeight: 20000,
-        showParticleSize: true,
         initialParticleSize: 1,
         showCrossSection: false,
         showChart: false,
@@ -276,7 +274,6 @@ export class AppComponent extends BaseComponent<IProps, IState> {
       initialEruptionMass,
       showColumnHeight,
       initialColumnHeight,
-      showParticleSize,
       initialParticleSize,
       showCrossSection,
       showChart,
@@ -417,7 +414,6 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                   showWindDirection={showWindDirection}
                   showEruptionMass={showEruptionMass}
                   showColumnHeight={showColumnHeight}
-                  showParticleSize={showParticleSize}
                 />
               </FixWidthTabPanel>
             }
@@ -550,10 +546,6 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                     <DatNumber
                       path="initialColumnHeight" label="Initial Column Height" key="initialColumnHeight"
                       min={1000} max={30000} step={1000}/>
-                    <DatBoolean path="showParticleSize" label="Show Particle Size?" key="showParticleSize" />
-                    <DatNumber
-                      path="initialParticleSize" label="Initial Particle Size" key="initialParticleSize"
-                      min={0} max={64} step={1}/>
                   </DatFolder>,
 
                   <DatBoolean path="showLog" label="Show Log?" key="showLog" />,

--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -176,7 +176,6 @@ interface IProps extends IBaseProps {
   showWindDirection: boolean;
   showEruptionMass: boolean;
   showColumnHeight: boolean;
-  showParticleSize: boolean;
 }
 interface IState {
   animate: boolean;
@@ -204,7 +203,6 @@ export class Controls extends BaseComponent<IProps, IState> {
       showWindDirection,
       showEruptionMass,
       showColumnHeight,
-      showParticleSize
     } = this.props;
 
     return(
@@ -254,38 +252,6 @@ export class Controls extends BaseComponent<IProps, IState> {
                   {(showWindSpeed && showWindDirection) && <ValueDivider/ >}
                   {showWindDirection && <div>{stagingWindDirection} °</div>}
                   </HorizontalContainer>
-                </ValueOutput>
-              </ValueContainer>
-            </HorizontalContainer>
-          </ControlContainer>}
-          {showParticleSize && <ControlContainer>
-            <HorizontalContainer>
-              <VerticalContainer alignItems="center" justifyContent="center">
-                <label>Particle Size (mm)</label>
-                <HorizontalContainer>
-                  <RangeControl
-                    min={1}
-                    max={64}
-                    value={stagingParticleSize}
-                    step={1}
-                    tickArray={[1, 10, 20, 30, 40, 50, 64]}
-                    width={this.props.width - 220}
-                    onChange={this.changeSize}
-                  />
-                </HorizontalContainer>
-              </VerticalContainer>
-              <ValueContainer>
-                <IconContainer>
-                  <Icon
-                    width={50}
-                    height={50}
-                    fill={"black"}
-                  >
-                    <ParticleIcon />
-                  </Icon>
-                </IconContainer>
-                <ValueOutput>
-                  {stagingParticleSize} mm
                 </ValueOutput>
               </ValueContainer>
             </HorizontalContainer>

--- a/src/components/map-sidebar-component.tsx
+++ b/src/components/map-sidebar-component.tsx
@@ -95,23 +95,12 @@ export class MapSidebarComponent extends BaseComponent <IProps, IState> {
                   colHeight={colHeight}
                   location={{x: 190, y: 90}}
                 />
-                <Text
-                  x={275}
-                  y={15}
-                  style={style}
-                  anchor={(0.5)}
-                  text="Particle Size"
-                />
-                <ParticleSizeWidget
-                  particleSize={particleSize}
-                  location={{x: 275, y: 60}}
-                />
                 <SidebarDataDisplay
                   vei={vei}
                   colHeight={colHeight}
                   mass={mass}
                   particleSize={particleSize}
-                  location={{x: 340, y: 10}}
+                  location={{x: 275, y: 10}}
                 />
             </Stage>
         </CanvDiv>);


### PR DESCRIPTION
Remove the particle size option from the controls tab, the sidebar container in the right panel, and from the model options list.  For now, I left in the `ParticleSizeWidget` component in case we need to reuse or recycle it.  