### PR TITLE
Fix block inputs disappearing in fullscreen mode

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -469,11 +469,10 @@ export class AppComponent extends BaseComponent<IProps, IState> {
   }
 
   private toggleFullscreen = () => {
-    if (this.rootComponent.current) {
-      if (screenfull && screenfull.enabled) {
-        const component = this.rootComponent.current;
-        screenfull.toggle(component);
-      }
+    if (screenfull && screenfull.enabled) {
+      // we expand the entire body, instead of just the app, because blockly appends
+      // things like input dialogs to the end of the document body
+      screenfull.toggle(document.body);
     }
   }
 


### PR DESCRIPTION
The issue was that we expand the app's DOM element to fullscreen, but blocky appends its own input dialogs outside of the wrapper element, at the end of the document body. So those elements are not part of the fullscreen app.

Since the model takes up the entire body, there should be little difference expanding the app or the body. When we embed the model in an iframe, only the app's document is expanded.

The only issue would be if we ever directly inlined the app in something else, but this app is not designed for that.

This can be tested at https://authoring.concord.org/activities/10028/pages/131215/ (compare to broken versions on earlier pages).