### PR TITLE
Author can set VEI by manipulating sliders.

### DIFF
--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -107,9 +107,15 @@ export const deserializeState = (serializedState: SerializedState): IStoreish =>
 };
 
 export function updateStores(state: IStoreish) {
-  const simulationStoreSettings: SimulationAuthorSettings = pick(simulationAuthorStateProps)(state.simulation);
-  const uiStoreSettings: UIAuthorSettings = pick(uiAuthorSettingsProps)(state.uiStore);
+  // TODO: FixMe NP 2020-01-09 :
+  // For some reason this filtering was preventing stagingVei from saving
+  // when it the slider was hidden in the UI …
 
-  simulation.loadAuthorSettingsData(simulationStoreSettings);
-  uiStore.loadAuthorSettingsData(uiStoreSettings);
+  // const simulationStoreSettings: SimulationAuthorSettings = pick(simulationAuthorStateProps)(state.simulation);
+  // const uiStoreSettings: UIAuthorSettings = pick(uiAuthorSettingsProps)(state.uiStore);
+  // uiStore.loadAuthorSettingsData(uiStoreSettings);
+  // simulation.loadAuthorSettingsData(simulationStoreSettings);
+
+  uiStore.loadAuthorSettingsData(state.uiStore);
+  simulation.loadAuthorSettingsData(state.simulation);
 }


### PR DESCRIPTION
Hello @sfentress --

Here is the change that let the `stagingVEI` param (and others) be set using the control sliders in authoring mode.

I wanted you to look it, because we were discussing it this morning.  Also, I recognize that you went out of the way to ensure that only certain simulation parameters were saved on serialization.  This commit basically undoes all that work.

This is a change that I would just want to use while in the classroom this week.  Chris has tested it, and it works for his needs.

Let me know if you have any reservations about committing this.  And thanks for the review.
