### PR TITLE
Fix code-saving

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -23,7 +23,7 @@ import WidgetPanel from "./widget-panel";
 import screenfull from "screenfull";
 import ResizeObserver from "react-resize-observer";
 import AuthoringMenu from "./authoring-menu";
-import { getAuthorableSettings, updateStores } from "../stores/stores";
+import { getAuthorableSettings, updateStores, serializeState, getSavableState, deserializeState, SerializedState } from "../stores/stores";
 
 interface IProps extends IBaseProps {}
 
@@ -437,8 +437,8 @@ export class AppComponent extends BaseComponent<IProps, IState> {
               options={getAuthorableSettings()}
               expandOptionsDialog={expandOptionsDialog}
               toggleShowOptions={this.toggleShowOptions}
-              saveCodeToLocalStorage={this.saveCodeToLocalStorage}
-              loadCodeFromLocalStorage={this.loadCodeFromLocalStorage}
+              saveStateToLocalStorage={this.saveStateToLocalStorage}
+              loadStateFromLocalStorage={this.loadStateFromLocalStorage}
               handleUpdate={updateStores}
             />
           }
@@ -490,20 +490,15 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     this.setState({rightTabIndex});
   }
 
-  private saveCodeToLocalStorage = () => {
-    localStorage.setItem("blockly-workspace", this.stores.simulation.xmlCode);
+  private saveStateToLocalStorage = () => {
+    localStorage.setItem("geocode-state", JSON.stringify(serializeState(getSavableState())));
   }
 
-  private loadCodeFromLocalStorage = () => {
-    const { simulation } = this.stores;
-    const code = localStorage.getItem("blockly-workspace");
-    if (code) {
-      // we need to unset and then set the state to force a re-render, if the user has already
-      // loaded the code once.
-      // because of the way Blockly injects to the DOM, we have to wait 100ms, instead of using
-      // the setState callback, or we may end up with two Blockly editors
-      simulation.setInitialXmlCode("<xml></xml>");
-      setTimeout(() => {simulation.setInitialXmlCode(code); }, 100);
+  private loadStateFromLocalStorage = () => {
+    const savedStateJSON = localStorage.getItem("geocode-state");
+    if (savedStateJSON) {
+      const savedState = JSON.parse(savedStateJSON) as SerializedState;
+      updateStores(deserializeState(savedState));
     }
   }
 

--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -9,8 +9,8 @@ interface IProps {
   options: IStoreish;
   expandOptionsDialog: boolean;
   toggleShowOptions: () => void;
-  saveCodeToLocalStorage: () => void;
-  loadCodeFromLocalStorage: () => void;
+  saveStateToLocalStorage: () => void;
+  loadStateFromLocalStorage: () => void;
   handleUpdate: (state: IStoreish) => void;
 }
 
@@ -51,11 +51,11 @@ const AuthoringMenu: React.SFC<IProps> = (props) => {
 
           <DatBoolean path="uiStore.showLog" label="Show Log?" key="showLog" />,
 
-          <DatButton label="Save current code to local storage"
-            onClick={props.saveCodeToLocalStorage}
+          <DatButton label="Save current state to local storage"
+            onClick={props.saveStateToLocalStorage}
             key="generate" />,
-          <DatButton label="Load code from local storage"
-            onClick={props.loadCodeFromLocalStorage}
+          <DatButton label="Load state from local storage"
+            onClick={props.loadStateFromLocalStorage}
             key="generate" />,
         ]
       }

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -31,6 +31,7 @@ const simulationAuthorSettingsProps = tuple(
 // additional props directly from current model that author will save
 const simulationAuthorStateProps = (simulationAuthorSettingsProps as string[]).concat(tuple(
   "xmlCode",
+  "initialXmlCode",
   "stagingWindSpeed",
   "stagingWindDirection",
   "stagingMass",


### PR DESCRIPTION
I thought I had fixed the saving code issue when I pulled in my last PR, but I hadn't. This now fixes it.

In order to make save-state testing easier, this updates the save/load to load storage button in the authoring menu to save the entire state. Now hitting those buttons does the same thing that LARA does.