### PR TITLE
Add VEI slider

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -44,6 +44,8 @@ export interface SimulationAuthoringOptions {
   showColumnHeight: boolean;
   initialColumnHeight: number;
   initialParticleSize: number;
+  showVEI: boolean;
+  initialVEI: number;
   showCrossSection: boolean;
   showChart: boolean;
   showSidebar: boolean;
@@ -157,6 +159,8 @@ export class AppComponent extends BaseComponent<IProps, IState> {
         showColumnHeight: true,
         initialColumnHeight: 20000,
         initialParticleSize: 1,
+        showVEI: true,
+        initialVEI: 1,
         showCrossSection: false,
         showChart: false,
         showSidebar: false
@@ -275,6 +279,8 @@ export class AppComponent extends BaseComponent<IProps, IState> {
       showColumnHeight,
       initialColumnHeight,
       initialParticleSize,
+      showVEI,
+      initialVEI,
       showCrossSection,
       showChart,
       showSidebar
@@ -414,6 +420,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                   showWindDirection={showWindDirection}
                   showEjectedVolume={showEjectedVolume}
                   showColumnHeight={showColumnHeight}
+                  showVEI={showVEI}
                 />
               </FixWidthTabPanel>
             }
@@ -546,6 +553,10 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                     <DatNumber
                       path="initialColumnHeight" label="Initial Column Height" key="initialColumnHeight"
                       min={1000} max={30000} step={1000}/>
+                    <DatBoolean path="showVEI" label="Show VEI?" key="showVEI" />
+                    <DatNumber
+                      path="initialVEI" label="Initial VEI" key="initialVEI"
+                      min={1} max={8} step={1}/>
                   </DatFolder>,
 
                   <DatBoolean path="showLog" label="Show Log?" key="showLog" />,

--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -47,17 +47,21 @@ const ControlLabel = styled.label`
   margin-top: 6px;
 `;
 
+interface ValueContainerProps {
+  width?: number;
+}
 const ValueContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  width: 104px;
+  width: ${(p: ValueContainerProps) => `${p.width ? `${p.width}px` : "104px"}`};
   height: 80px;
   margin-left: auto;
   padding: 2px;
   border-radius: 7px;
   background-color: #FFDBAC;
+  font-size: 12px;
 `;
 
 const ValueOutput = styled.div`
@@ -71,7 +75,6 @@ const ValueOutput = styled.div`
   border-radius: 0 0 5px 5px;
   background-color: white;
   text-align: center;
-  font-size: 12px;
 `;
 
 const ValueDivider = styled.div`
@@ -87,6 +90,15 @@ const IconContainer = styled.div`
   align-items: center;
   justify-content: center;
   height: 60px;
+  margin: 0 10px 0 10px;
+`;
+
+const VEIlabel = styled.div`
+  font-size: 10px;
+  color: #ff9300;
+`;
+const VEIvalue = styled.div`
+  font-size: 11px;
 `;
 
 interface HorizontalContainerProps {
@@ -143,6 +155,7 @@ interface IControls {
   changeSize: (a: any) => void;
   changeColumnHeight: (a: any) => void;
   changeMass: (a: any) => void;
+  changeVEI: (a: any) => void;
 }
 
 interface IProps extends IBaseProps {
@@ -151,6 +164,7 @@ interface IProps extends IBaseProps {
   showWindDirection: boolean;
   showEjectedVolume: boolean;
   showColumnHeight: boolean;
+  showVEI: boolean;
 }
 interface IState {
   animate: boolean;
@@ -170,7 +184,8 @@ export class Controls extends BaseComponent<IProps, IState> {
       stagingParticleSize,
       stagingMass,
       stagingColHeight, // in meters
-      stagingWindSpeed
+      stagingWindSpeed,
+      stagingVei
     } = this.stores;
 
     const {
@@ -178,6 +193,7 @@ export class Controls extends BaseComponent<IProps, IState> {
       showWindDirection,
       showEjectedVolume,
       showColumnHeight,
+      showVEI,
     } = this.props;
 
     return(
@@ -308,6 +324,49 @@ export class Controls extends BaseComponent<IProps, IState> {
               </ValueContainer>
             </HorizontalContainer>
           </ControlContainer>}
+          {showVEI && <ControlContainer>
+            <HorizontalContainer>
+              <VerticalContainer alignItems="center" justifyContent="center">
+                <label>VEI</label>
+                <HorizontalContainer>
+                  <RangeControl
+                    min={1}
+                    max={8}
+                    value={stagingVei}
+                    step={1}
+                    tickArray={[1, 2, 3, 4, 5, 6, 7, 8]}
+                    width={this.props.width - 274}
+                    onChange={this.changeVEI}
+                  />
+                </HorizontalContainer>
+              </VerticalContainer>
+              <ValueContainer width={160}>
+                <HorizontalContainer>
+                  <IconContainer>
+                    <Icon
+                      width={36}
+                      height={40}
+                      fill={"black"}
+                    >
+                      <ColumnHeightIcon/>
+                    </Icon>
+                  </IconContainer>
+                  <VerticalContainer alignItems="center" justifyContent="center">
+                    <VEIlabel>Column Height</VEIlabel>
+                    <VEIvalue>{stagingColHeight / 1000} km</VEIvalue>
+                    <VEIlabel>Ejected Volume</VEIlabel>
+                    <VEIvalue
+                        dangerouslySetInnerHTML={
+                          {__html: `10<sup>${Math.round(Math.log(stagingMass) / Math.LN10)}</sup> kg`}
+                      } />
+                  </VerticalContainer>
+                </HorizontalContainer>
+                <ValueOutput>
+                  {`${stagingVei}: ${this.getVEIDescription(stagingVei)}`}
+                </ValueOutput>
+              </ValueContainer>
+            </HorizontalContainer>
+          </ControlContainer>}
           <NoteLabel>
             <span>Note: changes made here will </span>
             <BoldSpan>not be</BoldSpan>
@@ -353,6 +412,24 @@ export class Controls extends BaseComponent<IProps, IState> {
 
   private changeSize = (size: number) => {
     this.stores.setParticleSize(size);
+  }
+
+  private changeVEI = (vei: number) => {
+    this.stores.setVEI(vei);
+  }
+
+  private getVEIDescription = (vei: number) => {
+    switch (vei) {
+      case 1: return "Gentle";
+      case 2: return "Explosive";
+      case 3: return "Catastrophic";
+      case 4: return "Cataclysmic";
+      case 5: return "Disastrous";
+      case 6: return "Colossal";
+      case 7: return "Super-Colossal";
+      case 8: return "Mega-Colossal";
+      default: return "";
+    }
   }
 
   private erupt = () => {

--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -10,6 +10,7 @@ import WindSpeedDirectionIcon from "../assets/controls-icons/wind-speed-directio
 import RunIcon from "../assets/blockly-icons/run.svg";
 import { Icon } from "./icon";
 import IconButton from "./icon-button";
+import { kVEIIndexInfo } from "../utilities/vei";
 
 const StyledControls = styled.div`
   display: flex;
@@ -419,17 +420,7 @@ export class Controls extends BaseComponent<IProps, IState> {
   }
 
   private getVEIDescription = (vei: number) => {
-    switch (vei) {
-      case 1: return "Gentle";
-      case 2: return "Explosive";
-      case 3: return "Catastrophic";
-      case 4: return "Cataclysmic";
-      case 5: return "Disastrous";
-      case 6: return "Colossal";
-      case 7: return "Super-Colossal";
-      case 8: return "Mega-Colossal";
-      default: return "";
-    }
+    return ((kVEIIndexInfo[vei] && kVEIIndexInfo[vei].description) || "");
   }
 
   private erupt = () => {

--- a/src/stores/simulation-store.ts
+++ b/src/stores/simulation-store.ts
@@ -2,6 +2,7 @@ import { types, getSnapshot } from "mobx-state-tree";
 import { IInterpreterController, makeInterpreterController } from "../utilities/interpreter";
 import { SimulationAuthoringOptions } from "../components/app";
 import { SerializedStateDataType } from "..";
+import { kVEIIndexInfo } from "../utilities/vei";
 
 let _cityCounter = 0;
 const genCityId = () => `city_${_cityCounter++}`;
@@ -367,17 +368,7 @@ export const SimulationStore = types
         const mass = Math.pow(10, clippedVEI + 7);
         self.stagingMass = mass;
 
-        const veiColumnHeightTable: { [key: number]: number } = {
-          1: .1 * 1000,
-          2: 1 * 1000,
-          3: 5 * 1000,
-          4: 10 * 1000,
-          5: 15 * 1000,
-          6: 20 * 1000,
-          7: 25 * 1000,
-          8: 25 * 1000,
-        };
-        const colHeight = veiColumnHeightTable[vei] || .1 * 1000;
+        const colHeight = ((kVEIIndexInfo[vei] && kVEIIndexInfo[vei].columnHeight) || .1 * 1000);
         self.stagingColHeight = colHeight;
 
         if (!self.requireEruption) {

--- a/src/stores/simulation-store.ts
+++ b/src/stores/simulation-store.ts
@@ -366,6 +366,20 @@ export const SimulationStore = types
         // we want vei 1 = 1e8, vei 8 = 1e15
         const mass = Math.pow(10, clippedVEI + 7);
         self.stagingMass = mass;
+
+        const veiColumnHeightTable: { [key: number]: number } = {
+          1: .1 * 1000,
+          2: 1 * 1000,
+          3: 5 * 1000,
+          4: 10 * 1000,
+          5: 15 * 1000,
+          6: 20 * 1000,
+          7: 25 * 1000,
+          8: 25 * 1000,
+        };
+        const colHeight = veiColumnHeightTable[vei] || .1 * 1000;
+        self.stagingColHeight = colHeight;
+
         if (!self.requireEruption) {
           self.erupt();
         }

--- a/src/utilities/vei.ts
+++ b/src/utilities/vei.ts
@@ -1,0 +1,39 @@
+interface VEIIndexInfo {
+  description: string;
+  columnHeight: number;
+}
+
+export const kVEIIndexInfo: { [index: number]: VEIIndexInfo } = {
+  1: {
+    description: "Gentle",
+    columnHeight: .1 * 1000,
+  },
+  2: {
+    description: "Explosive",
+    columnHeight: 1 * 1000,
+  },
+  3: {
+    description: "Catastrophic",
+    columnHeight: 5 * 1000,
+  },
+  4: {
+    description: "Cataclysmic",
+    columnHeight: 10 * 1000,
+  },
+  5: {
+    description: "Disastrous",
+    columnHeight: 15 * 1000,
+  },
+  6: {
+    description: "Colossal",
+    columnHeight: 20 * 1000,
+  },
+  7: {
+    description: "Super-Colossal",
+    columnHeight: 25 * 1000,
+  },
+  8: {
+    description: "Mega-Colossal",
+    columnHeight: 25 * 1000,
+  }
+};


### PR DESCRIPTION
This PR adds a VEI slider to the controls panel that ranges from 1 - 8.  Slider can be shown/hidden from the model options.  When adjusted, slider also updates the ejected volume and the column height so they are in sync with the selected VEI value.  Full VEI widget with updated display based on VEI slider value will be handled in a subsequent PR.