### PR TITLE
Save authored settings

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -153,40 +153,15 @@ export class AppComponent extends BaseComponent<IProps, IState> {
   public render() {
     const {
       simulation: {
-        mass,
-        windDirection,
-        windSpeed,
         code,
-        log,
         setBlocklyCode,
-        colHeight,
-        particleSize,
-        vei,
-        coloredColHeight,
-        coloredMass,
-        coloredParticleSize,
-        coloredWindDirection,
-        coloredWindSpeed,
         plotData,
-        cities,
-        volcanoLat,
-        volcanoLng,
-        crossPoint1Lat,
-        crossPoint1Lng,
-        crossPoint2Lat,
-        crossPoint2Lng,
-        viewportZoom,
-        viewportCenterLat,
-        viewportCenterLng,
         run,
         clearLog,
         step,
         stop,
         reset,
         running,
-        isErupting,
-        hasErupted,
-        isSelectingCrossSection,
         initialXmlCode,
         initialCodeTitle,
         toolbox,
@@ -201,11 +176,6 @@ export class AppComponent extends BaseComponent<IProps, IState> {
         showCrossSection,
         showChart,
         showSidebar,
-        showWindSpeed,
-        showWindDirection,
-        showEjectedVolume,
-        showColumnHeight,
-        showVEI,
       }
     } = this.stores;
 
@@ -227,21 +197,6 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     const logWidth = Math.floor(tabWidth * 0.95);
     const logHeight = Math.floor(height * .2);
     const scenarioData = (Scenarios as {[key: string]: {[key: string]: number}})[scenario];
-    const initialZoomKey = "initialZoom";
-    const minZoomKey = "minZoom";
-    const maxZoomKey = "maxZoom";
-    const topLeftLatKey = "topLeftLat";
-    const topLeftLngKey = "topLeftLng";
-    const bottomRightLatKey = "bottomRightLat";
-    const bottomRightLngKey = "bottomRightLng";
-
-    const initialZoom = scenarioData[initialZoomKey];
-    const minZoom = scenarioData[minZoomKey];
-    const maxZoom = scenarioData[maxZoomKey];
-    const topLeftLat = scenarioData[topLeftLatKey];
-    const topLeftLng = scenarioData[topLeftLngKey];
-    const bottomRightLat = scenarioData[bottomRightLatKey];
-    const bottomRightLng = scenarioData[bottomRightLngKey];
 
     const latKey = "volcanoLat";
     const lngKey = "volcanoLng";
@@ -327,7 +282,6 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                   <LogComponent
                     width={logWidth}
                     height={logHeight}
-                    log={log}
                     clear={clearLog}
                   />
                 }
@@ -355,11 +309,6 @@ export class AppComponent extends BaseComponent<IProps, IState> {
               >
                 <Controls
                   width={tabWidth}
-                  showWindSpeed={showWindSpeed}
-                  showWindDirection={showWindDirection}
-                  showEjectedVolume={showEjectedVolume}
-                  showColumnHeight={showColumnHeight}
-                  showVEI={showVEI}
                 />
               </TabPanel>
             }
@@ -373,42 +322,10 @@ export class AppComponent extends BaseComponent<IProps, IState> {
             >
               <Simulation width={mapWidth} backgroundColor={this.getRightTabColor(RightSectionTypes.CONDITIONS)}>
                 <MapComponent
-                  windDirection={ coloredWindDirection }
-                  windSpeed={ coloredWindSpeed }
-                  mass={ coloredMass }
-                  colHeight={ coloredColHeight }
-                  particleSize={ coloredParticleSize }
                   width={ mapWidth }
                   height={ height - 190 }
-                  cities={ cities }
-                  volcanoLat={ volcanoLat }
-                  volcanoLng={ volcanoLng }
-                  initialZoom={initialZoom}
-                  minZoom={ minZoom }
-                  maxZoom={ maxZoom }
-                  topLeftLat={topLeftLat}
-                  topLeftLng={topLeftLng}
-                  bottomRightLat={bottomRightLat}
-                  bottomRightLng={bottomRightLng}
-                  viewportZoom={ viewportZoom }
-                  viewportCenterLat={ viewportCenterLat }
-                  viewportCenterLng={ viewportCenterLng }
-                  isErupting={isErupting}
-                  showCrossSection={false}
-                  hasErupted={ hasErupted }
                 />
-                <WidgetPanel
-                  showWindSpeed={showWindSpeed}
-                  showWindDirection={showWindDirection}
-                  showColumnHeight={showColumnHeight}
-                  showEjectedVolume={showEjectedVolume}
-                  showVEI={showVEI}
-                  windSpeed={ windSpeed }
-                  windDirection={ windDirection }
-                  columnHeight={ colHeight }
-                  vei={ vei }
-                  mass={ mass }
-                />
+                <WidgetPanel />
               </Simulation>
             </TabPanel>
             <TabPanel
@@ -418,47 +335,12 @@ export class AppComponent extends BaseComponent<IProps, IState> {
             >
               <Simulation width={mapWidth} backgroundColor={this.getRightTabColor(RightSectionTypes.CROSS_SECTION)}>
                 <MapComponent
-                  windDirection={ coloredWindDirection }
-                  windSpeed={ coloredWindSpeed }
-                  mass={ coloredMass }
-                  colHeight={ coloredColHeight }
-                  particleSize={ coloredParticleSize }
                   width={ mapWidth }
                   height={ height - 190 }
-                  cities={ cities }
-                  volcanoLat={ volcanoLat }
-                  volcanoLng={ volcanoLng }
-                  initialZoom={initialZoom}
-                  minZoom={ minZoom }
-                  maxZoom={ maxZoom }
-                  topLeftLat={topLeftLat}
-                  topLeftLng={topLeftLng}
-                  bottomRightLat={bottomRightLat}
-                  bottomRightLng={bottomRightLng}
-                  viewportZoom={ viewportZoom }
-                  viewportCenterLat={ viewportCenterLat }
-                  viewportCenterLng={ viewportCenterLng }
-                  isErupting={isErupting}
-                  showCrossSection={true}
-                  hasErupted={ hasErupted }
                 />
                 <CrossSectionComponent
-                  isSelectingCrossSection={isSelectingCrossSection}
-                  showCrossSectionSelector={isSelectingCrossSection}
-                  height={ 100 }
                   width={ mapWidth }
-                  volcanoLat={ volcanoLat }
-                  volcanoLng={ volcanoLng }
-                  crossPoint1Lat={ crossPoint1Lat }
-                  crossPoint1Lng={ crossPoint1Lng }
-                  crossPoint2Lat={ crossPoint2Lat }
-                  crossPoint2Lng={ crossPoint2Lng }
-                  hasErupted={ hasErupted }
-                  windSpeed={windSpeed}
-                  windDirection={windDirection}
-                  colHeight={colHeight}
-                  mass={mass}
-                  particleSize={particleSize}
+                  height={ 100 }
                 />
               </Simulation>
             </TabPanel>

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -24,6 +24,7 @@ import WidgetPanel from "./widget-panel";
 import screenfull from "screenfull";
 import ResizeObserver from "react-resize-observer";
 import AuthoringMenu from "./authoring-menu";
+import { getAuthorableSettings, updateStores } from "../stores/stores";
 
 interface IProps extends IBaseProps {}
 
@@ -414,6 +415,16 @@ export class AppComponent extends BaseComponent<IProps, IState> {
               }
             </BottomBar>
           </Tabs>
+          { showOptionsDialog &&
+            <AuthoringMenu
+              options={getAuthorableSettings()}
+              expandOptionsDialog={expandOptionsDialog}
+              toggleShowOptions={this.toggleShowOptions}
+              saveCodeToLocalStorage={this.saveCodeToLocalStorage}
+              loadCodeFromLocalStorage={this.loadCodeFromLocalStorage}
+              handleUpdate={updateStores}
+            />
+          }
         </Row>
       </App>
     );

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -56,7 +56,6 @@ export interface SimulationAuthoringOptions {
 interface IState {
   tabIndex: number;
   rightTabIndex: number;
-  showOptionsDialog: boolean;
   expandOptionsDialog: boolean;
   simulationOptions: SimulationAuthoringOptions;
   dimensions: {
@@ -160,13 +159,14 @@ export class AppComponent extends BaseComponent<IProps, IState> {
   public constructor(props: IProps) {
     super(props);
 
+    const { simulation, uiStore } = this.stores;
+
     this.handleTabSelect = this.handleTabSelect.bind(this);
     this.handleRightTabSelect = this.handleRightTabSelect.bind(this);
 
     const initialState: IState = {
       tabIndex: 0,
       rightTabIndex: 0,
-      showOptionsDialog: true,
       expandOptionsDialog: false,
       simulationOptions: {
         requireEruption: true,
@@ -218,15 +218,16 @@ export class AppComponent extends BaseComponent<IProps, IState> {
 
     // for now, assume that if we've loaded from params that we don't want settings dialog
     if (Object.keys(urlParams).length > 0) {
-      initialState.showOptionsDialog = false;
+      uiStore.setShowOptionsDialog(false);
     }
 
     this.state = initialState;
-    this.stores.setAuthoringOptions(initialState.simulationOptions, true);
+    simulation.setAuthoringOptions(initialState.simulationOptions, true);
   }
 
   public componentDidUpdate(prevProps: IProps, prevState: IState) {
     const { scenario, showBlocks, showCode, showControls } = this.state.simulationOptions;
+    const { simulation } = this.stores;
     if (prevState.simulationOptions.showBlocks !== showBlocks ||
         prevState.simulationOptions.showCode !== showCode ||
         prevState.simulationOptions.showControls !== showControls) {
@@ -238,55 +239,59 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     const latKey = "volcanoLat";
     const lngKey = "volcanoLng";
 
-    this.stores.setVolcano(scenarioData[latKey], scenarioData[lngKey]);
+    simulation.setVolcano(scenarioData[latKey], scenarioData[lngKey]);
 
-    this.stores.setAuthoringOptions(this.state.simulationOptions, false);
+    simulation.setAuthoringOptions(this.state.simulationOptions, false);
   }
 
   public render() {
     const {
-      mass,
-      windDirection,
-      windSpeed,
-      code,
-      log,
-      setBlocklyCode,
-      colHeight,
-      particleSize,
-      vei,
-      coloredColHeight,
-      coloredMass,
-      coloredParticleSize,
-      coloredVei,
-      coloredWindDirection,
-      coloredWindSpeed,
-      plotData,
-      cities,
-      volcanoLat,
-      volcanoLng,
-      crossPoint1Lat,
-      crossPoint1Lng,
-      crossPoint2Lat,
-      crossPoint2Lng,
-      viewportZoom,
-      viewportCenterLat,
-      viewportCenterLng,
-      run,
-      clearLog,
-      step,
-      stop,
-      reset,
-      running,
-      isErupting,
-      hasErupted,
-      isSelectingCrossSection,
-      initialXmlCode
+      simulation: {
+        mass,
+        windDirection,
+        windSpeed,
+        code,
+        log,
+        setBlocklyCode,
+        colHeight,
+        particleSize,
+        vei,
+        coloredColHeight,
+        coloredMass,
+        coloredParticleSize,
+        coloredVei,
+        coloredWindDirection,
+        coloredWindSpeed,
+        plotData,
+        cities,
+        volcanoLat,
+        volcanoLng,
+        crossPoint1Lat,
+        crossPoint1Lng,
+        crossPoint2Lat,
+        crossPoint2Lng,
+        viewportZoom,
+        viewportCenterLat,
+        viewportCenterLng,
+        run,
+        clearLog,
+        step,
+        stop,
+        reset,
+        running,
+        isErupting,
+        hasErupted,
+        isSelectingCrossSection,
+        initialXmlCode
+      },
+      uiStore: {
+        showOptionsDialog
+      }
     } = this.stores;
 
     const {
       tabIndex,
       rightTabIndex,
-      showOptionsDialog,
       expandOptionsDialog,
       simulationOptions
     } = this.state;
@@ -698,18 +703,19 @@ export class AppComponent extends BaseComponent<IProps, IState> {
   }
 
   private saveCodeToLocalStorage = () => {
-    localStorage.setItem("blockly-workspace", this.stores.xmlCode);
+    localStorage.setItem("blockly-workspace", this.stores.simulation.xmlCode);
   }
 
   private loadCodeFromLocalStorage = () => {
+    const { simulation } = this.stores;
     const code = localStorage.getItem("blockly-workspace");
     if (code) {
       // we need to unset and then set the state to force a re-render, if the user has already
       // loaded the code once.
       // because of the way Blockly injects to the DOM, we have to wait 100ms, instead of using
       // the setState callback, or we may end up with two Blockly editors
-      this.stores.setInitialXmlCode("<xml></xml>");
-      setTimeout(() => {this.stores.setInitialXmlCode(code); }, 100);
+      simulation.setInitialXmlCode("<xml></xml>");
+      setTimeout(() => {simulation.setInitialXmlCode(code); }, 100);
     }
   }
 

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,6 +1,5 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
-import DatGui, { DatBoolean, DatButton, DatSelect, DatFolder, DatNumber } from "react-dat-gui";
 import { LineChart, Line, CartesianGrid, XAxis, YAxis } from "recharts";
 import { BaseComponent, IBaseProps } from "./base";
 import { MapComponent } from "./map-component";
@@ -24,6 +23,7 @@ import { Footer, TabContent } from "./styled-containers";
 import WidgetPanel from "./widget-panel";
 import screenfull from "screenfull";
 import ResizeObserver from "react-resize-observer";
+import AuthoringMenu from "./authoring-menu";
 
 interface IProps extends IBaseProps {}
 
@@ -632,60 +632,15 @@ export class AppComponent extends BaseComponent<IProps, IState> {
             </BottomBar>
           </Tabs>
           { showOptionsDialog &&
-            <DatGui data={simulationOptions} onUpdate={this.handleUpdate}>
-            <DatButton label="Model options" onClick={this.toggleShowOptions} />
-            { expandOptionsDialog &&
-              [
-                <DatBoolean path="requireEruption" label="Require eruption?" key="requireEruption" />,
-                <DatBoolean path="requirePainting" label="Require painting?" key="requirePainting" />,
-                <DatSelect path="scenario" label="Map Scenario" options={Object.keys(Scenarios)} key="background" />,
-                <DatSelect path="toolbox" label="Code toolbox"
-                  options={Object.keys(BlocklyAuthoring.toolbox)} key="toolbox" />,
-                <DatSelect path="initialCodeTitle" label="Initial code"
-                  options={Object.keys(BlocklyAuthoring.code)} key="code" />,
-                <DatButton label="Save current code to local storage"
-                  onClick={this.saveCodeToLocalStorage}
-                  key="generate" />,
-                <DatButton label="Load code from local storage"
-                  onClick={this.loadCodeFromLocalStorage}
-                  key="generate" />,
-                <DatBoolean path="showBlocks" label="Show blocks?" key="showBlocks" />,
-                <DatBoolean path="showCode" label="Show code?" key="showCode" />,
-                <DatBoolean path="showControls" label="Show controls?" key="showControls" />,
-                <DatFolder title="Controls Options" key="controlsFolder" closed={true}>
-                  <DatBoolean path="showWindSpeed" label="Show Wind Speed?" key="showWindSpeed"/>
-                  <DatNumber
-                    path="initialWindSpeed" label="Initial Wind Speed" key="initialWindSpeed"
-                    min={0} max={30} step={1}/>
-                  <DatBoolean path="showWindDirection" label="Show Wind Direction?" key="showWindDirection" />
-                  <DatNumber
-                    path="initialWindDirection" label="Initial Wind Direction" key="initialWindDirection"
-                    min={0} max={360} step={1}/>
-                  <DatBoolean path="showEjectedVolume" label="Show Ejected Volume?" key="showEjectedVolume" />
-                  <DatNumber
-                    path="initialEruptionMass" label="Initial Ejection Volume" key="initialEruptionMass"
-                    min={100000000} max={10000000000000000} step={1000}/>
-                  <DatBoolean path="showColumnHeight" label="Show Column Height?" key="showColumnHeight" />
-                  <DatNumber
-                    path="initialColumnHeight" label="Initial Column Height" key="initialColumnHeight"
-                    min={1000} max={30000} step={1000}/>
-                  <DatBoolean path="showVEI" label="Show VEI?" key="showVEI" />
-                  <DatNumber
-                    path="initialVEI" label="Initial VEI" key="initialVEI"
-                    min={1} max={8} step={1}/>
-                </DatFolder>,
-                <DatBoolean path="showCrossSection" label="Show cross section?" key="showCrossSection" />,
-                <DatBoolean path="showChart" label="Show chart?" key="showChart" />,
-                <DatBoolean path="showLog" label="Show Log?" key="showLog" />,
-                <DatBoolean path="showSidebar" label="Show sidebar?" key="showSidebar" />,
-                // submit button. Should remain at bottom
-                <DatButton
-                  label="Generate authored model"
-                  onClick={this.generateAndOpenAuthoredUrl}
-                  key="generate" />
-              ]
-            }
-            </DatGui>
+            <AuthoringMenu
+              options={simulationOptions}
+              expandOptionsDialog={expandOptionsDialog}
+              handleUpdate={this.handleAuthoringUpdate}
+              toggleShowOptions={this.toggleShowOptions}
+              saveCodeToLocalStorage={this.saveCodeToLocalStorage}
+              loadCodeFromLocalStorage={this.loadCodeFromLocalStorage}
+              generateAndOpenAuthoredUrl={this.generateAndOpenAuthoredUrl}
+            />
           }
         </Row>
       </App>
@@ -727,7 +682,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
 
   private toggleShowOptions = () => this.setState({expandOptionsDialog: !this.state.expandOptionsDialog});
 
-  private handleUpdate = (simulationOptions: SimulationAuthoringOptions) => this.setState({ simulationOptions });
+  private handleAuthoringUpdate = (opts: SimulationAuthoringOptions) => this.setState({ simulationOptions: opts });
 
   private handleTabSelect(tabIndex: number) {
     this.setState({tabIndex});

--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -3,15 +3,15 @@ import DatGui, { DatBoolean, DatButton, DatSelect, DatFolder, DatNumber } from "
 
 import * as Scenarios from "./../assets/maps/scenarios.json";
 import * as BlocklyAuthoring from "./../assets/blockly-authoring/index.json";
+import { IStoreish } from "../stores/stores.js";
 
 interface IProps {
-  options: {};
+  options: IStoreish;
   expandOptionsDialog: boolean;
-  handleUpdate: (simulationOptions: any) => void;
   toggleShowOptions: () => void;
   saveCodeToLocalStorage: () => void;
   loadCodeFromLocalStorage: () => void;
-  generateAndOpenAuthoredUrl: () => void;
+  handleUpdate: (state: IStoreish) => void;
 }
 
 const AuthoringMenu: React.SFC<IProps> = (props) => {
@@ -20,13 +20,31 @@ const AuthoringMenu: React.SFC<IProps> = (props) => {
       <DatButton label="Model options" onClick={props.toggleShowOptions} />
       { props.expandOptionsDialog &&
         [
-          <DatBoolean path="requireEruption" label="Require eruption?" key="requireEruption" />,
-          <DatBoolean path="requirePainting" label="Require painting?" key="requirePainting" />,
-          <DatSelect path="scenario" label="Map Scenario" options={Object.keys(Scenarios)} key="background" />,
-          <DatSelect path="toolbox" label="Code toolbox"
+          <DatBoolean path="simulation.requireEruption" label="Require eruption?" key="requireEruption" />,
+          <DatBoolean path="simulation.requirePainting" label="Require painting?" key="requirePainting" />,
+          <DatSelect path="simulation.scenario" label="Map Scenario"
+            options={Object.keys(Scenarios)} key="background" />,
+          <DatSelect path="simulation.toolbox" label="Code toolbox"
             options={Object.keys(BlocklyAuthoring.toolbox)} key="toolbox" />,
-          <DatSelect path="initialCodeTitle" label="Initial code"
+          <DatSelect path="simulation.initialCodeTitle" label="Initial code"
             options={Object.keys(BlocklyAuthoring.code)} key="code" />,
+
+          <DatBoolean path="uiStore.showBlocks" label="Show blocks?" key="showBlocks" />,
+          <DatBoolean path="uiStore.showCode" label="Show code?" key="showCode" />,
+          <DatBoolean path="uiStore.showControls" label="Show controls?" key="showControls" />,
+          <DatFolder title="Controls Options" key="controlsFolder" closed={true}>
+            <DatBoolean path="uiStore.showWindSpeed" label="Show Wind Speed?" key="showWindSpeed"/>
+            <DatBoolean path="uiStore.showWindDirection" label="Show Wind Direction?" key="showWindDirection" />
+            <DatBoolean path="uiStore.showEjectedVolume" label="Show Ejected Volume?" key="showEruptionMass" />
+            <DatBoolean path="uiStore.showColumnHeight" label="Show Column Height?" key="showColumnHeight" />
+            <DatBoolean path="uiStore.showVEI" label="Show VEI?" key="showVEI" />
+          </DatFolder>,
+
+          <DatBoolean path="uiStore.showLog" label="Show Log?" key="showLog" />,
+
+          <DatBoolean path="uiStore.showChart" label="Show chart?" key="showChart" />,
+          <DatBoolean path="uiStore.showSidebar" label="Show sidebar?" key="showSidebar" />,
+          <DatBoolean path="uiStore.showCrossSection" label="Show cross section?" key="showCrossSection" />,
 
           <DatButton label="Save current code to local storage"
             onClick={props.saveCodeToLocalStorage}
@@ -34,47 +52,6 @@ const AuthoringMenu: React.SFC<IProps> = (props) => {
           <DatButton label="Load code from local storage"
             onClick={props.loadCodeFromLocalStorage}
             key="generate" />,
-
-          <DatBoolean path="showCrossSection" label="Show cross section?" key="showCrossSection" />,
-          <DatBoolean path="showChart" label="Show chart?"
-            key="showChart" />,
-
-          <DatBoolean path="showBlocks" label="Show blocks?" key="showBlocks" />,
-          <DatBoolean path="showCode" label="Show code?" key="showCode" />,
-          <DatBoolean path="showControls" label="Show controls?" key="showControls" />,
-          <DatFolder title="Controls Options" key="controlsFolder" closed={true}>
-            <DatBoolean path="showWindSpeed" label="Show Wind Speed?" key="showWindSpeed"/>
-            <DatNumber
-              path="initialWindSpeed" label="Initial Wind Speed" key="initialWindSpeed"
-              min={0} max={30} step={1}/>
-            <DatBoolean path="showWindDirection" label="Show Wind Direction?" key="showWindDirection" />
-            <DatNumber
-              path="initialWindDirection" label="Initial Wind Direction" key="initialWindDirection"
-              min={0} max={360} step={1}/>
-            <DatBoolean path="showEruptionMass" label="Show Eruption Mass?" key="showEruptionMass" />
-            <DatNumber
-              path="initialEruptionMass" label="Initial Eruption Mass" key="initialEruptionMass"
-              min={100000000} max={10000000000000000} step={1000}/>
-            <DatBoolean path="showColumnHeight" label="Show Column Height?" key="showColumnHeight" />
-            <DatNumber
-              path="initialColumnHeight" label="Initial Column Height" key="initialColumnHeight"
-              min={1000} max={30000} step={1000}/>
-            <DatBoolean path="showParticleSize" label="Show Particle Size?" key="showParticleSize" />
-            <DatBoolean path="showVEI" label="Show VEI?" key="showVEI" />
-            <DatNumber
-              path="initialVEI" label="Initial VEI" key="initialVEI"
-              min={1} max={8} step={1}/>
-          </DatFolder>,
-
-          <DatBoolean path="showLog" label="Show Log?" key="showLog" />,
-
-          <DatBoolean path="showChart" label="Show chart?" key="showChart" />,
-          <DatBoolean path="showSidebar" label="Show sidebar?" key="showSidebar" />,
-          // submit button. Should remain at bottom
-          <DatButton
-            label="Generate authored model"
-            onClick={props.generateAndOpenAuthoredUrl}
-            key="generate" />
         ]
       }
     </DatGui>

--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -1,0 +1,85 @@
+import * as React from "react";
+import DatGui, { DatBoolean, DatButton, DatSelect, DatFolder, DatNumber } from "react-dat-gui";
+
+import * as Scenarios from "./../assets/maps/scenarios.json";
+import * as BlocklyAuthoring from "./../assets/blockly-authoring/index.json";
+import { SimulationAuthoringOptions } from "./app.js";
+
+interface IProps {
+  options: {};
+  expandOptionsDialog: boolean;
+  handleUpdate: (simulationOptions: SimulationAuthoringOptions) => void;
+  toggleShowOptions: () => void;
+  saveCodeToLocalStorage: () => void;
+  loadCodeFromLocalStorage: () => void;
+  generateAndOpenAuthoredUrl: () => void;
+}
+
+const AuthoringMenu: React.SFC<IProps> = (props) => {
+  return (
+    <DatGui data={props.options} onUpdate={props.handleUpdate}>
+      <DatButton label="Model options" onClick={props.toggleShowOptions} />
+      { props.expandOptionsDialog &&
+        [
+          <DatBoolean path="requireEruption" label="Require eruption?" key="requireEruption" />,
+          <DatBoolean path="requirePainting" label="Require painting?" key="requirePainting" />,
+          <DatSelect path="scenario" label="Map Scenario" options={Object.keys(Scenarios)} key="background" />,
+          <DatSelect path="toolbox" label="Code toolbox"
+            options={Object.keys(BlocklyAuthoring.toolbox)} key="toolbox" />,
+          <DatSelect path="initialCodeTitle" label="Initial code"
+            options={Object.keys(BlocklyAuthoring.code)} key="code" />,
+
+          <DatButton label="Save current code to local storage"
+            onClick={props.saveCodeToLocalStorage}
+            key="generate" />,
+          <DatButton label="Load code from local storage"
+            onClick={props.loadCodeFromLocalStorage}
+            key="generate" />,
+
+          <DatBoolean path="showCrossSection" label="Show cross section?" key="showCrossSection" />,
+          <DatBoolean path="showChart" label="Show chart?"
+            key="showChart" />,
+
+          <DatBoolean path="showBlocks" label="Show blocks?" key="showBlocks" />,
+          <DatBoolean path="showCode" label="Show code?" key="showCode" />,
+          <DatBoolean path="showControls" label="Show controls?" key="showControls" />,
+          <DatFolder title="Controls Options" key="controlsFolder" closed={true}>
+            <DatBoolean path="showWindSpeed" label="Show Wind Speed?" key="showWindSpeed"/>
+            <DatNumber
+              path="initialWindSpeed" label="Initial Wind Speed" key="initialWindSpeed"
+              min={0} max={30} step={1}/>
+            <DatBoolean path="showWindDirection" label="Show Wind Direction?" key="showWindDirection" />
+            <DatNumber
+              path="initialWindDirection" label="Initial Wind Direction" key="initialWindDirection"
+              min={0} max={360} step={1}/>
+            <DatBoolean path="showEruptionMass" label="Show Eruption Mass?" key="showEruptionMass" />
+            <DatNumber
+              path="initialEruptionMass" label="Initial Eruption Mass" key="initialEruptionMass"
+              min={100000000} max={10000000000000000} step={1000}/>
+            <DatBoolean path="showColumnHeight" label="Show Column Height?" key="showColumnHeight" />
+            <DatNumber
+              path="initialColumnHeight" label="Initial Column Height" key="initialColumnHeight"
+              min={1000} max={30000} step={1000}/>
+            <DatBoolean path="showParticleSize" label="Show Particle Size?" key="showParticleSize" />
+            <DatBoolean path="showVEI" label="Show VEI?" key="showVEI" />
+            <DatNumber
+              path="initialVEI" label="Initial VEI" key="initialVEI"
+              min={1} max={8} step={1}/>
+          </DatFolder>,
+
+          <DatBoolean path="showLog" label="Show Log?" key="showLog" />,
+
+          <DatBoolean path="showChart" label="Show chart?" key="showChart" />,
+          <DatBoolean path="showSidebar" label="Show sidebar?" key="showSidebar" />,
+          // submit button. Should remain at bottom
+          <DatButton
+            label="Generate authored model"
+            onClick={props.generateAndOpenAuthoredUrl}
+            key="generate" />
+        ]
+      }
+    </DatGui>
+  );
+};
+
+export default AuthoringMenu;

--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -3,12 +3,11 @@ import DatGui, { DatBoolean, DatButton, DatSelect, DatFolder, DatNumber } from "
 
 import * as Scenarios from "./../assets/maps/scenarios.json";
 import * as BlocklyAuthoring from "./../assets/blockly-authoring/index.json";
-import { SimulationAuthoringOptions } from "./app.js";
 
 interface IProps {
   options: {};
   expandOptionsDialog: boolean;
-  handleUpdate: (simulationOptions: SimulationAuthoringOptions) => void;
+  handleUpdate: (simulationOptions: any) => void;
   toggleShowOptions: () => void;
   saveCodeToLocalStorage: () => void;
   loadCodeFromLocalStorage: () => void;

--- a/src/components/base.ts
+++ b/src/components/base.ts
@@ -1,15 +1,15 @@
 import * as React from "react";
-import { SimulationModelType } from "../stores/simulation-store";
+import { IStore } from "../stores/stores";
 
 export interface IBaseProps {
-  stores?: SimulationModelType;
+  stores?: IStore;
 }
 
 export class BaseComponent<P, S> extends React.Component<P, S> {
 
   // this assumes that stores are injected by the classes that extend BaseComponent
   get stores() {
-    return (this.props as IBaseProps).stores as SimulationModelType;
+    return (this.props as IBaseProps).stores as IStore;
   }
 
 }

--- a/src/components/blockly-container.tsx
+++ b/src/components/blockly-container.tsx
@@ -72,7 +72,7 @@ export default class BlocklyContainer extends React.Component<IProps, IState> {
       media: "blockly/media/",
       toolbox: `
       <xml id="toolbox" style="display: none">
-        <category name="dummy">
+        <category name="Loading...">
         </category>
       </xml>
       `,

--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -106,10 +106,10 @@ export class Controls extends BaseComponent<IProps, IState> {
       stagingWindDirection,
       stagingParticleSize,
       stagingMass,
-      stagingColHeight, // in meters
+      stagingColHeight,
       stagingWindSpeed,
       stagingVei
-    } = this.stores;
+    } = this.stores.simulation;
 
     const {
       showWindSpeed,
@@ -269,34 +269,34 @@ export class Controls extends BaseComponent<IProps, IState> {
   }
 
   private changeWindDirection = (direction: number) => {
-    this.stores.setWindDirection(direction);
+    this.stores.simulation.setWindDirection(direction);
   }
 
   private changeWindSpeed = (speed: number) => {
-    this.stores.setWindSpeed(speed);
+    this.stores.simulation.setWindSpeed(speed);
   }
 
   private changeColumnHeight = (heightInKilometers: number) => {
-    this.stores.setColumnHeight(heightInKilometers);
+    this.stores.simulation.setColumnHeight(heightInKilometers);
   }
 
   private changeMass = (zeroBasedPower: number) => {
     // -4 index conversion, +9 km^3 to m^3, +3 m^3 to kg
     const massInKilograms = Math.pow(10, zeroBasedPower - 4 + 9 + 3);
-    this.stores.setMass(massInKilograms);
+    this.stores.simulation.setMass(massInKilograms);
   }
 
   private changeSize = (size: number) => {
-    this.stores.setParticleSize(size);
+    this.stores.simulation.setParticleSize(size);
   }
 
   private changeVEI = (vei: number) => {
-    this.stores.setVEI(vei);
+    this.stores.simulation.setVEI(vei);
   }
 
   private erupt = () => {
-    this.stores.erupt(this.state.animate);
-    this.stores.paintMap();
+    this.stores.simulation.erupt(this.state.animate);
+    this.stores.simulation.paintMap();
 
     // This code is used for waiting for the animation to complete and then painting
     // if (this.state.animate) {

--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -66,28 +66,8 @@ const BoldSpan = styled.span`
   font-weight: bold;
 `;
 
-interface IControls {
-  windDirection: number;
-  particleSize: number;
-  mass: number;
-  colHeight: number;
-  windSpeed: number;
-
-  changeWindDirection: (a: any) => void;
-  changeWindSpeed: (a: any) => void;
-  changeSize: (a: any) => void;
-  changeColumnHeight: (a: any) => void;
-  changeMass: (a: any) => void;
-  changeVEI: (a: any) => void;
-}
-
 interface IProps extends IBaseProps {
   width: number;
-  showWindSpeed: boolean;
-  showWindDirection: boolean;
-  showEjectedVolume: boolean;
-  showColumnHeight: boolean;
-  showVEI: boolean;
 }
 interface IState {
   animate: boolean;
@@ -104,7 +84,6 @@ export class Controls extends BaseComponent<IProps, IState> {
 
     const {
       stagingWindDirection,
-      stagingParticleSize,
       stagingMass,
       stagingColHeight,
       stagingWindSpeed,
@@ -116,8 +95,8 @@ export class Controls extends BaseComponent<IProps, IState> {
       showWindDirection,
       showEjectedVolume,
       showColumnHeight,
-      showVEI,
-    } = this.props;
+      showVEI
+    } = this.stores.uiStore;
 
     return(
       <TabContent>

--- a/src/components/cross-section-component.tsx
+++ b/src/components/cross-section-component.tsx
@@ -18,22 +18,8 @@ const ContainerDiv = styled.div`
 interface IState {}
 
 interface IProps extends IBaseProps {
-  showCrossSectionSelector: boolean;
-  isSelectingCrossSection: boolean;
   height: number;
   width: number;
-  volcanoLat: number;
-  volcanoLng: number;
-  crossPoint1Lat: number;
-  crossPoint1Lng: number;
-  crossPoint2Lat: number;
-  crossPoint2Lng: number;
-  hasErupted: boolean;
-  windSpeed: number;
-  windDirection: number;
-  colHeight: number;
-  mass: number;
-  particleSize: number;
 }
 
 @inject("stores")
@@ -54,13 +40,16 @@ export class CrossSectionComponent extends BaseComponent<IProps, IState>{
   public render() {
     if (! this.metrics) { this.recomputeMetrics(); }
     const {
+      height
+    } = this.props;
+
+    const {
       volcanoLat,
       volcanoLng,
       crossPoint1Lat,
       crossPoint1Lng,
       crossPoint2Lat,
       crossPoint2Lng,
-      height,
       hasErupted,
       windSpeed,
       windDirection,
@@ -68,7 +57,8 @@ export class CrossSectionComponent extends BaseComponent<IProps, IState>{
       mass,
       particleSize,
       isSelectingCrossSection
-    } = this.props;
+    } = this.stores.simulation;
+
     const { width } = this.metrics;
 
     return (

--- a/src/components/cross-section-draw-layer.tsx
+++ b/src/components/cross-section-draw-layer.tsx
@@ -90,9 +90,9 @@ export class CrossSectionDrawLayer extends BaseComponent<IProps, IState> {
     }
     if (point !== null) {
         if (index === 0) {
-          this.stores.setPoint1Pos(point.lat, point.lng);
+          this.stores.simulation.setPoint1Pos(point.lat, point.lng);
         } else {
-          this.stores.setPoint2Pos(point.lat, point.lng);
+          this.stores.simulation.setPoint2Pos(point.lat, point.lng);
         }
     }
   }

--- a/src/components/log-component.tsx
+++ b/src/components/log-component.tsx
@@ -31,7 +31,6 @@ interface IState{}
 interface IProps extends IBaseProps {
     width: number;
     height: number;
-    log: string;
     clear: any;
 }
 interface ILog {
@@ -46,7 +45,8 @@ export class LogComponent extends BaseComponent<IProps, IState> {
     private ref = React.createRef<HTMLDivElement>();
 
     public render() {
-        const { log, height, width, clear } = this.props;
+        const { height, width, clear } = this.props;
+        const { log } = this.stores.simulation;
 
         return(
             <CanvDiv ref={this.ref} height={height} width={width}>

--- a/src/components/map-component.tsx
+++ b/src/components/map-component.tsx
@@ -87,20 +87,20 @@ export class MapComponent extends BaseComponent<IProps, IState>{
   }
 
   public handleDragEnter(e: React.MouseEvent<HTMLDivElement>) {
-    this.stores.setPoint1Pos(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
-    this.stores.setPoint2Pos(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
+    this.stores.simulation.setPoint1Pos(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
+    this.stores.simulation.setPoint2Pos(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
     this.setState({moveMouse: true});
   }
 
   public handleDragMove(e: React.MouseEvent<HTMLDivElement>) {
     const { moveMouse } = this.state;
     if (moveMouse) {
-      this.stores.setPoint2Pos(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
+      this.stores.simulation.setPoint2Pos(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
     }
   }
 
   public handleDragExit(e: React.MouseEvent<HTMLDivElement>) {
-    this.stores.setPoint2Pos(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
+    this.stores.simulation.setPoint2Pos(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
     this.setState({moveMouse: false});
   }
 
@@ -130,7 +130,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
     const {
       isSelectingCrossSection,
       isSelectingRuler
-    } = this.stores;
+    } = this.stores.simulation;
 
     const cityItems = cities.map( (city) => {
       const {x, y, name} = city;
@@ -150,7 +150,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
       }
     });
 
-    const { crossPoint1Lat, crossPoint1Lng, crossPoint2Lat, crossPoint2Lng } = this.stores;
+    const { crossPoint1Lat, crossPoint1Lng, crossPoint2Lat, crossPoint2Lng } = this.stores.simulation;
     const volcanoPos = L.latLng(volcanoLat, volcanoLng);
     const corner1 = L.latLng(topLeftLat, topLeftLng);
     const corner2 = L.latLng(bottomRightLat, bottomRightLng);
@@ -236,10 +236,10 @@ export class MapComponent extends BaseComponent<IProps, IState>{
         </LeafletMap>
         <OverlayControls
           showRuler={isSelectingRuler}
-          onRulerClick={this.stores.rulerClick}
+          onRulerClick={this.stores.simulation.rulerClick}
           isSelectingCrossSection={isSelectingCrossSection}
           showCrossSection={hasErupted && showCrossSection}
-          onCrossSectionClick={this.stores.crossSectionClick}
+          onCrossSectionClick={this.stores.simulation.crossSectionClick}
           onReCenterClick={this.onRecenterClick}
         />
       </CanvDiv>
@@ -261,7 +261,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
       if (this.map.current) {
         const center = this.map.current.leafletElement.getCenter();
         const zoom = this.map.current.leafletElement.getZoom();
-        this.stores.setViewportParameters(zoom, center.lat, center.lng);
+        this.stores.simulation.setViewportParameters(zoom, center.lat, center.lng);
       }
     }
   }

--- a/src/components/map-component.tsx
+++ b/src/components/map-component.tsx
@@ -56,7 +56,6 @@ interface IProps extends IBaseProps {
   viewportCenterLat: number;
   viewportCenterLng: number;
   cities: CityType[];
-  map: string;
   isErupting: boolean;
   hasErupted: boolean;
   showCrossSection: boolean;

--- a/src/components/map-component.tsx
+++ b/src/components/map-component.tsx
@@ -7,6 +7,7 @@ import "../css/map-component.css";
 import { iconVolcano, getCachedDivIcon } from "./icons";
 
 import { CityType  } from "../stores/simulation-store";
+import * as Scenarios from "./../assets/maps/scenarios.json";
 import styled from "styled-components";
 import { observer, inject } from "mobx-react";
 import { BaseComponent, IBaseProps } from "./base";
@@ -38,27 +39,6 @@ interface IState {
 interface IProps extends IBaseProps {
   width: number;
   height: number;
-  windSpeed: number;
-  windDirection: number;
-  mass: number;
-  colHeight: number;
-  particleSize: number;
-  volcanoLat: number;
-  volcanoLng: number;
-  topLeftLat: number;
-  topLeftLng: number;
-  bottomRightLat: number;
-  bottomRightLng: number;
-  initialZoom: number;
-  minZoom: number;
-  maxZoom: number;
-  viewportZoom: number;
-  viewportCenterLat: number;
-  viewportCenterLng: number;
-  cities: CityType[];
-  isErupting: boolean;
-  hasErupted: boolean;
-  showCrossSection: boolean;
 }
 
 @inject("stores")
@@ -116,7 +96,14 @@ export class MapComponent extends BaseComponent<IProps, IState>{
       mass,
       particleSize,
       hasErupted,
-      showCrossSection,
+      scenario,
+    } = this.stores.simulation;
+
+    const { showCrossSection } = this.stores.uiStore;
+
+    const scenarioData = (Scenarios as {[key: string]: {[key: string]: number}})[scenario];
+
+    const {
       initialZoom,
       minZoom,
       maxZoom,
@@ -124,14 +111,14 @@ export class MapComponent extends BaseComponent<IProps, IState>{
       topLeftLng,
       bottomRightLat,
       bottomRightLng
-    } = this.props;
+    } = scenarioData;
 
     const {
       isSelectingCrossSection,
       isSelectingRuler
     } = this.stores.simulation;
 
-    const cityItems = cities.map( (city) => {
+    const cityItems = cities.map( (city: CityType) => {
       const {x, y, name} = city;
       if (x && y && name) {
         const mapPos = LocalToLatLng({x, y}, L.latLng(volcanoLat, volcanoLng));
@@ -247,7 +234,9 @@ export class MapComponent extends BaseComponent<IProps, IState>{
 
   private onRecenterClick = () => {
     if (this.map.current) {
-      const {volcanoLat, volcanoLng, initialZoom} = this.props;
+      const { volcanoLat, volcanoLng, scenario } = this.stores.simulation;
+      const scenarioData = (Scenarios as {[key: string]: {[key: string]: number}})[scenario];
+      const { initialZoom } = scenarioData;
 
       this.map.current.leafletElement.flyTo(L.latLng(volcanoLat, volcanoLng), initialZoom);
     }

--- a/src/components/map-sidebar-component.tsx
+++ b/src/components/map-sidebar-component.tsx
@@ -29,12 +29,6 @@ interface IState {}
 interface IProps extends IBaseProps {
   width: number;
   height: number;
-  windSpeed: number;
-  windDirection: number;
-  colHeight: number;
-  vei: number;
-  mass: number;
-  particleSize: number;
 }
 interface ISidebarMetrics {
   width: number;
@@ -66,7 +60,7 @@ export class MapSidebarComponent extends BaseComponent <IProps, IState> {
             vei,
             mass,
             particleSize
-        } = this.props;
+        } = this.stores.simulation;
         const {width, height} = this.metrics;
 
         return (

--- a/src/components/overlay-controls.tsx
+++ b/src/components/overlay-controls.tsx
@@ -26,7 +26,7 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
             showCrossSection,
             onCrossSectionClick,
             onReCenterClick} = this.props;
-        const { hasErupted } = this.stores;
+        const { hasErupted } = this.stores.simulation;
 
         const rulerColor = showRuler ? "primary" : "secondary";
         const selectingColor = isSelectingCrossSection ? "primary" : "secondary";

--- a/src/components/ruler-draw-layer.tsx
+++ b/src/components/ruler-draw-layer.tsx
@@ -33,7 +33,7 @@ export class RulerDrawLayer extends BaseComponent<IProps, IState> {
     this.drawEnd = this.drawEnd.bind(this);
     this.setPoint = this.setPoint.bind(this);
 
-    const { volcanoLat, volcanoLng } = this.stores;
+    const { volcanoLat, volcanoLng } = this.stores.simulation;
 
     const initialState: IState = {
         pointLat: volcanoLat,
@@ -94,7 +94,7 @@ export class RulerDrawLayer extends BaseComponent<IProps, IState> {
   public render() {
     const { map } = this.props;
     const { pointLat, pointLng, hasDrawn } = this.state;
-    const { volcanoLat, volcanoLng } = this.stores;
+    const { volcanoLat, volcanoLng } = this.stores.simulation;
     const point1 = L.latLng(volcanoLat, volcanoLng);
     const point2 = L.latLng(pointLat, pointLng);
     const point3 = L.latLng(volcanoLat, pointLng);

--- a/src/components/widget-panel.tsx
+++ b/src/components/widget-panel.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
-import { PureComponent } from "react";
 import WindSpeedDirectionWidget from "./wind-speed-direction-widget";
 import ColumnHeightWidget from "./column-height-widget";
 import VEIWidget from "./vei-widget";
 import EjectedVolumeWidget from "./ejected-volume-widget";
 import { WidgetPanelTypes } from "../utilities/widget";
 import styled from "styled-components";
+import { inject, observer } from "mobx-react";
+import { BaseComponent } from "./base";
 
 const WidgetBar = styled.div`
   display: flex;
@@ -31,22 +32,13 @@ const WidgetTitle = styled.div`
   margin-bottom: 5px;
 `;
 
-interface IProps {
-  showWindSpeed: boolean;
-  showWindDirection: boolean;
-  showColumnHeight: boolean;
-  showEjectedVolume: boolean;
-  showVEI: boolean;
-  windSpeed: number;
-  windDirection: number;
-  columnHeight: number; // m for vei, km for col height
-  vei: number;
-  mass: number;
-}
+interface IProps {}
 
 interface IState {}
 
-export default class WidgetPanel extends PureComponent<IProps, IState> {
+@inject("stores")
+@observer
+export default class WidgetPanel extends BaseComponent<IProps, IState> {
   public static defaultProps = {
     showWindSpeed: true,
     showWindDirection: true,
@@ -61,8 +53,8 @@ export default class WidgetPanel extends PureComponent<IProps, IState> {
   };
 
   public render() {
-    const { showVEI, showEjectedVolume, showColumnHeight, showWindSpeed, showWindDirection,
-            vei, mass, columnHeight, windDirection, windSpeed } = this.props;
+    const { showVEI, showEjectedVolume, showColumnHeight, showWindSpeed, showWindDirection } = this.stores.uiStore;
+    const { vei, mass, colHeight, windDirection, windSpeed } = this.stores.simulation;
     return (
       <WidgetBar>
         { (showWindSpeed || showWindDirection) && <WidgetContainer>
@@ -81,7 +73,7 @@ export default class WidgetPanel extends PureComponent<IProps, IState> {
             type={WidgetPanelTypes.RIGHT}
             vei={vei}
             mass={mass}
-            columnHeight={columnHeight}
+            columnHeight={colHeight}
           />
         </WidgetContainer> }
         { showEjectedVolume && <WidgetContainer>
@@ -95,7 +87,7 @@ export default class WidgetPanel extends PureComponent<IProps, IState> {
           <WidgetTitle>Column Height</WidgetTitle>
             <ColumnHeightWidget
               type={WidgetPanelTypes.RIGHT}
-              columnHeightInKilometers={columnHeight / 1000}
+              columnHeightInKilometers={colHeight / 1000}
             />
         </WidgetContainer> }
       </WidgetBar>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,11 +5,11 @@ import * as ReactDOM from "react-dom";
 import * as iframePhone from "iframe-phone";
 
 import { AppComponent } from "./components/app";
-import { simulation } from "./stores/simulation-store";
 import { onSnapshot } from "mobx-state-tree";
+import { stores } from "./stores/stores";
 
 ReactDOM.render(
-  <Provider stores={simulation}>
+  <Provider stores={stores}>
     <AppComponent />
   </Provider>,
   document.getElementById("reactApp")
@@ -28,7 +28,7 @@ type Mode = "student" | "author";
  */
 const loadStateData = (state: SerializedStateDataType) => {
   if (state.blocklyXmlCode) {
-    simulation.setInitialXmlCode(state.blocklyXmlCode);
+    stores.simulation.setInitialXmlCode(state.blocklyXmlCode);
   }
 };
 
@@ -48,6 +48,7 @@ phone.addListener("initInteractive", (data: {
 
   if (data.mode === "authoring") {
     mode = "author";
+    stores.uiStore.setShowOptionsDialog(false);
     loadStateData(authorState);
   } else {
     // student state overwrites authored state
@@ -59,12 +60,13 @@ phone.addListener("initInteractive", (data: {
 // Save data everytime stores change
 const saveUserData = () => {
   if (mode === "student") {
-    phone.post("interactiveState", simulation.userSnapshot);
+    phone.post("interactiveState", stores.simulation.userSnapshot);
   } else {
-    phone.post("authoredState", simulation.userSnapshot);
+    phone.post("authoredState", stores.simulation.userSnapshot);
   }
 };
-onSnapshot(simulation, saveUserData);       // MobX function called on every store change
+onSnapshot(stores.simulation, saveUserData);       // MobX function called on every store change
+onSnapshot(stores.uiStore, saveUserData);
 
 // When we exit page and LARA asks for student data, tell it it's already up-to-date
 phone.addListener("getInteractiveState", () => {

--- a/src/stores/simulation-store.ts
+++ b/src/stores/simulation-store.ts
@@ -1,7 +1,5 @@
 import { types, getSnapshot } from "mobx-state-tree";
 import { IInterpreterController, makeInterpreterController } from "../utilities/interpreter";
-// import { SimulationAuthoringOptions } from "../components/app";
-import { SerializedStateDataType } from "..";
 import { kVEIIndexInfo } from "../utilities/vei";
 import { SimulationAuthorSettings, SimulationAuthorSettingsProps } from "./stores";
 
@@ -450,13 +448,6 @@ export const SimulationStore = types
       get cityHash() {
         return self.cities.reduce( (pre, cur) => `${pre}-${cur.name}${cur.x}${cur.y}`, "");
       },
-      // returns values we need to save to LARA
-      get userSnapshot(): SerializedStateDataType {
-        return {
-          version: 1,
-          blocklyXmlCode: self.xmlCode
-        };
-      }
     };
   });
 export const simulation = SimulationStore.create({});

--- a/src/stores/simulation-store.ts
+++ b/src/stores/simulation-store.ts
@@ -1,6 +1,6 @@
 import { types, getSnapshot } from "mobx-state-tree";
 import { IInterpreterController, makeInterpreterController } from "../utilities/interpreter";
-import { SimulationAuthoringOptions } from "../components/app";
+// import { SimulationAuthoringOptions } from "../components/app";
 import { SerializedStateDataType } from "..";
 import { kVEIIndexInfo } from "../utilities/vei";
 
@@ -91,21 +91,21 @@ export const SimulationStore = types
   .model("simulation", {
     windSpeed: 6,
     windDirection: 0,    // from north
-    mass: 20000000,
-    vei: 0,
-    colHeight: 2000,      // meters
+    mass: 10000000000000,
+    vei: 1,
+    colHeight: 20000,      // meters
     particleSize: 1,
     stagingWindSpeed: 6,
     stagingWindDirection: 0,
-    stagingMass: 20000000,
-    stagingVei: 0,
-    stagingColHeight: 2000,
+    stagingMass: 10000000000000,
+    stagingVei: 1,
+    stagingColHeight: 20000,
     stagingParticleSize: 1,
     coloredWindSpeed: 6,
     coloredWindDirection: 0,
-    coloredMass: 20000000,
-    coloredVei: 0,
-    coloredColHeight: 2000,
+    coloredMass: 10000000000000,
+    coloredVei: 1,
+    coloredColHeight: 20000,
     coloredParticleSize: 1,
     volcanoLat: 0,
     volcanoLng: 0,
@@ -129,6 +129,9 @@ export const SimulationStore = types
     // authoring props
     requireEruption: true,
     requirePainting: true,
+    scenario: "Cerro Negro",
+    toolbox: "Everything",
+    initialCodeTitle: "Basic",
   })
   .volatile(self => ({
     running: false,
@@ -427,17 +430,6 @@ export const SimulationStore = types
           };
           return (out);
         }
-      },
-      setAuthoringOptions(opts: SimulationAuthoringOptions, changeDefaultParameters: boolean) {
-        if (changeDefaultParameters) {
-          self.stagingWindSpeed = opts.initialWindSpeed;
-          self.stagingWindDirection = opts.initialWindDirection;
-          self.stagingMass = opts.initialEruptionMass;
-          self.stagingColHeight = opts.initialColumnHeight;
-          self.stagingParticleSize = opts.initialParticleSize;
-        }
-        self.requireEruption = opts.requireEruption;
-        self.requirePainting = opts.requirePainting;
       }
     };
   })

--- a/src/stores/simulation-store.ts
+++ b/src/stores/simulation-store.ts
@@ -3,6 +3,7 @@ import { IInterpreterController, makeInterpreterController } from "../utilities/
 // import { SimulationAuthoringOptions } from "../components/app";
 import { SerializedStateDataType } from "..";
 import { kVEIIndexInfo } from "../utilities/vei";
+import { SimulationAuthorSettings, SimulationAuthorSettingsProps } from "./stores";
 
 let _cityCounter = 0;
 const genCityId = () => `city_${_cityCounter++}`;
@@ -431,6 +432,17 @@ export const SimulationStore = types
           return (out);
         }
       }
+    };
+  })
+  .actions((self) => {
+    return {
+      loadAuthorSettingsData: (data: SimulationAuthorSettings) => {
+        Object.keys(data).forEach((key: SimulationAuthorSettingsProps) => {
+          // annoying `as any ... as any` is needed because we're mixing bool and non-bool props, which combine to never
+          // see https://github.com/microsoft/TypeScript/issues/31663
+          (self[key] as any) = data[key] as any;
+        });
+      },
     };
   })
   .views((self) => {

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -7,7 +7,67 @@ export interface IStore {
   uiStore: UIModelType;
 }
 
+export interface IStoreish {simulation: any; uiStore: any; }
+
 export const stores = {
   simulation,
   uiStore
 };
+
+// this tuple syntx allows us to declare an array of strings and a type based on
+// that array at the same time.
+const tuple = <T extends string[]>(...args: T) => args;
+
+const simulationAuthorSettingsProps = tuple(
+  "requireEruption",
+  "requirePainting",
+  "scenario",
+  "toolbox",
+  "initialCodeTitle",
+);
+
+const uiAuthorSettingsProps = tuple(
+  "showBlocks",
+  "showCode",
+  "showControls",
+  "showWindSpeed",
+  "showWindDirection",
+  "showEjectedVolume",
+  "showColumnHeight",
+  "showVEI",
+  "showChart",
+  "showSidebar",
+  "showCrossSection",
+  "showLog",
+);
+
+export type SimulationAuthorSettingsProps = typeof simulationAuthorSettingsProps[number];
+export type UIAuthorSettingsProps = typeof uiAuthorSettingsProps[number];
+
+export type SimulationAuthorSettings = {
+  [key in SimulationAuthorSettingsProps]?: any;
+};
+export type UIAuthorSettings = {
+  [key in UIAuthorSettingsProps]?: any;
+};
+
+// picks props into a new object given an array of keys
+const pick = (keys: string[]) => (o: any) => keys.reduce((a, e) => ({ ...a, [e]: o[e] }), {});
+
+// gets the current stores state in a version appropriate for the authoring menu
+export function getAuthorableSettings(): IStoreish {
+  const authoredSimulation = pick(simulationAuthorSettingsProps)(simulation);
+  const authoredUi = pick(uiAuthorSettingsProps)(uiStore);
+  return {
+    simulation: authoredSimulation,
+    uiStore: authoredUi
+  };
+}
+
+export function updateStores(state: IStoreish) {
+  const simulationStoreSettings: SimulationAuthorSettings = pick(simulationAuthorSettingsProps)(state.simulation);
+  const uiStoreSettings: UIAuthorSettings = pick(uiAuthorSettingsProps)(state.uiStore);
+
+  simulation.loadAuthorSettingsData(simulationStoreSettings);
+  uiStore.loadAuthorSettingsData(uiStoreSettings);
+}

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -1,0 +1,13 @@
+
+import { simulation, SimulationModelType } from "./simulation-store";
+import { uiStore, UIModelType } from "./ui-store";
+
+export interface IStore {
+  simulation: SimulationModelType;
+  uiStore: UIModelType;
+}
+
+export const stores = {
+  simulation,
+  uiStore
+};

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -83,11 +83,18 @@ export const getAuthorableSettings = getStoreSubstate(simulationAuthorSettingsPr
 // gets the current store state to be saved by an author or student
 export const getSavableState = getStoreSubstate(simulationAuthorStateProps, uiAuthorSettingsProps);
 
-// makes state appropriate for saving to e.g. LARA. Adds a version number
+// makes state appropriate for saving to e.g. LARA. Changes keys or values as needed. Adds a version number
 export const serializeState = (state: any): SerializedState => {
+  const serializedState = {...state};
+
+  // we copy simulation.xmlCode (the current blockly code) to simulation.initialXmlCode (how we want
+  // to initialize blockly) when we save state
+  serializedState.simulation.initialXmlCode = serializedState.simulation.xmlCode;
+  delete serializedState.simulation.xmlCode;
+
   return {
     version: 1,
-    state
+    state: serializedState
   };
 };
 // deserializes saved state, migrating data if necessary

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -1,0 +1,14 @@
+import { types } from "mobx-state-tree";
+
+const UIStore = types.model("UI", {
+  showOptionsDialog: true
+})
+.actions((self) => ({
+  setShowOptionsDialog(show: boolean) {
+    self.showOptionsDialog = show;
+  }
+}));
+
+export type UIModelType = typeof UIStore.Type;
+
+export const uiStore = UIStore.create({});

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -1,4 +1,5 @@
 import { types } from "mobx-state-tree";
+import { UIAuthorSettings, UIAuthorSettingsProps } from "./stores";
 
 const UIStore = types.model("UI", {
   showOptionsDialog: true,
@@ -23,7 +24,16 @@ const UIStore = types.model("UI", {
   setShowOptionsDialog(show: boolean) {
     self.showOptionsDialog = show;
   }
-}));
+}))
+.actions((self) => {
+  return {
+    loadAuthorSettingsData: (data: UIAuthorSettings) => {
+      Object.keys(data).forEach((key: UIAuthorSettingsProps) => {
+        self[key] = data[key];
+      });
+    },
+  };
+});
 
 export type UIModelType = typeof UIStore.Type;
 

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -1,7 +1,23 @@
 import { types } from "mobx-state-tree";
 
 const UIStore = types.model("UI", {
-  showOptionsDialog: true
+  showOptionsDialog: true,
+  // tabs
+  showBlocks: true,
+  showCode: true,
+  showControls: true,
+  // other ui
+  showLog: false,
+  showCrossSection: false,
+  showChart: false,
+  showSidebar: false,
+  // slider controls
+  showWindSpeed: true,
+  showWindDirection: true,
+  showEjectedVolume: true,
+  showColumnHeight: true,
+  showParticleSize: true,
+  showVEI: true,
 })
 .actions((self) => ({
   setShowOptionsDialog(show: boolean) {


### PR DESCRIPTION
This PR makes it possible for authors and users to save the app state.

This first ensures that all the app state is maintained in MST stores, and adds a new UI store for this purpose. It removes the local authoring state maintained by app.tsx, and makes the authoring widget interact directly with the stores. It then allows for serializing and deserializing the stores to a backend, specifically LARA.

To help with this, the components were also all cleaned up to rely on the stores that were already being passed to them, to reduce the amount of props that needed to be unnecessarily passed down.

As an author, you can use the pulldown menu to set state; set up the initial code how you want; and set the sliders to a value. As a student all the exact same data will be saved, but since they don't have access to the authoring menu they won't be able to make those changes, so in practice their code and slider values will be saved.

An example of an authored model can be seen here:

https://authoring.concord.org/activities/10028/pages/127921/

To test this out more deeply, you can create a new activity in authoring.concord.org and add this branch as the interactive.