### PR TITLE
Improve VEI calculations

### DIFF
--- a/src/stores/simulation-store.test.ts
+++ b/src/stores/simulation-store.test.ts
@@ -1,0 +1,64 @@
+import { SimulationStore, SimulationModelType } from "./simulation-store";
+
+describe("simulation-store", () => {
+  let simulation: SimulationModelType;
+
+  beforeEach(() => {
+    simulation = SimulationStore.create({});
+  });
+
+  describe("vei", () => {
+    it("we can set vei and staging mass and column height will be set", () => {
+      simulation.setVEI(1);
+      expect(simulation.stagingMass).toBe(1e8);
+      expect(simulation.stagingColHeight).toBe(500);
+
+      simulation.setVEI(4);
+      expect(simulation.stagingMass).toBe(1e11);
+      expect(simulation.stagingColHeight).toBe(10000);
+
+      simulation.setVEI(8);
+      expect(simulation.stagingMass).toBe(1e15);
+      expect(simulation.stagingColHeight).toBe(25000);
+    });
+
+    it("we can set vei and we can read correct vei back", () => {
+      for (let vei = 1; vei < 9; vei++) {
+        simulation.setVEI(vei);
+        expect(simulation.stagingVei).toBe(vei);
+      }
+    });
+
+    it("we can set mass and height to reasonable values and read correct vei back", () => {
+      simulation.setMass(1e8);
+      simulation.setColumnHeight(0.5);
+      expect(simulation.stagingVei).toBe(1);
+
+      simulation.setMass(1e10);
+      simulation.setColumnHeight(5);
+      expect(simulation.stagingVei).toBe(3);
+
+      simulation.setMass(1e14);
+      simulation.setColumnHeight(25);
+      expect(simulation.stagingVei).toBe(7);
+    });
+
+    it("we can set mass and height to conflicting values and read a best-guess vei back", () => {
+      simulation.setMass(1e8);
+      simulation.setColumnHeight(5);
+      expect(simulation.stagingVei).toBe(2);
+
+      simulation.setMass(1e8);
+      simulation.setColumnHeight(25);
+      expect(simulation.stagingVei).toBe(4);
+
+      simulation.setMass(1e14);
+      simulation.setColumnHeight(0.5);
+      expect(simulation.stagingVei).toBe(4);
+
+      simulation.setMass(1e15);
+      simulation.setColumnHeight(0.5);
+      expect(simulation.stagingVei).toBe(5);
+    });
+  });
+});

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -35,7 +35,6 @@ const simulationAuthorStateProps = (simulationAuthorSettingsProps as string[]).c
   "stagingWindSpeed",
   "stagingWindDirection",
   "stagingMass",
-  "stagingVei",
   "stagingColHeight",
 ));
 


### PR DESCRIPTION
This makes VEI an entirely computed value, removing from concern whether it is saved when an author or user modifies the value.

This removes `vei` and `stagingVei` from the simulations-store's properties, and instead makes it a computed value given mass and column height.

When the user sets VEI, this will simply set the mass and column height.

If the user requests the VEI, we will make our best guess as to the VEI given the mass and column height. If those properties were set using `setVEI`, our "guess" will always be correct. If the user manually sets
mass and height to some non-possible combination, we will return a value in-between the values suggested by the two properties.

This also adds `stagingVei` based on the staging mass and height values, so that the VEI slider updates as the user updates the mass and height sliders.

@knowuh I believe that this may work better than #98, because it should remove any of the odd behavior we've seen with the VEI in the past (VEI widget not showing the right value), and allow us to keep our defined set of authored values, while still allowing an author to set VEI in the authoring view.

This should fix this bug: https://www.pivotaltracker.com/story/show/169983751

> I am currently trying to author different set ups in the curriculum. In one set-up, I only have the wind direction and wind speed sliders showing. I wish to set the VEI (eruption volume and height) to a specific value--but still hide the slider. Whenever i set the value of VEI and then hide the slider, it does not hold the value I set after I hit (save authored state.