### PR TITLE
Fix Chromebook & safari layout bug.

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -191,7 +191,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     const tabWidth = Math.floor(width * .5);
     const mapWidth = Math.floor(width * .5);
     const blocklyWidth = tabWidth - (blocklyMargin * 2);
-    const blocklyHeight = Math.floor(height * .7);
+    const blocklyHeight = Math.floor(height - 90);
     const logWidth = Math.floor(tabWidth * 0.95);
     const logHeight = Math.floor(height * .2);
     const scenarioData = (Scenarios as {[key: string]: {[key: string]: number}})[scenario];

--- a/src/components/blockly-container.tsx
+++ b/src/components/blockly-container.tsx
@@ -27,7 +27,7 @@ interface WorkspaceProps {
 const WorkSpace = styled.div`
   font-family: sans-serif;
   width: ${(p: WorkspaceProps) => `${p.width}px`};
-  height: 100%;
+  height: ${(p: WorkspaceProps) => `${p.height}px`};
 `;
 
 export default class BlocklyContainer extends React.Component<IProps, IState> {


### PR DESCRIPTION
Sam, you were right this was a CSS layout issue.  

Thanks for the pointer.

Setting the blockly container div height to 100% was not working in safari or on Chromebooks

[#170584783]

https://www.pivotaltracker.com/story/show/170584783