### PR TITLE
167254328 conditions tab right panel

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -14,7 +14,8 @@ import * as BlocklyAuthoring from "./../assets/blockly-authoring/index.json";
 import BlocklyContainer from "./blockly-container";
 import styled from "styled-components";
 import { StyledButton } from "./styled-button";
-import { SectionTypes, TabInfo, kTabInfo, TabBack, Tab, Tabs, TabList, FixWidthTabPanel } from "./tabs";
+import { SectionTypes, RightSectionTypes, TabInfo, kTabInfo, kRightTabInfo,
+         TabBack, Tab, Tabs, TabList, TabPanel, RightTabBack, BottomTab } from "./tabs";
 import { js_beautify } from "js-beautify";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import Controls from "./controls";
@@ -53,6 +54,7 @@ export interface SimulationAuthoringOptions {
 
 interface IState {
   tabIndex: number;
+  rightTabIndex: number;
   showOptionsDialog: boolean;
   expandOptionsDialog: boolean;
   simulationOptions: SimulationAuthoringOptions;
@@ -69,6 +71,7 @@ const App = styled.div`
     flex-direction: row;
     height: 100vh;
     background-color: #ffffff;
+    overflow-x: hidden;
 `;
 
 const Row = styled.div`
@@ -80,34 +83,76 @@ const Row = styled.div`
   flex-direction: row;
 `;
 
+const Content = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  height: 100%;
+  width: 100%;
+`;
+
+const BottomBar = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: row;
+`;
+const TabsContainer = styled.div`
+  flex: 1 1 auto;
+`;
+
 const Simulation = styled.div`
   display: flex;
   flex-direction: column;
   width: ${(p: ISim) => `${p.width}px`};
+  height: 100%;
   justify-content: flex-start;
   align-items: flex-start;
+  background-color: ${(p: ISim) => p.backgroundColor};
+  border-top-left-radius: 10px;
+  border-top-right-radius: 10px;
 `;
 
 interface ISim {
   width: number;
+  backgroundColor?: string;
 }
 
 const Code = styled.div`
-  max-height: 400px;
+  display: flex;
+  flex: 1 1 auto;
+  box-sizing: border-box;
+  width: 100%;
   overflow: auto;
-  border: 2px solid white;
+  justify-content: flex-start;
 `;
 
 const Syntax = styled(SyntaxHighlighter)`
-  margin: 0px;
+  flex: 1 1 auto;
+  border: 2px solid white;
+  margin: 3px;
+`;
+
+const Footer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  flex: 0 1 44px;
+`;
+
+const FullscreenContainer = styled.div`
+  flex: 0 1 33px;
 `;
 
 const FullscreenButton = styled(StyledButton)`
-  width: 2.5em;
-  height: 2.5em;
+  width: 25px;
+  height: 25px;
+  margin: 2px;
+  padding: 0px;
   border: 0px solid hsl(0, 0%, 0%);
   background-repeat: no-repeat;
-  background-size: 95%;
+  background-size: 100%;
 `;
 
 const FullscreenButtonOpen = styled(FullscreenButton)`
@@ -135,9 +180,11 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     super(props);
 
     this.handleTabSelect = this.handleTabSelect.bind(this);
+    this.handleRightTabSelect = this.handleRightTabSelect.bind(this);
 
     const initialState: IState = {
       tabIndex: 0,
+      rightTabIndex: 0,
       showOptionsDialog: true,
       expandOptionsDialog: false,
       simulationOptions: {
@@ -203,7 +250,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
         prevState.simulationOptions.showCode !== showCode ||
         prevState.simulationOptions.showControls !== showControls) {
           this.setState({tabIndex: 0});
-    }
+        }
     const scenarioData = (Scenarios as {[key: string]: {[key: string]: number}})[scenario];
 
     // Have to do this or lint yells about string literals as keys
@@ -257,6 +304,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
 
     const {
       tabIndex,
+      rightTabIndex,
       showOptionsDialog,
       expandOptionsDialog,
       simulationOptions
@@ -283,7 +331,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
       initialVEI,
       showCrossSection,
       showChart,
-      showSidebar
+      showSidebar,
     } = simulationOptions;
 
     const mapPath = (Maps as {[key: string]: string})[map];
@@ -291,15 +339,13 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     const codePath = (BlocklyAuthoring.code as {[key: string]: string})[initialCodeTitle];
 
     const {width, height} = this.state.dimensions;
-    const margin = 10;
     const blocklyMargin = 3;
-    const tabWidth = Math.floor(width * .6);
-    const mapWidth = Math.floor(width * .4) - margin;
+    const tabWidth = Math.floor(width * .5);
+    const mapWidth = Math.floor(width * .5);
     const blocklyWidth = tabWidth - (blocklyMargin * 2);
     const blocklyHeight = Math.floor(height * .7);
     const logWidth = Math.floor(tabWidth * 0.95);
     const logHeight = Math.floor(height * .2);
-
     const { scenario } = this.state.simulationOptions;
     const scenarioData = (Scenarios as {[key: string]: {[key: string]: number}})[scenario];
     const initialZoomKey = "initialZoom";
@@ -325,7 +371,11 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     if (showBlocks)   { enabledTabTypes.push(SectionTypes.BLOCKS); }
     if (showCode)     { enabledTabTypes.push(SectionTypes.CODE); }
     if (showControls) { enabledTabTypes.push(SectionTypes.CONTROLS); }
+    const enabledRightTabTypes = [RightSectionTypes.CONDITIONS,
+                                  RightSectionTypes.CROSS_SECTION,
+                                  RightSectionTypes.DATA];
     const currentTabType = enabledTabTypes[tabIndex || 0];
+    const currentRightTabType = enabledRightTabTypes[rightTabIndex || 0];
 
     return (
       <App className="app" ref={this.rootComponent}>
@@ -374,19 +424,21 @@ export class AppComponent extends BaseComponent<IProps, IState> {
               }
             </TabList>
             { showBlocks &&
-              <FixWidthTabPanel
+              <TabPanel
                 width={`${tabWidth}px`}
                 forceRender={true}
                 tabcolor={this.getTabColor(SectionTypes.BLOCKS)}
               >
-                <BlocklyContainer
-                  width={blocklyWidth}
-                  height={blocklyHeight}
-                  toolboxPath={toolboxPath}
-                  initialCode={initialXmlCode}
-                  initialCodePath={codePath}
-                  setBlocklyCode={setBlocklyCode} />
-                <RunButtons {...{run, stop, step, reset, running}} />
+                <Content>
+                  <BlocklyContainer
+                    width={blocklyWidth}
+                    height={blocklyHeight}
+                    toolboxPath={toolboxPath}
+                    initialCode={initialXmlCode}
+                    initialCodePath={codePath}
+                    setBlocklyCode={setBlocklyCode} />
+                  <RunButtons {...{run, stop, step, reset, running}} />
+                </Content>
                 { showLog &&
                   <LogComponent
                     width={logWidth}
@@ -395,22 +447,25 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                     clear={clearLog}
                   />
                 }
-              </FixWidthTabPanel>
+              </TabPanel>
             }
             { showCode &&
-              <FixWidthTabPanel
+              <TabPanel
                 width={`${tabWidth}px`}
                 tabcolor={this.getTabColor(SectionTypes.CODE)}
               >
-                <Code>
-                  <Syntax>
-                    {js_beautify(code.replace(/endStep\(\)\;\n/g, "").replace(/startStep\(\'.*\'\)\;\n/g, ""))}
-                  </Syntax>
-                </Code>
-              </FixWidthTabPanel>
+                <Content>
+                  <Code>
+                    <Syntax>
+                      {js_beautify(code.replace(/endStep\(\)\;\n/g, "").replace(/startStep\(\'.*\'\)\;\n/g, ""))}
+                    </Syntax>
+                  </Code>
+                  <Footer />
+                </Content>
+              </TabPanel>
             }
             { showControls &&
-              <FixWidthTabPanel
+              <TabPanel
                 width={`${tabWidth}px`}
                 tabcolor={this.getTabColor(SectionTypes.CONTROLS)}
               >
@@ -422,157 +477,241 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                   showColumnHeight={showColumnHeight}
                   showVEI={showVEI}
                 />
-              </FixWidthTabPanel>
+              </TabPanel>
             }
           </Tabs>
 
-          <Simulation width={mapWidth}>
-            { (screenfull && screenfull.isFullscreen) &&
-              <FullscreenButtonOpen onClick={this.toggleFullscreen} />
-            }
-            { (screenfull && !screenfull.isFullscreen) &&
-              <FullscreenButtonClosed onClick={this.toggleFullscreen} />
-            }
-            <MapComponent
-              windDirection={ coloredWindDirection }
-              windSpeed={ coloredWindSpeed }
-              mass={ coloredMass }
-              colHeight={ coloredColHeight }
-              particleSize={ coloredParticleSize }
-              width={ mapWidth }
-              height={ mapWidth }
-              cities={ cities }
-              volcanoLat={ volcanoLat }
-              volcanoLng={ volcanoLng }
-              initialZoom={initialZoom}
-              minZoom={ minZoom }
-              maxZoom={ maxZoom }
-              topLeftLat={topLeftLat}
-              topLeftLng={topLeftLng}
-              bottomRightLat={bottomRightLat}
-              bottomRightLng={bottomRightLng}
-              viewportZoom={ viewportZoom }
-              viewportCenterLat={ viewportCenterLat }
-              viewportCenterLng={ viewportCenterLng }
-              map={ mapPath }
-              isErupting={isErupting}
-              showCrossSection={showCrossSection}
-              hasErupted={ hasErupted }
+          <Tabs selectedIndex={rightTabIndex} onSelect={this.handleRightTabSelect}>
+            <TabPanel
+              width={`${tabWidth}px`}
+              tabcolor={this.getRightTabColor(RightSectionTypes.CONDITIONS)}
+              rightpanel={"true"}
+            >
+              <Simulation width={mapWidth} backgroundColor={this.getRightTabColor(RightSectionTypes.CONDITIONS)}>
+                <MapComponent
+                  windDirection={ coloredWindDirection }
+                  windSpeed={ coloredWindSpeed }
+                  mass={ coloredMass }
+                  colHeight={ coloredColHeight }
+                  particleSize={ coloredParticleSize }
+                  width={ mapWidth }
+                  height={ height - 200 }
+                  cities={ cities }
+                  volcanoLat={ volcanoLat }
+                  volcanoLng={ volcanoLng }
+                  initialZoom={initialZoom}
+                  minZoom={ minZoom }
+                  maxZoom={ maxZoom }
+                  topLeftLat={topLeftLat}
+                  topLeftLng={topLeftLng}
+                  bottomRightLat={bottomRightLat}
+                  bottomRightLng={bottomRightLng}
+                  viewportZoom={ viewportZoom }
+                  viewportCenterLat={ viewportCenterLat }
+                  viewportCenterLng={ viewportCenterLng }
+                  map={ mapPath }
+                  isErupting={isErupting}
+                  showCrossSection={false}
+                  hasErupted={ hasErupted }
+                />
+                { showChart &&
+                  <LineChart width={mapWidth} height={200} data={plotData.chartData}>
+                    <Line type="linear" dataKey={plotData.yAxis} stroke="red" strokeWidth={2} />
+                    <CartesianGrid stroke="#ddd" strokeDasharray="5 5" />
+                    <XAxis
+                      type="number"
+                      domain={[0, "auto"]}
+                      allowDecimals={false}
+                      dataKey={plotData.xAxis}
+                      label={{ value: plotData.xAxis, offset: -5, position: "insideBottom" }}
+                    />
+                    <YAxis
+                      type="number"
+                      domain={[0, "auto"]}
+                      label={{ value: plotData.yAxis, angle: -90, offset: 12, position: "insideBottomLeft" }}
+                    />
+                  </LineChart>
+                }
+                <MapSidebarComponent
+                  width={ mapWidth - 400 }
+                  height={ 100 }
+                  windSpeed={ windSpeed }
+                  windDirection={ windDirection }
+                  colHeight={ colHeight }
+                  vei={ vei }
+                  mass={ mass }
+                  particleSize={ particleSize }
+                />
+              </Simulation>
+            </TabPanel>
+            <TabPanel
+              width={`${tabWidth}px`}
+              tabcolor={this.getRightTabColor(RightSectionTypes.CROSS_SECTION)}
+              rightpanel={"true"}
+            >
+              <Simulation width={mapWidth} backgroundColor={this.getRightTabColor(RightSectionTypes.CROSS_SECTION)}>
+                <MapComponent
+                  windDirection={ coloredWindDirection }
+                  windSpeed={ coloredWindSpeed }
+                  mass={ coloredMass }
+                  colHeight={ coloredColHeight }
+                  particleSize={ coloredParticleSize }
+                  width={ mapWidth }
+                  height={ height - 200 }
+                  cities={ cities }
+                  volcanoLat={ volcanoLat }
+                  volcanoLng={ volcanoLng }
+                  initialZoom={initialZoom}
+                  minZoom={ minZoom }
+                  maxZoom={ maxZoom }
+                  topLeftLat={topLeftLat}
+                  topLeftLng={topLeftLng}
+                  bottomRightLat={bottomRightLat}
+                  bottomRightLng={bottomRightLng}
+                  viewportZoom={ viewportZoom }
+                  viewportCenterLat={ viewportCenterLat }
+                  viewportCenterLng={ viewportCenterLng }
+                  map={ mapPath }
+                  isErupting={isErupting}
+                  showCrossSection={true}
+                  hasErupted={ hasErupted }
+                />
+                <CrossSectionComponent
+                  isSelectingCrossSection={isSelectingCrossSection}
+                  showCrossSectionSelector={isSelectingCrossSection}
+                  height={ 100 }
+                  width={ mapWidth }
+                  volcanoLat={ volcanoLat }
+                  volcanoLng={ volcanoLng }
+                  crossPoint1Lat={ crossPoint1Lat }
+                  crossPoint1Lng={ crossPoint1Lng }
+                  crossPoint2Lat={ crossPoint2Lat }
+                  crossPoint2Lng={ crossPoint2Lng }
+                  hasErupted={ hasErupted }
+                  windSpeed={windSpeed}
+                  windDirection={windDirection}
+                  colHeight={colHeight}
+                  mass={mass}
+                  particleSize={particleSize}
+                />
+              </Simulation>
+            </TabPanel>
+            <TabPanel
+              width={`${tabWidth}px`}
+              tabcolor={this.getRightTabColor(RightSectionTypes.DATA)}
+              rightpanel={"true"}
+            >
+              <div/>
+            </TabPanel>
+            <RightTabBack
+              width={tabWidth}
+              backgroundcolor={this.getRightTabColor(currentRightTabType)}
             />
-            { showCrossSection &&
-              <CrossSectionComponent
-                isSelectingCrossSection={isSelectingCrossSection}
-                showCrossSectionSelector={isSelectingCrossSection}
-                height={ 150 }
-                width={ mapWidth }
-                volcanoLat={ volcanoLat }
-                volcanoLng={ volcanoLng }
-                crossPoint1Lat={ crossPoint1Lat }
-                crossPoint1Lng={ crossPoint1Lng }
-                crossPoint2Lat={ crossPoint2Lat }
-                crossPoint2Lng={ crossPoint2Lng }
-                hasErupted={ hasErupted }
-                windSpeed={windSpeed}
-                windDirection={windDirection}
-                colHeight={colHeight}
-                mass={mass}
-                particleSize={particleSize}
-              />
+            <BottomBar>
+              <TabsContainer>
+                <TabList>
+                  <BottomTab
+                    selected={rightTabIndex === kRightTabInfo.conditions.index}
+                    leftofselected={rightTabIndex === (kRightTabInfo.conditions.index + 1) ? "true" : undefined}
+                    rightofselected={rightTabIndex === (kRightTabInfo.conditions.index - 1) ? "true" : undefined}
+                    backgroundcolor={this.getRightTabColor(RightSectionTypes.CONDITIONS)}
+                    backgroundhovercolor={this.getRightTabHoverColor(RightSectionTypes.CONDITIONS)}
+                  >
+                    {this.getRightTabName(RightSectionTypes.CONDITIONS)}
+                  </BottomTab>
+                  <BottomTab
+                    selected={rightTabIndex === kRightTabInfo.crossSection.index}
+                    leftofselected={rightTabIndex === (kRightTabInfo.crossSection.index + 1) ? "true" : undefined}
+                    rightofselected={rightTabIndex === (kRightTabInfo.crossSection.index - 1) ? "true" : undefined}
+                    backgroundcolor={this.getRightTabColor(RightSectionTypes.CROSS_SECTION)}
+                    backgroundhovercolor={this.getRightTabHoverColor(RightSectionTypes.CROSS_SECTION)}
+                  >
+                    {this.getRightTabName(RightSectionTypes.CROSS_SECTION)}
+                  </BottomTab>
+                  <BottomTab
+                    selected={rightTabIndex === kRightTabInfo.data.index}
+                    leftofselected={rightTabIndex === (kRightTabInfo.data.index + 1) ? "true" : undefined}
+                    rightofselected={rightTabIndex === (kRightTabInfo.data.index - 1) ? "true" : undefined}
+                    backgroundcolor={this.getRightTabColor(RightSectionTypes.DATA)}
+                    backgroundhovercolor={this.getRightTabHoverColor(RightSectionTypes.DATA)}
+                  >
+                    {this.getRightTabName(RightSectionTypes.DATA)}
+                  </BottomTab>
+                </TabList>
+              </TabsContainer>
+              <FullscreenContainer>
+                { (screenfull && screenfull.isFullscreen) &&
+                  <FullscreenButtonOpen onClick={this.toggleFullscreen} />
+                }
+                { (screenfull && !screenfull.isFullscreen) &&
+                  <FullscreenButtonClosed onClick={this.toggleFullscreen} />
+                }
+              </FullscreenContainer>
+            </BottomBar>
+          </Tabs>
+          { showOptionsDialog &&
+            <DatGui data={simulationOptions} onUpdate={this.handleUpdate}>
+            <DatButton label="Model options" onClick={this.toggleShowOptions} />
+            { expandOptionsDialog &&
+              [
+                <DatBoolean path="requireEruption" label="Require eruption?" key="requireEruption" />,
+                <DatBoolean path="requirePainting" label="Require painting?" key="requirePainting" />,
+                <DatSelect path="scenario" label="Map Scenario" options={Object.keys(Scenarios)} key="background" />,
+                <DatSelect path="toolbox" label="Code toolbox"
+                  options={Object.keys(BlocklyAuthoring.toolbox)} key="toolbox" />,
+                <DatSelect path="initialCodeTitle" label="Initial code"
+                  options={Object.keys(BlocklyAuthoring.code)} key="code" />,
+
+                <DatButton label="Save current code to local storage"
+                  onClick={this.saveCodeToLocalStorage}
+                  key="generate" />,
+                <DatButton label="Load code from local storage"
+                  onClick={this.loadCodeFromLocalStorage}
+                  key="generate" />,
+
+                <DatBoolean path="showCrossSection" label="Show cross section?" key="showCrossSection" />,
+                <DatBoolean path="showChart" label="Show chart?"
+                  key="showChart" />,
+
+                <DatBoolean path="showBlocks" label="Show blocks?" key="showBlocks" />,
+                <DatBoolean path="showCode" label="Show code?" key="showCode" />,
+                <DatBoolean path="showControls" label="Show controls?" key="showControls" />,
+                <DatFolder title="Controls Options" key="controlsFolder" closed={true}>
+                  <DatBoolean path="showWindSpeed" label="Show Wind Speed?" key="showWindSpeed"/>
+                  <DatNumber
+                    path="initialWindSpeed" label="Initial Wind Speed" key="initialWindSpeed"
+                    min={0} max={30} step={1}/>
+                  <DatBoolean path="showWindDirection" label="Show Wind Direction?" key="showWindDirection" />
+                  <DatNumber
+                    path="initialWindDirection" label="Initial Wind Direction" key="initialWindDirection"
+                    min={0} max={360} step={1}/>
+                  <DatBoolean path="showEjectedVolume" label="Show Ejected Volume?" key="showEjectedVolume" />
+                  <DatNumber
+                    path="initialEruptionMass" label="Initial Ejection Volume" key="initialEruptionMass"
+                    min={100000000} max={10000000000000000} step={1000}/>
+                  <DatBoolean path="showColumnHeight" label="Show Column Height?" key="showColumnHeight" />
+                  <DatNumber
+                    path="initialColumnHeight" label="Initial Column Height" key="initialColumnHeight"
+                    min={1000} max={30000} step={1000}/>
+                  <DatBoolean path="showVEI" label="Show VEI?" key="showVEI" />
+                  <DatNumber
+                    path="initialVEI" label="Initial VEI" key="initialVEI"
+                    min={1} max={8} step={1}/>
+                </DatFolder>,
+
+                <DatBoolean path="showLog" label="Show Log?" key="showLog" />,
+
+                <DatBoolean path="showChart" label="Show chart?" key="showChart" />,
+                <DatBoolean path="showSidebar" label="Show sidebar?" key="showSidebar" />,
+                // submit button. Should remain at bottom
+                <DatButton
+                  label="Generate authored model"
+                  onClick={this.generateAndOpenAuthoredUrl}
+                  key="generate" />
+              ]
             }
-            { showChart &&
-              <LineChart width={mapWidth} height={200} data={plotData.chartData}>
-                <Line type="linear" dataKey={plotData.yAxis} stroke="red" strokeWidth={2} />
-                <CartesianGrid stroke="#ddd" strokeDasharray="5 5" />
-                <XAxis
-                  type="number"
-                  domain={[0, "auto"]}
-                  allowDecimals={false}
-                  dataKey={plotData.xAxis}
-                  label={{ value: plotData.xAxis, offset: -5, position: "insideBottom" }}
-                />
-                <YAxis
-                  type="number"
-                  domain={[0, "auto"]}
-                  label={{ value: plotData.yAxis, angle: -90, offset: 12, position: "insideBottomLeft" }}
-                />
-              </LineChart>
-            }
-            { showSidebar &&
-              <MapSidebarComponent
-                width={ mapWidth - 200 }
-                height={ 100 }
-                windSpeed={ windSpeed }
-                windDirection={ windDirection }
-                colHeight={ colHeight }
-                vei={ vei }
-                mass={ mass }
-                particleSize={ particleSize }
-              />
-            }
-            { showOptionsDialog &&
-              <DatGui data={simulationOptions} onUpdate={this.handleUpdate}>
-              <DatButton label="Model options" onClick={this.toggleShowOptions} />
-              { expandOptionsDialog &&
-                [
-                  <DatBoolean path="requireEruption" label="Require eruption?" key="requireEruption" />,
-                  <DatBoolean path="requirePainting" label="Require painting?" key="requirePainting" />,
-                  <DatSelect path="scenario" label="Map Scenario" options={Object.keys(Scenarios)} key="background" />,
-                  <DatSelect path="toolbox" label="Code toolbox"
-                    options={Object.keys(BlocklyAuthoring.toolbox)} key="toolbox" />,
-                  <DatSelect path="initialCodeTitle" label="Initial code"
-                    options={Object.keys(BlocklyAuthoring.code)} key="code" />,
-
-                  <DatButton label="Save current code to local storage"
-                    onClick={this.saveCodeToLocalStorage}
-                    key="generate" />,
-                  <DatButton label="Load code from local storage"
-                    onClick={this.loadCodeFromLocalStorage}
-                    key="generate" />,
-
-                  <DatBoolean path="showCrossSection" label="Show cross section?" key="showCrossSection" />,
-                  <DatBoolean path="showChart" label="Show chart?"
-                    key="showChart" />,
-
-                  <DatBoolean path="showBlocks" label="Show blocks?" key="showBlocks" />,
-                  <DatBoolean path="showCode" label="Show code?" key="showCode" />,
-                  <DatBoolean path="showControls" label="Show controls?" key="showControls" />,
-                  <DatFolder title="Controls Options" key="controlsFolder" closed={true}>
-                    <DatBoolean path="showWindSpeed" label="Show Wind Speed?" key="showWindSpeed"/>
-                    <DatNumber
-                      path="initialWindSpeed" label="Initial Wind Speed" key="initialWindSpeed"
-                      min={0} max={30} step={1}/>
-                    <DatBoolean path="showWindDirection" label="Show Wind Direction?" key="showWindDirection" />
-                    <DatNumber
-                      path="initialWindDirection" label="Initial Wind Direction" key="initialWindDirection"
-                      min={0} max={360} step={1}/>
-                    <DatBoolean path="showEjectedVolume" label="Show Ejected Volume?" key="showEjectedVolume" />
-                    <DatNumber
-                      path="initialEruptionMass" label="Initial Ejection Volume" key="initialEruptionMass"
-                      min={100000000} max={10000000000000000} step={1000}/>
-                    <DatBoolean path="showColumnHeight" label="Show Column Height?" key="showColumnHeight" />
-                    <DatNumber
-                      path="initialColumnHeight" label="Initial Column Height" key="initialColumnHeight"
-                      min={1000} max={30000} step={1000}/>
-                    <DatBoolean path="showVEI" label="Show VEI?" key="showVEI" />
-                    <DatNumber
-                      path="initialVEI" label="Initial VEI" key="initialVEI"
-                      min={1} max={8} step={1}/>
-                  </DatFolder>,
-
-                  <DatBoolean path="showLog" label="Show Log?" key="showLog" />,
-
-                  <DatBoolean path="showChart" label="Show chart?" key="showChart" />,
-                  <DatBoolean path="showSidebar" label="Show sidebar?" key="showSidebar" />,
-                  // submit button. Should remain at bottom
-                  <DatButton
-                    label="Generate authored model"
-                    onClick={this.generateAndOpenAuthoredUrl}
-                    key="generate" />
-                ]
-              }
-              </DatGui>
-            }
-          </Simulation>
+            </DatGui>
+          }
         </Row>
       </App>
     );
@@ -586,6 +725,16 @@ export class AppComponent extends BaseComponent<IProps, IState> {
   }
   private getTabName = (type: SectionTypes) => {
     return (type ? kTabInfo[type].name : "");
+  }
+
+  private getRightTabColor = (type: RightSectionTypes) => {
+    return (type ? kRightTabInfo[type].backgroundColor : "white");
+  }
+  private getRightTabHoverColor = (type: RightSectionTypes) => {
+    return (type ? kRightTabInfo[type].hoverBackgroundColor : "white");
+  }
+  private getRightTabName = (type: RightSectionTypes) => {
+    return (type ? kRightTabInfo[type].name : "");
   }
 
   private resize = (rect: DOMRect) => {
@@ -607,6 +756,10 @@ export class AppComponent extends BaseComponent<IProps, IState> {
 
   private handleTabSelect(tabIndex: number) {
     this.setState({tabIndex});
+  }
+
+  private handleRightTabSelect(rightTabIndex: number) {
+    this.setState({rightTabIndex});
   }
 
   private generateAndOpenAuthoredUrl = () => {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -495,24 +495,6 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                   showCrossSection={false}
                   hasErupted={ hasErupted }
                 />
-                { showChart &&
-                  <LineChart width={mapWidth} height={200} data={plotData.chartData}>
-                    <Line type="linear" dataKey={plotData.yAxis} stroke="red" strokeWidth={2} />
-                    <CartesianGrid stroke="#ddd" strokeDasharray="5 5" />
-                    <XAxis
-                      type="number"
-                      domain={[0, "auto"]}
-                      allowDecimals={false}
-                      dataKey={plotData.xAxis}
-                      label={{ value: plotData.xAxis, offset: -5, position: "insideBottom" }}
-                    />
-                    <YAxis
-                      type="number"
-                      domain={[0, "auto"]}
-                      label={{ value: plotData.yAxis, angle: -90, offset: 12, position: "insideBottomLeft" }}
-                    />
-                  </LineChart>
-                }
                 <WidgetPanel
                   showWindSpeed={showWindSpeed}
                   showWindDirection={showWindDirection}
@@ -584,7 +566,26 @@ export class AppComponent extends BaseComponent<IProps, IState> {
               tabcolor={this.getRightTabColor(RightSectionTypes.DATA)}
               rightpanel={"true"}
             >
-              <div/>
+              <div>
+              { showChart &&
+                <LineChart width={mapWidth} height={200} data={plotData.chartData}>
+                  <Line type="linear" dataKey={plotData.yAxis} stroke="red" strokeWidth={2} />
+                  <CartesianGrid stroke="#ddd" strokeDasharray="5 5" />
+                  <XAxis
+                    type="number"
+                    domain={[0, "auto"]}
+                    allowDecimals={false}
+                    dataKey={plotData.xAxis}
+                    label={{ value: plotData.xAxis, offset: -5, position: "insideBottom" }}
+                  />
+                  <YAxis
+                    type="number"
+                    domain={[0, "auto"]}
+                    label={{ value: plotData.yAxis, angle: -90, offset: 12, position: "insideBottomLeft" }}
+                  />
+                </LineChart>
+              }
+              </div>
             </TabPanel>
             <RightTabBack
               width={tabWidth}
@@ -642,18 +643,12 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                   options={Object.keys(BlocklyAuthoring.toolbox)} key="toolbox" />,
                 <DatSelect path="initialCodeTitle" label="Initial code"
                   options={Object.keys(BlocklyAuthoring.code)} key="code" />,
-
                 <DatButton label="Save current code to local storage"
                   onClick={this.saveCodeToLocalStorage}
                   key="generate" />,
                 <DatButton label="Load code from local storage"
                   onClick={this.loadCodeFromLocalStorage}
                   key="generate" />,
-
-                <DatBoolean path="showCrossSection" label="Show cross section?" key="showCrossSection" />,
-                <DatBoolean path="showChart" label="Show chart?"
-                  key="showChart" />,
-
                 <DatBoolean path="showBlocks" label="Show blocks?" key="showBlocks" />,
                 <DatBoolean path="showCode" label="Show code?" key="showCode" />,
                 <DatBoolean path="showControls" label="Show controls?" key="showControls" />,
@@ -679,10 +674,9 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                     path="initialVEI" label="Initial VEI" key="initialVEI"
                     min={1} max={8} step={1}/>
                 </DatFolder>,
-
-                <DatBoolean path="showLog" label="Show Log?" key="showLog" />,
-
+                <DatBoolean path="showCrossSection" label="Show cross section?" key="showCrossSection" />,
                 <DatBoolean path="showChart" label="Show chart?" key="showChart" />,
+                <DatBoolean path="showLog" label="Show Log?" key="showLog" />,
                 <DatBoolean path="showSidebar" label="Show sidebar?" key="showSidebar" />,
                 // submit button. Should remain at bottom
                 <DatButton

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -21,6 +21,7 @@ import SyntaxHighlighter from "react-syntax-highlighter";
 import Controls from "./controls";
 import RunButtons from "./run-buttons";
 import { Footer, TabContent } from "./styled-containers";
+import WidgetPanel from "./widget-panel";
 import screenfull from "screenfull";
 import ResizeObserver from "react-resize-observer";
 
@@ -475,7 +476,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                   colHeight={ coloredColHeight }
                   particleSize={ coloredParticleSize }
                   width={ mapWidth }
-                  height={ height - 200 }
+                  height={ height - 190 }
                   cities={ cities }
                   volcanoLat={ volcanoLat }
                   volcanoLng={ volcanoLng }
@@ -512,15 +513,17 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                     />
                   </LineChart>
                 }
-                <MapSidebarComponent
-                  width={ mapWidth - 400 }
-                  height={ 100 }
+                <WidgetPanel
+                  showWindSpeed={showWindSpeed}
+                  showWindDirection={showWindDirection}
+                  showColumnHeight={showColumnHeight}
+                  showEjectedVolume={showEjectedVolume}
+                  showVEI={showVEI}
                   windSpeed={ windSpeed }
                   windDirection={ windDirection }
-                  colHeight={ colHeight }
+                  columnHeight={ colHeight }
                   vei={ vei }
                   mass={ mass }
-                  particleSize={ particleSize }
                 />
               </Simulation>
             </TabPanel>
@@ -537,7 +540,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                   colHeight={ coloredColHeight }
                   particleSize={ coloredParticleSize }
                   width={ mapWidth }
-                  height={ height - 200 }
+                  height={ height - 190 }
                   cities={ cities }
                   volcanoLat={ volcanoLat }
                   volcanoLng={ volcanoLng }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -20,7 +20,7 @@ import { js_beautify } from "js-beautify";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import Controls from "./controls";
 import RunButtons from "./run-buttons";
-
+import { Footer, TabContent } from "./styled-containers";
 import screenfull from "screenfull";
 import ResizeObserver from "react-resize-observer";
 
@@ -83,20 +83,12 @@ const Row = styled.div`
   flex-direction: row;
 `;
 
-const Content = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: flex-start;
-  height: 100%;
-  width: 100%;
-`;
-
 const BottomBar = styled.div`
   display: flex;
   width: 100%;
   flex-direction: row;
 `;
+
 const TabsContainer = styled.div`
   flex: 1 1 auto;
 `;
@@ -130,25 +122,13 @@ const Code = styled.div`
 const Syntax = styled(SyntaxHighlighter)`
   flex: 1 1 auto;
   border: 2px solid white;
-  margin: 3px;
-`;
-
-const Footer = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
-  flex: 0 1 44px;
-`;
-
-const FullscreenContainer = styled.div`
-  flex: 0 1 33px;
+  margin: 0px;
 `;
 
 const FullscreenButton = styled(StyledButton)`
   width: 25px;
   height: 25px;
-  margin: 2px;
+  margin: 1px;
   padding: 0px;
   border: 0px solid hsl(0, 0%, 0%);
   background-repeat: no-repeat;
@@ -429,7 +409,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                 forceRender={true}
                 tabcolor={this.getTabColor(SectionTypes.BLOCKS)}
               >
-                <Content>
+                <TabContent>
                   <BlocklyContainer
                     width={blocklyWidth}
                     height={blocklyHeight}
@@ -438,7 +418,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                     initialCodePath={codePath}
                     setBlocklyCode={setBlocklyCode} />
                   <RunButtons {...{run, stop, step, reset, running}} />
-                </Content>
+                </TabContent>
                 { showLog &&
                   <LogComponent
                     width={logWidth}
@@ -454,14 +434,14 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                 width={`${tabWidth}px`}
                 tabcolor={this.getTabColor(SectionTypes.CODE)}
               >
-                <Content>
+                <TabContent>
                   <Code>
                     <Syntax>
                       {js_beautify(code.replace(/endStep\(\)\;\n/g, "").replace(/startStep\(\'.*\'\)\;\n/g, ""))}
                     </Syntax>
                   </Code>
                   <Footer />
-                </Content>
+                </TabContent>
               </TabPanel>
             }
             { showControls &&
@@ -639,14 +619,12 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                   </BottomTab>
                 </TabList>
               </TabsContainer>
-              <FullscreenContainer>
-                { (screenfull && screenfull.isFullscreen) &&
-                  <FullscreenButtonOpen onClick={this.toggleFullscreen} />
-                }
-                { (screenfull && !screenfull.isFullscreen) &&
-                  <FullscreenButtonClosed onClick={this.toggleFullscreen} />
-                }
-              </FullscreenContainer>
+              { (screenfull && screenfull.isFullscreen) &&
+                <FullscreenButtonOpen onClick={this.toggleFullscreen} />
+              }
+              { (screenfull && !screenfull.isFullscreen) &&
+                <FullscreenButtonClosed onClick={this.toggleFullscreen} />
+              }
             </BottomBar>
           </Tabs>
           { showOptionsDialog &&

--- a/src/components/blockly-container.tsx
+++ b/src/components/blockly-container.tsx
@@ -18,7 +18,6 @@ interface IState {}
 const Wrapper = styled.div`
   flex: 1 1 auto;
   justify-content: flex-start;
-  margin: 3px;
 `;
 const StartBlocks = styled.div``;
 interface WorkspaceProps {

--- a/src/components/blockly-container.tsx
+++ b/src/components/blockly-container.tsx
@@ -15,7 +15,11 @@ interface IProps {
 
 interface IState {}
 
-const Wrapper = styled.div``;
+const Wrapper = styled.div`
+  flex: 1 1 auto;
+  justify-content: flex-start;
+  margin: 3px;
+`;
 const StartBlocks = styled.div``;
 interface WorkspaceProps {
   width: number;
@@ -24,8 +28,7 @@ interface WorkspaceProps {
 const WorkSpace = styled.div`
   font-family: sans-serif;
   width: ${(p: WorkspaceProps) => `${p.width}px`};
-  height: ${(p: WorkspaceProps) => `${p.height}px`};
-  border: 2px solid white;
+  height: 100%;
 `;
 
 export default class BlocklyContainer extends React.Component<IProps, IState> {

--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -9,26 +9,17 @@ import WindSpeedDirectionIcon from "../assets/controls-icons/wind-speed-directio
 import RunIcon from "../assets/blockly-icons/run.svg";
 import { Icon } from "./icon";
 import IconButton from "./icon-button";
-import { HorizontalContainer, VerticalContainer,
-         ValueContainer, ValueOutput, IconContainer } from "./styled-containers";
+import { HorizontalContainer, VerticalContainer, ValueContainer,
+         ValueOutput, IconContainer, Footer, TabContent } from "./styled-containers";
 import VEIWidget from "./vei-widget";
 import { WidgetPanelTypes } from "../utilities/widget";
-
-const StyledControls = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-start;
-  align-items: flex-start;
-  height: 100%;
-  width: 100%;
-  padding: 3px;
-  box-sizing: border-box;
-`;
 
 const ControlsContainer = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
+  overflow: auto;
+  min-height: 0px;
   justify-content: flex-start;
   align-items: center;
   box-sizing: border-box;
@@ -60,14 +51,6 @@ const ValueDivider = styled.div`
   height: 21px;
   margin: 0 5px 0 5px;
   background-color: #FFDBAC;
-`;
-
-const EruptContainer = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
-  flex: 0 1 44px;
 `;
 
 const EruptButtons = styled.div`
@@ -137,7 +120,7 @@ export class Controls extends BaseComponent<IProps, IState> {
     } = this.props;
 
     return(
-      <StyledControls>
+      <TabContent>
         <ControlsContainer>
           {(showWindSpeed || showWindDirection) && <ControlContainer
                                                       height={showWindSpeed && showWindDirection ? 172 : 100}>
@@ -294,7 +277,7 @@ export class Controls extends BaseComponent<IProps, IState> {
             <span> reflected in your Blocks/Code.</span>
           </NoteLabel>
         </ControlsContainer>
-        <EruptContainer>
+        <Footer>
           <EruptButtons>
             <IconButton
               onClick={this.erupt}
@@ -308,8 +291,8 @@ export class Controls extends BaseComponent<IProps, IState> {
               height={26}
             />
           </EruptButtons>
-        </EruptContainer>
-      </StyledControls>
+        </Footer>
+      </TabContent>
     );
   }
 

--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -19,12 +19,17 @@ const StyledControls = styled.div`
   flex-direction: column;
   justify-content: flex-start;
   align-items: flex-start;
+  height: 100%;
+  width: 100%;
+  padding: 3px;
+  box-sizing: border-box;
 `;
 
 const ControlsContainer = styled.div`
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  flex: 1 1 auto;
+  justify-content: flex-start;
   align-items: center;
   box-sizing: border-box;
   width: 100%;
@@ -62,7 +67,7 @@ const EruptContainer = styled.div`
   justify-content: center;
   align-items: center;
   width: 100%;
-  height: 44px;
+  flex: 0 1 44px;
 `;
 
 const EruptButtons = styled.div`

--- a/src/components/icon-button.tsx
+++ b/src/components/icon-button.tsx
@@ -11,6 +11,7 @@ const IconButtonContainer = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  box-sizing: border-box;
   width: 83px;
   height: 34px;
   border-radius: 5px;

--- a/src/components/map-component.tsx
+++ b/src/components/map-component.tsx
@@ -22,8 +22,12 @@ interface WorkspaceProps {
 }
 const CanvDiv = styled.div`
   border: 0px solid black; border-radius: 0px;
-  width: ${(p: WorkspaceProps) => `${p.width}px`};
+  width: ${(p: WorkspaceProps) => `${p.width - 56}px`};
   height: ${(p: WorkspaceProps) => `${p.height}px`};
+  padding-left: 28px;
+  padding-right: 28px;
+  padding-top: 25px;
+  box-sizing: content-box;
 `;
 
 interface IState {

--- a/src/components/map-sidebar-component.tsx
+++ b/src/components/map-sidebar-component.tsx
@@ -15,6 +15,7 @@ const CanvDiv = styled.div`
   display: flex;
   border: 0px solid black;
   border-radius: 0px;
+  margin: 10px 28px 10px 28px;
 `;
 
 const style = new PIXI.TextStyle({

--- a/src/components/run-buttons.tsx
+++ b/src/components/run-buttons.tsx
@@ -21,7 +21,7 @@ const ButtonContainer = styled.div`
   justify-content: center;
   align-items: center;
   width: 100%;
-  height: 44px;
+  flex: 0 1 44px;
 `;
 
 const RunButton = (props: IProps) => {

--- a/src/components/run-buttons.tsx
+++ b/src/components/run-buttons.tsx
@@ -21,7 +21,7 @@ const ButtonContainer = styled.div`
   justify-content: center;
   align-items: center;
   width: 100%;
-  flex: 0 1 44px;
+  flex: 0 0 44px;
 `;
 
 const RunButton = (props: IProps) => {

--- a/src/components/styled-containers.tsx
+++ b/src/components/styled-containers.tsx
@@ -61,3 +61,22 @@ export const IconContainer = styled.div`
   height: 60px;
   margin: 0 10px 0 10px;
 `;
+
+export const TabContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  height: 100%;
+  width: 100%;
+  padding: 3px;
+  box-sizing: border-box;
+`;
+
+export const Footer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  flex: 0 0 44px;
+`;

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -177,9 +177,11 @@ const TabPanel = styled(UnstyledTabPanel).attrs({ selectedClassName: "selected" 
   border: none;
   width: 100%;
   background-color: ${props => props.tabcolor || "white"};
-  border-radius: ${props => props.rightpanel && "10px 10px 0 0" || "0 0 10px 10px"};
-  margin: 0;
+  border-radius: ${props => props.rightpanel && "10px 10px 10px 0" || "0 0 10px 10px"};
+  margin: 0px;
   padding: 0px;
+  overflow: hidden;
+  min-height: 0px;
   flex-grow: 1;
   &.selected {
     display: block;

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -40,6 +40,40 @@ const kTabInfo: TabInfo = {
   },
 };
 
+enum RightSectionTypes {
+  CONDITIONS = "conditions",
+  CROSS_SECTION = "crossSection",
+  DATA = "data"
+}
+type RightTabInfo = {
+  [tab in RightSectionTypes]: {
+    name: string;
+    index: number;
+    backgroundColor: string;
+    hoverBackgroundColor: string;
+  }
+};
+const kRightTabInfo: RightTabInfo = {
+  conditions: {
+    name: "Conditions",
+    index: 0,
+    backgroundColor: "#b7dcad",
+    hoverBackgroundColor: "#add1a2",
+  },
+  crossSection: {
+    name: "Cross-Section",
+    index: 1,
+    backgroundColor: "#cee6c9",
+    hoverBackgroundColor: "#c3dabd",
+  },
+  data: {
+    name: "Data",
+    index: 2,
+    backgroundColor: "#e6f2e4",
+    hoverBackgroundColor: "#dae6d7",
+  },
+};
+
 interface TabBackProps {
   width: number;
   backgroundcolor: string;
@@ -48,9 +82,18 @@ const TabBack = styled.div`
   height: 15px;
   background-color: ${(p: TabBackProps) => p.backgroundcolor};
   position: absolute;
-  width: ${(p: TabBackProps) => `${p.width}px`};
+  width: 50%;
   top: 16px;
-  left: 4px;
+  left: 0px;
+`;
+
+const RightTabBack = styled.div`
+  height: 15px;
+  background-color: ${(p: TabBackProps) => p.backgroundcolor};
+  position: absolute;
+  width: ${(p: TabBackProps) => `${p.width - 33}px`};
+  bottom: 24px;
+  right: 33px;
 `;
 
 const Tabs = styled(UnstyledTabs)`
@@ -58,7 +101,8 @@ const Tabs = styled(UnstyledTabs)`
   background: white;
   display: flex;
   flex-direction: column;
-  margin: 0 0 0 2px;
+  margin:0;
+  width: 50%;
 `;
 
 const TabList = styled(UnstyledTabList)`
@@ -66,7 +110,7 @@ const TabList = styled(UnstyledTabList)`
   justify-content: space-between;
   flex-wrap: wrap;
   padding: 0;
-  margin: 2px 0 0 0;
+  margin: 0;
 `;
 
 interface TabProps {
@@ -108,33 +152,44 @@ const Tab = styled(UnstyledTab)<TabProps>`
     cursor: not-allowed;
   }
 `;
+const BottomTab = styled(Tab)<TabProps>`
+  border-bottom-left-radius: 10px;
+  border-bottom-right-radius: 10px;
+  border-top-left-radius: ${props => props.rightofselected === "true" ? "10px" : "0px"};
+  border-top-right-radius: ${props => props.leftofselected === "true" ? "10px" : "0px"};
+  &:first-child {
+    border-bottom-left-radius 10px;
+    border-top-left-radius 0px;
+  }
+  &:last-child {
+    border-bottom-right-radius 10px;
+    border-top-right-radius 0px;
+  }
+`;
 
-const TabPanel = styled(UnstyledTabPanel).attrs({ selectedClassName: "selected" })`
+interface TabPanelProps {
+  tabcolor: string;
+  width: string;
+  rightpanel?: string;
+}
+const TabPanel = styled(UnstyledTabPanel).attrs({ selectedClassName: "selected" })<TabPanelProps>`
   display: none;
-  padding: 0px 0;
   border: none;
-  border-radius: 0 0 10px 10px;
-  margin: 0 0 2px 0;
+  width: 100%;
+  background-color: ${props => props.tabcolor || "white"};
+  border-radius: ${props => props.rightpanel && "10px 10px 0 0" || "0 0 10px 10px"};
+  margin: 0;
+  padding: 0px;
   flex-grow: 1;
   &.selected {
     display: block;
   }
 `;
 
-interface FixWidthTabPanelProps {
-  tabcolor: string;
-  width: string;
-}
-const FixWidthTabPanel = styled(TabPanel)<FixWidthTabPanelProps>`
-  width: ${props => props.width || "300px"};
-  background-color: ${props => props.tabcolor || "white"};
-  padding: 3px;
-`;
-
 (Tab as any).tabsRole = "Tab";
 (Tabs as any).tabsRole = "Tabs";
 (TabPanel as any).tabsRole = "TabPanel";
-(FixWidthTabPanel as any).tabsRole = "TabPanel";
 (TabList as any).tabsRole = "TabList";
 
-export { SectionTypes, TabInfo, kTabInfo, TabBack, Tab, TabList, Tabs, TabPanel, FixWidthTabPanel };
+export { SectionTypes, TabInfo, kTabInfo, TabBack, Tab, TabList, Tabs, TabPanel,
+         RightSectionTypes, kRightTabInfo, RightTabBack, BottomTab };

--- a/src/components/widget-panel.tsx
+++ b/src/components/widget-panel.tsx
@@ -1,0 +1,77 @@
+import * as React from "react";
+import { PureComponent } from "react";
+import VEIWidget from "./vei-widget";
+import { WidgetPanelTypes } from "../utilities/widget";
+import styled from "styled-components";
+
+const WidgetBar = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  margin-top: 16px;
+`;
+
+const WidgetContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin-right: 11px;
+  margin-left: 11px;
+`;
+
+const WidgetTitle = styled.div`
+  font-size: 14px;
+  color: white;
+  margin-bottom: 5px;
+`;
+
+interface IProps {
+  showWindSpeed: boolean;
+  showWindDirection: boolean;
+  showColumnHeight: boolean;
+  showEjectedVolume: boolean;
+  showVEI: boolean;
+  windSpeed: number;
+  windDirection: number;
+  columnHeight: number; // m for vei, km for col height
+  vei: number;
+  mass: number;
+}
+
+interface IState {}
+
+export default class WidgetPanel extends PureComponent<IProps, IState> {
+  public static defaultProps = {
+    showWindSpeed: true,
+    showWindDirection: true,
+    showColumnHeight: true,
+    showEjectedVolume: true,
+    showVEI: true,
+    windSpeed: 1,
+    windDirection: 0,
+    columnHeight: 1,
+    vei: 1,
+    mass: 1,
+  };
+
+  public render() {
+    const { showVEI, vei, mass, columnHeight } = this.props;
+    return (
+      <WidgetBar>
+        { showVEI && <WidgetContainer>
+          <WidgetTitle>VEI</WidgetTitle>
+          <VEIWidget
+            type={WidgetPanelTypes.RIGHT}
+            vei={vei}
+            mass={mass}
+            columnHeight={columnHeight}
+          />
+        </WidgetContainer> }
+      </WidgetBar>
+    );
+  }
+
+}


### PR DESCRIPTION
This pull request adds the following layout and styling based on the UI spec:
- adds the styled right tabs with correct tab selection states
- adds a styled conditions panel with map and section for widgets (model options is still placed at the top)
- positions the fullscreen button in the lower right
- properly handles vertical sizing of panels (content stretches to fit, footer with any needed buttons appears at bottom)

This work was initially started by @llzes.  I wrapped it up and rolled in a couple of related pieces.  Most of this work is restructuring layout and styling - be on the lookout for places where we might refactor to reduce code (I took the path of least resistance to get much of this working).

Ideally I would like to bring this PR in first and then add in the 3 outstanding widget PRs (since I now have a dedicated space and method for adding widgets to the right panel).

For clarity, this encompasses the following 3 PT stories:
https://www.pivotaltracker.com/story/show/167254328
https://www.pivotaltracker.com/story/show/167253917
https://www.pivotaltracker.com/story/show/169625376