### PR TITLE
[#169399156] Move Leaflet Scale to Top Left Corner

### DIFF
--- a/src/components/map-component.tsx
+++ b/src/components/map-component.tsx
@@ -181,7 +181,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
           easeLinearity={0.35}
           >
           <ScaleControl
-            position="topright"
+            position="topleft"
           />
           <Pane
             style={{zIndex: 0}}>


### PR DESCRIPTION
This moves it from being directly underneath the map key to resting below the map zoom controls.