### PR TITLE
Convert eruption mass to ejected volume

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -39,7 +39,7 @@ export interface SimulationAuthoringOptions {
   initialWindSpeed: number;
   showWindDirection: boolean;
   initialWindDirection: number;
-  showEruptionMass: boolean;
+  showEjectedVolume: boolean;
   initialEruptionMass: number;
   showColumnHeight: boolean;
   initialColumnHeight: number;
@@ -152,7 +152,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
         initialWindSpeed: 5,
         showWindDirection: true,
         initialWindDirection: 310,
-        showEruptionMass: true,
+        showEjectedVolume: true,
         initialEruptionMass: 10000000000000,
         showColumnHeight: true,
         initialColumnHeight: 20000,
@@ -270,7 +270,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
       initialWindSpeed,
       showWindDirection,
       initialWindDirection,
-      showEruptionMass,
+      showEjectedVolume,
       initialEruptionMass,
       showColumnHeight,
       initialColumnHeight,
@@ -412,7 +412,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                   width={tabWidth}
                   showWindSpeed={showWindSpeed}
                   showWindDirection={showWindDirection}
-                  showEruptionMass={showEruptionMass}
+                  showEjectedVolume={showEjectedVolume}
                   showColumnHeight={showColumnHeight}
                 />
               </FixWidthTabPanel>
@@ -538,9 +538,9 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                     <DatNumber
                       path="initialWindDirection" label="Initial Wind Direction" key="initialWindDirection"
                       min={0} max={360} step={1}/>
-                    <DatBoolean path="showEruptionMass" label="Show Eruption Mass?" key="showEruptionMass" />
+                    <DatBoolean path="showEjectedVolume" label="Show Ejected Volume?" key="showEjectedVolume" />
                     <DatNumber
-                      path="initialEruptionMass" label="Initial Eruption Mass" key="initialEruptionMass"
+                      path="initialEruptionMass" label="Initial Ejection Volume" key="initialEruptionMass"
                       min={100000000} max={10000000000000000} step={1000}/>
                     <DatBoolean path="showColumnHeight" label="Show Column Height?" key="showColumnHeight" />
                     <DatNumber

--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -149,7 +149,7 @@ interface IProps extends IBaseProps {
   width: number;
   showWindSpeed: boolean;
   showWindDirection: boolean;
-  showEruptionMass: boolean;
+  showEjectedVolume: boolean;
   showColumnHeight: boolean;
 }
 interface IState {
@@ -176,7 +176,7 @@ export class Controls extends BaseComponent<IProps, IState> {
     const {
       showWindSpeed,
       showWindDirection,
-      showEruptionMass,
+      showEjectedVolume,
       showColumnHeight,
     } = this.props;
 
@@ -232,25 +232,25 @@ export class Controls extends BaseComponent<IProps, IState> {
               </ValueContainer>
             </HorizontalContainer>
           </ControlContainer>}
-          {showEruptionMass && <ControlContainer>
+          {showEjectedVolume && <ControlContainer>
             <HorizontalContainer>
               <VerticalContainer alignItems="center" justifyContent="center">
-                <ControlLabel>Eruption Mass (kg)</ControlLabel>
+                <ControlLabel>Ejected Volume (km<sup>3</sup>)</ControlLabel>
                 <HorizontalContainer>
                   <RangeControl
-                    min={8}
-                    max={15}
-                    value={Math.round(Math.log(stagingMass) / Math.LN10)}
+                    min={0}
+                    max={7}
+                    value={Math.round(Math.log(stagingMass) / Math.LN10) - 8}
                     step={1}
                     tickMap={{
-                      8: "10<sup>8</sup>",
-                      9: "10<sup>9</sup>",
-                      10: "10<sup>10</sup>",
-                      11: "10<sup>11</sup>",
-                      12: "10<sup>12</sup>",
-                      13: "10<sup>13</sup>",
-                      14: "10<sup>14</sup>",
-                      15: "10<sup>15</sup>",
+                      0: "10<sup>-4</sup>",
+                      1: "10<sup>-3</sup>",
+                      2: "10<sup>-2</sup>",
+                      3: "10<sup>-1</sup>",
+                      4: "10<sup>0</sup>",
+                      5: "10<sup>1</sup>",
+                      6: "10<sup>2</sup>",
+                      7: "10<sup>3</sup>",
                     }}
                     width={this.props.width - 220}
                     onChange={this.changeMass}
@@ -270,7 +270,7 @@ export class Controls extends BaseComponent<IProps, IState> {
                 <ValueOutput>
                   <div
                     dangerouslySetInnerHTML={
-                      {__html: `10<sup>${Math.round(Math.log(stagingMass) / Math.LN10)}</sup> kg`}
+                      {__html: `10<sup>${Math.round(Math.log(stagingMass) / Math.LN10) - 12}</sup> km<sup>3</sup>`}
                   } />
                 </ValueOutput>
               </ValueContainer>
@@ -345,9 +345,10 @@ export class Controls extends BaseComponent<IProps, IState> {
     this.stores.setColumnHeight(heightInKilometers);
   }
 
-  private changeMass = (vei: number) => {
-    const mass =  Math.pow(10, vei);
-    this.stores.setMass(mass);
+  private changeMass = (zeroBasedPower: number) => {
+    // -4 index conversion, +9 km^3 to m^3, +3 m^3 to kg
+    const massInKilograms = Math.pow(10, zeroBasedPower - 4 + 9 + 3);
+    this.stores.setMass(massInKilograms);
   }
 
   private changeSize = (size: number) => {


### PR DESCRIPTION
Change the eruption mass slider (in kg) to an ejected volume slider (km^3).  Keep underlying calculations in kg.  This only changes the user-facing slider in the control panel (and the options in the model options panel).  

Note: I did not change any of the blockly blocks that may incorporate the mass in kg - this might be something that we want to consider.