### PR TITLE
Fix widgets so that they respect min and max values

### DIFF
--- a/src/components/column-height-widget.tsx
+++ b/src/components/column-height-widget.tsx
@@ -52,12 +52,14 @@ export default class ColumnHeightWidget extends PureComponent<IProps, IState> {
   };
 
   public render() {
+    const minColumnHeight = .1;
     const maxColumnHeight = 25;
     const maxGuageHeight = 48;
     const maxCoverHeight = 50;
     const { columnHeightInKilometers, type } = this.props;
-    const guageHeight = maxGuageHeight * (columnHeightInKilometers) / maxColumnHeight;
-    const coverHeight = maxCoverHeight - (maxCoverHeight * columnHeightInKilometers / maxColumnHeight);
+    const constrainedColumnHeight = Math.min(Math.max(columnHeightInKilometers, minColumnHeight), maxColumnHeight);
+    const guageHeight = maxGuageHeight * (constrainedColumnHeight) / maxColumnHeight;
+    const coverHeight = maxCoverHeight - (maxCoverHeight * constrainedColumnHeight / maxColumnHeight);
     return (
       <ValueContainer backgroundColor={kWidgetPanelInfo[type].backgroundColor}>
         <RelativeIconContainer>

--- a/src/components/ejected-volume-widget.tsx
+++ b/src/components/ejected-volume-widget.tsx
@@ -63,12 +63,17 @@ export default class EjectedVolumeWidget extends PureComponent<IProps, IState> {
 
   public render() {
     const { type, volumeInKilometersCubed } = this.props;
+    const minVolume = .0001;
+    const maxVolume = 1000;
+    const constrainedVolume = Math.min(Math.max(volumeInKilometersCubed, minVolume), maxVolume);
     const index = Math.round(Math.log(volumeInKilometersCubed) / Math.LN10);
+    const constrainedIndex = Math.round(Math.log(constrainedVolume) / Math.LN10);
     const maxBoxGrowth = 33;
     const minBoxHeight = 1;
     const indexOffset = 4;
     const maxIndex = 7;
-    const boxHeight = minBoxHeight + maxBoxGrowth * (Math.pow(2, index + indexOffset) / Math.pow(2, maxIndex));
+    const boxHeight = minBoxHeight + maxBoxGrowth
+                      * (Math.pow(2, constrainedIndex + indexOffset) / Math.pow(2, maxIndex));
     const topOffset = 25;
     return (
       <ValueContainer backgroundColor={kWidgetPanelInfo[type].backgroundColor}>

--- a/src/components/vei-widget.tsx
+++ b/src/components/vei-widget.tsx
@@ -83,7 +83,8 @@ export default class VEIWidget extends PureComponent<IProps, IState> {
   }
 
   private getVEIIcon = (vei: number, type: WidgetPanelTypes) => {
-    switch (vei) {
+    const constrainedVei = Math.min(Math.max(vei, 1), 8);
+    switch (constrainedVei) {
       case 1: return type === WidgetPanelTypes.LEFT ? <VEI1Orange/> : <VEI1Blue/>;
       case 2: return type === WidgetPanelTypes.LEFT ? <VEI2Orange/> : <VEI2Blue/>;
       case 3: return type === WidgetPanelTypes.LEFT ? <VEI3Orange/> : <VEI3Blue/>;

--- a/src/components/wind-speed-direction-widget.tsx
+++ b/src/components/wind-speed-direction-widget.tsx
@@ -87,11 +87,12 @@ export default class WindSpeedDirectionWidget extends PureComponent<IProps, ISta
   public render() {
     const { type, showWindSpeed, showWindDirection, windSpeed, windDirection } = this.props;
     const maxWindSpeed = 30;
+    const constrainedSpeed = Math.min(Math.max(windSpeed, 0), maxWindSpeed);
     const arrowPos = 6;
     const arrowTailPos = -28;
     const arrowHeadOffset = 5;
     const maxArrowLength = 10;
-    const arrowHeight = 1 + windSpeed / maxWindSpeed * maxArrowLength;
+    const arrowHeight = 1 + constrainedSpeed / maxWindSpeed * maxArrowLength;
     return (
       <ValueContainer backgroundColor={kWidgetPanelInfo[type].backgroundColor}>
         <RelativeIconContainer>


### PR DESCRIPTION
This PR updates the ejected volume, wind, VEI, and column height widgets so that they enforce min and max values for the visual, icon portion of the widget.  Using the blockly blocks, a user can specify eruption values that are outside of the expected range of values used within the widgets.  This PR allows the block specified value to be displayed in the text field within the widget, but also constrains the min and max values used when drawing the icon portion of the widget (prevents things like an ejected volume that is drawn outside the box or a wind speed arrow that is extremely long).  In the future we might want to enforce min and max values for the blockly block, but at least for now we can prevent the widgets from drawing bizarre or confusing representations of the widget values.