### PR TITLE
Minor fixes to right tab display

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -212,7 +212,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     kRightTabInfo.conditions.index = showConditions ? 0 : -1;
     kRightTabInfo.crossSection.index = showCrossSection ? kRightTabInfo.conditions.index + 1 : -1;
     kRightTabInfo.data.index = showData
-      ? (showCrossSection ? kRightTabInfo.conditions.index + 1 : kRightTabInfo.conditions.index + 1)
+      ? (showCrossSection ? kRightTabInfo.crossSection.index + 1 : kRightTabInfo.conditions.index + 1)
       : -1;
     const enabledRightTabTypes = [];
     if (showConditions)   { enabledRightTabTypes.push(RightSectionTypes.CONDITIONS); }

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -91,9 +91,9 @@ const RightTabBack = styled.div`
   height: 15px;
   background-color: ${(p: TabBackProps) => p.backgroundcolor};
   position: absolute;
-  width: ${(p: TabBackProps) => `${p.width - 33}px`};
-  bottom: 24px;
-  right: 33px;
+  width: ${(p: TabBackProps) => `${p.width - 27}px`};
+  bottom: 20px;
+  right: 27px;
 `;
 
 const Tabs = styled(UnstyledTabs)`


### PR DESCRIPTION
Minor fixes to the right tabs to improve tab display so they more closely match the UI spec:
- Data index was incorrectly computed - caused incorrect tab borders to be displayed
- Tab back was incorrectly placed