### PR TITLE
Switch to ArcGIS map server for map image tiles

### DIFF
--- a/src/components/map-component.tsx
+++ b/src/components/map-component.tsx
@@ -201,7 +201,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
           <Pane
             style={{zIndex: 0}}>
             <TileLayer
-                url="https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}@2x.png"
+                url="https://services.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}"
             />
             <MapTephraThicknessLayer
               ref={this.tephraRef}


### PR DESCRIPTION
This switches from Wikimaps, which appears to be broken due to incorrect cookie handling and/or is rate-limiting us, to the ArcGIS World_Topo_Map tile service which appears to have no restrictive terms of service (https://www.arcgis.com/home/item.html?id=6cf03fb0a88f448b84ab7d3bb3ac79e6).

The new version can be tested here: http://geocode-app.concord.org/branch/fix-leaflet-tiles/index.html

Comparison images, since the old one is broken and so hard to compare:

Old Wikimaps:

<img width="877" alt="Screen Shot 2020-02-07 at 4 04 34 PM" src="https://user-images.githubusercontent.com/35721/74065820-bad20d80-49c3-11ea-9067-ccab1ab1058c.png">

New World_Topo_Map:

<img width="878" alt="Screen Shot 2020-02-07 at 4 05 05 PM" src="https://user-images.githubusercontent.com/35721/74065844-c6253900-49c3-11ea-826e-f56a5c79a931.png">
