### PR TITLE
Update button states and styling

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -331,6 +331,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                   <MapComponent
                     width={ mapWidth }
                     height={ height - 190 }
+                    panelType={RightSectionTypes.CONDITIONS}
                   />
                   <WidgetPanel />
                 </Simulation>
@@ -346,6 +347,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                   <MapComponent
                     width={ mapWidth }
                     height={ height - 190 }
+                    panelType={RightSectionTypes.CROSS_SECTION}
                   />
                   <CrossSectionComponent
                     width={ mapWidth }

--- a/src/components/icon-button.tsx
+++ b/src/components/icon-button.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import { Icon } from "./icon";
 
 interface IconButtonContainerProps {
+  backgroundColor?: string;
   hoverColor: string;
   activeColor: string;
 }
@@ -12,17 +13,18 @@ const IconButtonContainer = styled.div`
   justify-content: center;
   align-items: center;
   box-sizing: border-box;
-  width: 83px;
+  min-width: 83px;
   height: 34px;
   border-radius: 5px;
-  background-color: white;
+  background-color: ${(p: IconButtonContainerProps) => p.backgroundColor || "white"};
   border: solid 2px white;
   margin: 0 4px 0 4px;
+  padding: 4px;
   &:hover {
-    background-color: ${(p: IconButtonContainerProps) => `${p.hoverColor}`};
+    background-color: ${(p: IconButtonContainerProps) => p.hoverColor};
   }
   &:active {
-    background-color: ${(p: IconButtonContainerProps) => `${p.activeColor}`};
+    background-color: ${(p: IconButtonContainerProps) => p.activeColor};
   }
 `;
 
@@ -37,6 +39,7 @@ interface IProps {
   onClick: any;
   disabled: any;
   label: string;
+  backgroundColor?: string;
   hoverColor: string;
   activeColor: string;
   fill: string;
@@ -51,6 +54,7 @@ export default class IconButton extends PureComponent<IProps, IState> {
     onClick: undefined,
     disabled: undefined,
     label: undefined,
+    backgroundColor: undefined,
     hoverColor: undefined,
     activeColor: undefined,
     fill: undefined,
@@ -59,9 +63,15 @@ export default class IconButton extends PureComponent<IProps, IState> {
   };
 
   public render() {
-    const { onClick, disabled, children, label, hoverColor, activeColor, fill, width, height } = this.props;
+    const { onClick, disabled, children, label, backgroundColor, hoverColor, activeColor,
+            fill, width, height } = this.props;
     return (
-      <IconButtonContainer onClick={onClick} hoverColor={hoverColor} activeColor={activeColor}>
+      <IconButtonContainer
+        onClick={onClick}
+        backgroundColor={backgroundColor}
+        hoverColor={hoverColor}
+        activeColor={activeColor}
+      >
         { children && <Icon
             width={width}
             height={height}

--- a/src/components/map-component.tsx
+++ b/src/components/map-component.tsx
@@ -16,7 +16,7 @@ import { LocalToLatLng } from "../utilities/coordinateSpaceConversion";
 import { MapTephraThicknessLayer } from "./map-tephra-thickness-layer";
 import { OverlayControls } from "./overlay-controls";
 import { RulerDrawLayer } from "./ruler-draw-layer";
-
+import { RightSectionTypes } from "./tabs";
 import KeyButton from "./map-key-button";
 import CompassComponent from "./map-compass";
 import ScaleComponent from "./map-scale";
@@ -45,6 +45,7 @@ interface IState {
 interface IProps extends IBaseProps {
   width: number;
   height: number;
+  panelType: RightSectionTypes;
 }
 
 @inject("stores")
@@ -91,7 +92,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
   }
 
   public render() {
-    const { width, height } = this.props;
+    const { width, height, panelType } = this.props;
 
     const {
       cities,
@@ -154,7 +155,6 @@ export class MapComponent extends BaseComponent<IProps, IState>{
       mapRef = this.map.current.leafletElement;
       viewportBounds = this.map.current.leafletElement.getBounds();
     }
-
     return (
       <CanvDiv
         ref={this.ref}
@@ -231,7 +231,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
           showRuler={isSelectingRuler}
           onRulerClick={this.stores.simulation.rulerClick}
           isSelectingCrossSection={isSelectingCrossSection}
-          showCrossSection={hasErupted && showCrossSection}
+          showCrossSection={hasErupted && showCrossSection && panelType === RightSectionTypes.CROSS_SECTION}
           onCrossSectionClick={this.stores.simulation.crossSectionClick}
           onReCenterClick={this.onRecenterClick}
         />

--- a/src/components/overlay-controls.tsx
+++ b/src/components/overlay-controls.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
-import Button from "./overlay-button";
 import IconButton from "./icon-button";
+import { RightSectionTypes, kRightTabInfo } from "./tabs";
 
 import "../css/overlay-controls.css";
 import { observer, inject } from "mobx-react";
@@ -29,8 +29,10 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
             onReCenterClick} = this.props;
         const { hasErupted } = this.stores.simulation;
 
-        const rulerColor = showRuler ? "primary" : "secondary";
-        const selectingColor = isSelectingCrossSection ? "primary" : "secondary";
+        const rulerColor = showRuler ? kRightTabInfo[RightSectionTypes.CONDITIONS].hoverBackgroundColor : "white";
+        const selectingColor = isSelectingCrossSection
+                               ? kRightTabInfo[RightSectionTypes.CROSS_SECTION].hoverBackgroundColor
+                               : "white";
 
         return (
             <div className="overlay-controls">
@@ -39,8 +41,8 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
                         onClick={onReCenterClick}
                         disabled={false}
                         label={"Re-center"}
-                        hoverColor={"#ADD1A2"}
-                        activeColor={"#B7DCAD"}
+                        hoverColor={kRightTabInfo[RightSectionTypes.CONDITIONS].hoverBackgroundColor}
+                        activeColor={kRightTabInfo[RightSectionTypes.CONDITIONS].backgroundColor}
                         fill={"black"}
                         width={26}
                         height={26}
@@ -49,19 +51,26 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
                         onClick={onRulerClick}
                         disabled={false}
                         label={"Ruler"}
-                        hoverColor={"#ADD1A2"}
-                        activeColor={"#B7DCAD"}
+                        backgroundColor={rulerColor}
+                        hoverColor={kRightTabInfo[RightSectionTypes.CONDITIONS].hoverBackgroundColor}
+                        activeColor={kRightTabInfo[RightSectionTypes.CONDITIONS].backgroundColor}
                         fill={"black"}
                         width={26}
                         height={26}
                     />
                 </div>
                 <div className="controls bottom right">
-                    {(showCrossSection && hasErupted) && <Button
+                    {(showCrossSection && hasErupted) && <IconButton
                         onClick={onCrossSectionClick}
-                        color={selectingColor}>
-                        Draw a cross section line
-                    </Button>}
+                        disabled={false}
+                        label={"Draw a cross section line"}
+                        backgroundColor={selectingColor}
+                        hoverColor={kRightTabInfo[RightSectionTypes.CROSS_SECTION].hoverBackgroundColor}
+                        activeColor={kRightTabInfo[RightSectionTypes.CROSS_SECTION].backgroundColor}
+                        fill={"black"}
+                        width={26}
+                        height={26}
+                    />}
                 </div>
             </div>
         );


### PR DESCRIPTION
Small fixes to the button states and styling on the map:
 - only show cross section button if we are on the cross section tab
 - style cross section button to match cross section tab
 - have ruler and cross section buttons have an "activated" (AKA "on") color state for when the user is in the process of using the button feature (measuring with ruler or drawing cross section line)