### PR TITLE
Fix z-order of model options so it doesn't conflict with map content

### DIFF
--- a/src/public/css/react-dat-gui.css
+++ b/src/public/css/react-dat-gui.css
@@ -9,7 +9,8 @@
   box-sizing: border-box;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  -webkit-tap-highlight-color: transparent; }
+  -webkit-tap-highlight-color: transparent;
+  z-index: 4; }
   .react-dat-gui *, .react-dat-gui *:before, .react-dat-gui *:after {
     box-sizing: inherit; }
   .react-dat-gui .dg {


### PR DESCRIPTION
Adjust the z-index of the model options so that it does not conflict and overlap with map content.