### PR TITLE
Hide cross section tab

### DIFF
--- a/cypress/integration/branch/condition-panel.test.js
+++ b/cypress/integration/branch/condition-panel.test.js
@@ -29,18 +29,18 @@ context("Controls panel", () => {
     });
     describe('Verify control tab slider settings reflect in the conditions tab widget',()=>{
         it('verify wind speed widget',()=>{
-            conditionsTab.getWindSpeedDirectionWidget().find('[data-test=info]').should('contain',windSpeed +' m/s')   
+            conditionsTab.getWindSpeedDirectionWidget().find('[data-test=info]').should('contain',windSpeed +' m/s')
         })
         it('verify wind direction slider',()=>{
-            conditionsTab.getWindSpeedDirectionWidget().find('[data-test=info]').should('contain',windDirection)    
+            conditionsTab.getWindSpeedDirectionWidget().find('[data-test=info]').should('contain',windDirection)
             conditionsTab.getWindSymbol().parent().parent().should('have.attr','rotate',windDirection.toString())
         })
         it('verify eject volume widget',()=>{
-            conditionsTab.getEjectedVolumeWidget().find('[data-test=info]').should('contain',volume)    
+            conditionsTab.getEjectedVolumeWidget().find('[data-test=info]').should('contain',volume)
             conditionsTab.getEjectedVolumeHeightVisual().siblings('div').should('have.attr','height',evHeight, {multiple:true})
         })
         it('verify column height widget',()=>{
-            conditionsTab.getColumnHeightWidget().find('[data-test=info]').should('contain',cHeight)    
+            conditionsTab.getColumnHeightWidget().find('[data-test=info]').should('contain',cHeight)
             conditionsTab.getColumnHeightVisual().should('have.attr','height',visualHeight)
         })
     })
@@ -48,11 +48,11 @@ context("Controls panel", () => {
         it('verify tephra is visible',()=>{
             conditionsTab.getTephra().should('be.visible');
         })
-        it('verify switching to Cross Section tab shows tephra',()=>{
-            rightPanel.getCrossSectionTab().click();
+        it('verify switching to Monte Carol tab shows tephra',()=>{
+            rightPanel.getMonteCarloTab().click();
             conditionsTab.getTephra().should('be.visible');
         })
-        it('verify Reset in Control Panel removes tephra in Cross Section tab',()=>{
+        it('verify Reset in Control Panel removes tephra in Monte Carlo tab',()=>{
             controlsTab.getControlsPanel().find(controlsTab.getResetButtonEl()).click();
             conditionsTab.getTephra().should('not.exist');
         })
@@ -60,8 +60,8 @@ context("Controls panel", () => {
             rightPanel.getConditionsTab().click();
             conditionsTab.getTephra().should('not.exist');
         })
-        it('verify Erupt while in Cross Section tab shows tephra in Cross Section tab',()=>{
-            rightPanel.getCrossSectionTab().click();
+        it('verify Erupt while in Monte Carlo tab shows tephra in Monte Carlo tab',()=>{
+            rightPanel.getMonteCarloTab().click();
             controlsTab.getEruptButton().click();
             conditionsTab.getTephra().should('be.visible');
         })

--- a/cypress/integration/smoke/cross-section-tab-ui.test.js
+++ b/cypress/integration/smoke/cross-section-tab-ui.test.js
@@ -13,10 +13,10 @@ const controlsTab = new ControlsTab;
 context("Cross Section panel", () => {
     before(() => {
       cy.visit("");
-      rightPanel.getCrossSectionTab().should('be.visible').click();
+      // rightPanel.getCrossSectionTab().should('be.visible').click();
     });
-  
-    describe("Cross Section panel ui", () => {
+
+    describe.skip("Cross Section panel ui", () => {
         it('verify Cross Section tab shows correct elements',()=>{
             crossSectionTab.getCrossSectionPanel().should('be.visible');
             map.getRecenterButton().should('be.visible');

--- a/cypress/integration/smoke/workspace-ui.test.js
+++ b/cypress/integration/smoke/workspace-ui.test.js
@@ -27,8 +27,8 @@ context("Test app workspace", () => {
         leftPanel.getCodeTab().should('be.visible');
         leftPanel.getControlsTab().should('be.visible');
         rightPanel.getConditionsTab().should('be.visible');
-        rightPanel.getCrossSectionTab().should('be.visible');
+        rightPanel.getMonteCarloTab().should('be.visible');
         rightPanel.getDataTab().should('be.visible')
     });
-  });  
+  });
 })

--- a/cypress/support/elements/RightPanel.js
+++ b/cypress/support/elements/RightPanel.js
@@ -8,6 +8,9 @@ class RightPanel {
     getDataTab(){
         return cy.get('[data-test=Data-tab')
     }
+    getMonteCarloTab(){
+        return cy.get('[data-test=Monte-Carlo-tab')
+    }
 }
 
 export default RightPanel;

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -68,7 +68,7 @@ const kRightTabInfo: RightTabInfo = {
     hoverBackgroundColor: "#c3dabd",
   },
   monteCarlo: {
-    name: "Monte Carlo",
+    name: "Monte-Carlo",
     index: -1,
     backgroundColor: "#cee6c9",
     hoverBackgroundColor: "#c3dabd",

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -9,7 +9,7 @@ const UIStore = types.model("UI", {
   showControls: true,
   // right tabs
   showConditions: true,
-  showCrossSection: true,
+  showCrossSection: false,
   showMonteCarlo: true,
   showData: true,
   // other ui


### PR DESCRIPTION
This PR disables the cross-section tab by default.  For now, the code is still there to display the tab and it can be turned on in the authoring panel, but it is not shown if the app is loaded without any authoring settings.