### PR TITLE
Remove forceRender from Block TabPanel component

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -271,7 +271,6 @@ export class AppComponent extends BaseComponent<IProps, IState> {
             { showBlocks &&
               <TabPanel
                 width={`${tabWidth}px`}
-                forceRender={true}
                 tabcolor={this.getTabColor(SectionTypes.BLOCKS)}
               >
                 <TabContent>


### PR DESCRIPTION
This one line change eliminates a bug that was causing the contents of the blocks tab to not be displayed.  To reproduce the original bug, go to master and do the following:
 - open cross-section or code tab
 - resize browser
 - open blocks tabs (content does not display)
This fix allows the blocks tab to render properly, but the user will sometimes see a slight delay as the content is rendered (on my system the delay is about .5 seconds although it does not happen every time).  Do we think this is acceptable?  Please compare this version to master (http://geocode-app.concord.org/branch/master/index.html) and let me know what folks think.