### PR TITLE
Restore force render

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -271,6 +271,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
             { showBlocks &&
               <TabPanel
                 width={`${tabWidth}px`}
+                forceRender={true}
                 tabcolor={this.getTabColor(SectionTypes.BLOCKS)}
               >
                 <TabContent>


### PR DESCRIPTION
Revert change to remove forceRender from Blocks tab.  Causes program changes in blockly to be erased when changing tabs.