### PR TITLE
170909174 monte carlo histogram

### DIFF
--- a/src/components/charts/canvas-d3-scatter-chart.tsx
+++ b/src/components/charts/canvas-d3-scatter-chart.tsx
@@ -114,7 +114,7 @@ export class CanvasD3ScatterChart extends React.Component<IProps> {
 
     const ctx = this.canvasRef.current.getContext("2d")!;
 
-    data.forEach(d => {
+    data.forEach((d: number[] | Date[]) => {
       ctx.beginPath();
       ctx.fillStyle = "#448878";
       const px = xScale(d[0]) + canvasPadding;

--- a/src/components/charts/svg-d3-histogram-chart.tsx
+++ b/src/components/charts/svg-d3-histogram-chart.tsx
@@ -2,22 +2,23 @@ import * as ReactFauxDOM from "react-faux-dom";
 import * as d3 from "d3";
 import { ChartType } from "../../stores/charts-store";
 
-type Scale = d3.ScaleLinear<number, number> | d3.ScaleTime<number, number>;
-
 interface IProps {
   chart: ChartType;
+  chartMin: number;
+  chartMax: number;
   width: number;
   height: number;
-  bars: boolean;
+  showBars: boolean;
 }
 
 export const SvgD3HistogramChart = (props: IProps) => {
-  const { width, height, chart, bars } = props;
+  const { width, height, chart, showBars, chartMin, chartMax } = props;
   const { data, xAxisLabel, yAxisLabel } = chart;
 
   const margin = {top: 15, right: 20, bottom: 35, left: 50};
   const chartWidth = width - margin.left - margin.right;
   const chartHeight = height - margin.top - margin.bottom;
+  const numBins = 40;
 
   const div = new ReactFauxDOM.Element("div");
 
@@ -28,10 +29,8 @@ export const SvgD3HistogramChart = (props: IProps) => {
     .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
   const xScale = d3.scaleLinear();
-  xScale.domain([0, 400]);
+  xScale.domain([chartMin, chartMax]);
   xScale.range([0, chartWidth]);
-  // xScale.rangeRound([0, chartWidth]).domain(chart.extent(0));
-  // xScale.nice();
 
   // add axes
   const axisBottom = d3.axisBottom(xScale);
@@ -42,9 +41,11 @@ export const SvgD3HistogramChart = (props: IProps) => {
   const xDomain: number[] = xScale.domain();
   const histogram = d3.histogram<number, number>()
     .domain([ xDomain[0], xDomain[1] ])
-    .thresholds(xScale.ticks(40));
+    .thresholds(xScale.ticks(numBins));
 
-  const binData: any[] = data.map(d => d[1]);
+  // histogram data is stored in 2D array where
+  // internal arrays contain single value
+  const binData: any[] = data.map(d => d[0]);
 
   // And apply this function to data to get the bins
   const bins = histogram(binData);
@@ -53,7 +54,6 @@ export const SvgD3HistogramChart = (props: IProps) => {
     max = Math.max(max, bin.length);
   });
   const yScale = d3.scaleLinear();
-  // yScale.rangeRound([chartHeight, 0]).domain(chart.extent(1));
   yScale.range([chartHeight, 0]);
   yScale.domain([0, max]);
 
@@ -79,8 +79,7 @@ export const SvgD3HistogramChart = (props: IProps) => {
       .style("fill", "#555")
       .text(yAxisLabel);
   }
-
-  if (bars) {
+  if (showBars) {
     bins.forEach((bin, binIndex) => {
       const binMap = bin.map((x, i) => i);
       svg.append("g")
@@ -88,9 +87,9 @@ export const SvgD3HistogramChart = (props: IProps) => {
         .data(binMap)
         .enter()
         .append("circle")
-          .attr("cx", d => (xScale(binIndex) * 10 + 5) )
-          .attr("cy", d => (yScale(d) - 3) )
-          .attr("r", 5)
+          .attr("cx", d => (xScale(binIndex) * 10 + (chartWidth / numBins * .45)) )
+          .attr("cy", d => (yScale(d) - 5) )
+          .attr("r", chartWidth / numBins * .45)
           .style("fill", "#448878");
     });
   } else {

--- a/src/components/charts/svg-d3-histogram-chart.tsx
+++ b/src/components/charts/svg-d3-histogram-chart.tsx
@@ -76,6 +76,7 @@ export const SvgD3HistogramChart = (props: IProps) => {
       .text(yAxisLabel);
   }
   if (!showBars) {
+    const dotRadius = Math.min(chartWidth / numBins * .45, chartHeight / max * .45);
     bins.forEach((bin, binIndex) => {
       const binMap = bin.map((x, i) => i);
       svg.append("g")
@@ -83,9 +84,9 @@ export const SvgD3HistogramChart = (props: IProps) => {
         .data(binMap)
         .enter()
         .append("circle")
-          .attr("cx", d => (xScale(binIndex) * 10 + (chartWidth / numBins * .45)) )
+          .attr("cx", d => (xScale(binIndex) * 10 + dotRadius) )
           .attr("cy", d => (yScale(d) - 5) )
-          .attr("r", chartWidth / numBins * .45)
+          .attr("r", dotRadius)
           .style("fill", "#448878");
     });
   } else {

--- a/src/components/charts/svg-d3-histogram-chart.tsx
+++ b/src/components/charts/svg-d3-histogram-chart.tsx
@@ -43,12 +43,8 @@ export const SvgD3HistogramChart = (props: IProps) => {
     .domain([ xDomain[0], xDomain[1] ])
     .thresholds(xScale.ticks(numBins));
 
-  // histogram data is stored in 2D array where
-  // internal arrays contain single value
-  const binData: any[] = data.map(d => d[0]);
-
   // And apply this function to data to get the bins
-  const bins = histogram(binData);
+  const bins = histogram(data as number[]);
   let max = 0;
   bins.forEach(bin => {
     max = Math.max(max, bin.length);
@@ -79,7 +75,7 @@ export const SvgD3HistogramChart = (props: IProps) => {
       .style("fill", "#555")
       .text(yAxisLabel);
   }
-  if (showBars) {
+  if (!showBars) {
     bins.forEach((bin, binIndex) => {
       const binMap = bin.map((x, i) => i);
       svg.append("g")

--- a/src/components/charts/svg-d3-histogram-chart.tsx
+++ b/src/components/charts/svg-d3-histogram-chart.tsx
@@ -1,0 +1,109 @@
+import * as ReactFauxDOM from "react-faux-dom";
+import * as d3 from "d3";
+import { ChartType } from "../../stores/charts-store";
+
+type Scale = d3.ScaleLinear<number, number> | d3.ScaleTime<number, number>;
+
+interface IProps {
+  chart: ChartType;
+  width: number;
+  height: number;
+  bars: boolean;
+}
+
+export const SvgD3HistogramChart = (props: IProps) => {
+  const { width, height, chart, bars } = props;
+  const { data, xAxisLabel, yAxisLabel } = chart;
+
+  const margin = {top: 15, right: 20, bottom: 35, left: 50};
+  const chartWidth = width - margin.left - margin.right;
+  const chartHeight = height - margin.top - margin.bottom;
+
+  const div = new ReactFauxDOM.Element("div");
+
+  const svg = d3.select(div).append("svg")
+    .attr("width", width)
+    .attr("height", height)
+    .append("g")
+    .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+  const xScale = d3.scaleLinear();
+  xScale.domain([0, 400]);
+  xScale.range([0, chartWidth]);
+  // xScale.rangeRound([0, chartWidth]).domain(chart.extent(0));
+  // xScale.nice();
+
+  // add axes
+  const axisBottom = d3.axisBottom(xScale);
+  svg.append("g")
+    .attr("transform", "translate(0," + chartHeight + ")")
+    .call(axisBottom);
+
+  const xDomain: number[] = xScale.domain();
+  const histogram = d3.histogram<number, number>()
+    .domain([ xDomain[0], xDomain[1] ])
+    .thresholds(xScale.ticks(40));
+
+  const binData: any[] = data.map(d => d[1]);
+
+  // And apply this function to data to get the bins
+  const bins = histogram(binData);
+  let max = 0;
+  bins.forEach(bin => {
+    max = Math.max(max, bin.length);
+  });
+  const yScale = d3.scaleLinear();
+  // yScale.rangeRound([chartHeight, 0]).domain(chart.extent(1));
+  yScale.range([chartHeight, 0]);
+  yScale.domain([0, max]);
+
+  const axisLeft = d3.axisLeft(yScale);
+  svg.append("g")
+    .call(axisLeft);
+
+  // Add labels
+  if (xAxisLabel) {
+    svg.append("text")
+      .attr("x", `${width / 3}`)
+      .attr("y", `${height - margin.top - 2}`)
+      .style("font-size", "0.9em")
+      .style("fill", "#555")
+      .text(xAxisLabel);
+  }
+  if (yAxisLabel) {
+    svg.append("text")
+      .attr("x", `-${2 * height / 3}`)
+      .attr("dy", "-30px")
+      .attr("transform", "rotate(-90)")
+      .style("font-size", "0.9em")
+      .style("fill", "#555")
+      .text(yAxisLabel);
+  }
+
+  if (bars) {
+    bins.forEach((bin, binIndex) => {
+      const binMap = bin.map((x, i) => i);
+      svg.append("g")
+        .selectAll("dot")
+        .data(binMap)
+        .enter()
+        .append("circle")
+          .attr("cx", d => (xScale(binIndex) * 10 + 5) )
+          .attr("cy", d => (yScale(d) - 3) )
+          .attr("r", 5)
+          .style("fill", "#448878");
+    });
+  } else {
+    svg.selectAll("rect")
+    .data(bins)
+    .enter()
+    .append("rect")
+      .attr("x", 1)
+      .attr("transform", d => "translate(" + xScale(d.x0 as number) + "," + (yScale(d.length)) + ")")
+      .attr("width", d => (Math.max(0, xScale(d.x1 as number) - xScale(d.x0 as number) - 1)))
+      .attr("height", d => (chartHeight - yScale(d.length)))
+      .style("fill", "#448878");
+  }
+
+  return div.toReact();
+};

--- a/src/components/montecarlo/histogram-panel.tsx
+++ b/src/components/montecarlo/histogram-panel.tsx
@@ -67,16 +67,15 @@ export class HistogramPanel extends BaseComponent<IProps, IState>{
     const { width, height } = this.props;
     const { data } = chart;
 
-    const dataArray: any[] = data.map(d => d[0]);
     const threshold = kTephaThreshold;
     let above = 0;
-    dataArray.forEach(d => {
+    data.forEach((d: number) => {
       if (d > threshold) {
         above++;
       }
     });
-    const below = dataArray.length - above;
-    const abovePercent = Math.round(above / dataArray.length * 100);
+    const below = data.length - above;
+    const abovePercent = Math.round(above / data.length * 100);
     const belowPercent = 100 - abovePercent;
 
     return (
@@ -121,9 +120,9 @@ export class HistogramPanel extends BaseComponent<IProps, IState>{
   private addHistogram = () => {
       const numPoints = 300;
       const title = "Chart " + (this.stores.chartsStore.charts.length + 1);
-      const data: number[][] = [];
+      const data: number[] = [];
       for (let i = 0; i < numPoints; i++) {
-        data.push([Math.floor(this.randomG(3) * (kTephaMax + 1))]);
+        data.push(Math.floor(this.randomG(3) * (kTephaMax + 1)));
       }
       const xAxisLabel = "Tephra Thickness (mm)";
       const yAxisLabel = "Number of Runs";

--- a/src/components/montecarlo/histogram-panel.tsx
+++ b/src/components/montecarlo/histogram-panel.tsx
@@ -2,6 +2,9 @@ import * as React from "react";
 import styled from "styled-components";
 import { inject, observer } from "mobx-react";
 import { BaseComponent, IBaseProps } from "../base";
+import { HorizontalContainer, VerticalContainer } from "../styled-containers";
+import { SvgD3HistogramChart } from "../charts/svg-d3-histogram-chart";
+import { ChartType } from "../../stores/charts-store";
 
 interface PanelProps {
   height: number;
@@ -14,6 +17,10 @@ const Panel = styled.div`
   width: ${(p: PanelProps) => `${p.width - 56}px`};
   margin: 10px 28px;
   box-sizing: content-box;
+`;
+const PanelStat = styled.div`
+  margin: 5px;
+  font-size: 14px;
 `;
 
 interface IState {
@@ -39,12 +46,80 @@ export class HistogramPanel extends BaseComponent<IProps, IState>{
 
   public render() {
     const {width, height} = this.props;
+    const histogramChart = this.stores.chartsStore.charts.find(chart => chart.type === "histogram");
 
     return (
       <Panel height={height} width={width}>
-        MONTE CARLO
+        { histogramChart
+          ? this.renderHistogram(histogramChart)
+          : <button onClick={this.addHistogram}>Add histogram</button>
+        }
       </Panel>
     );
   }
 
+  private renderHistogram = (chart: ChartType) => {
+    const {width, height} = this.props;
+    const { data } = chart;
+    const fakeData: any[] = data.map(d => d[1]);
+    const threshold = 201;
+    let above = 0;
+    fakeData.forEach(d => {
+      if (d > threshold) {
+        above++;
+      }
+    });
+    const below = fakeData.length - above;
+    const abovePercent = Math.round(above / fakeData.length * 100);
+    const belowPercent = 100 - abovePercent;
+
+    return (
+      <HorizontalContainer>
+        <SvgD3HistogramChart
+          width={width - 200}
+          height={height - 10}
+          chart={chart}
+          bars={this.state.bars}
+        />
+        <VerticalContainer>
+          <PanelStat>Threshold = 201mm</PanelStat>
+          <PanelStat>{`Count below threshold: ${below} (${belowPercent}%)`}</PanelStat>
+          <PanelStat>{`Count above threshold: ${above} (${abovePercent}%)`}</PanelStat>
+          <PanelStat>Risk: Medium</PanelStat>
+          <button onClick={this.changeDisplayType}>Change display type</button>
+        </VerticalContainer>
+      </HorizontalContainer>
+    );
+  }
+
+  private changeDisplayType = () => {
+    this.setState(prevState => ({
+      bars: !prevState.bars
+    }));
+  }
+
+  private addHistogram = () => {
+      const numPoints = 300;
+
+      const title = "Chart " + (this.stores.chartsStore.charts.length + 1);
+
+      const data: number[][] = [];
+      for (let i = 0; i < numPoints; i++) {
+        data.push([Date.now(), Math.floor(this.randomG(3) * 401)]);
+        // data.push([Date.now(), Math.floor(Math.random() * 401)]);
+      }
+
+      const xAxisLabel = "Tephra Thickness (mm)";
+      const yAxisLabel = "Number of Runs";
+      const dateLabelFormat = "%b";
+      this.stores.chartsStore.addChart({type: "histogram", data, title, xAxisLabel, yAxisLabel, dateLabelFormat});
+  }
+
+  private randomG = (v: number) => {
+    let r = 0;
+    for (let i = v; i > 0; i--) {
+        r += Math.random();
+    }
+    return r / v;
+  }
 }

--- a/src/stores/charts-store.ts
+++ b/src/stores/charts-store.ts
@@ -8,13 +8,14 @@ export type ChartTypeType = typeof ChartType.Type;
 export const ChartStyle = types.enumeration("type", ["dot", "arrow"]);
 export type ChartStyleType = typeof ChartStyle.Type;
 
-type ChartData = Array<Array<number|Date>>;
+type ChartData = Array<Array<number|Date>> | number[];
 type Column = number|Date;
 
 const Chart = types.model("Chart", {
   type: ChartType,
   chartStyle: types.maybe(ChartStyle),      // rendering options, given a specific type
-  data: types.array(types.array(types.union(types.number, types.Date))), // [x,y], [deg,mag], or [date, y] tuples
+  // [x,y], [deg,mag], or [date, y] tuples
+  data: types.array(types.union(types.array(types.union(types.number, types.Date)), types.number)),
   title: types.maybe(types.string),
   customExtents: types.array(types.array(types.number)),
   xAxisLabel: types.maybe(types.string),
@@ -23,12 +24,15 @@ const Chart = types.model("Chart", {
 })
 .views((self) => {
   const isDate = (column: 0|1) => {
-    if (self.data.length === 0) return false;
+    if (self.data.length === 0 || !Array.isArray(self.data[0])) return false;
     return self.data[0][column] instanceof Date;
   };
 
   // returns one column as an array
-  const getColumnData = (column: 0|1) => self.data.map(d => d[column]);
+  const getColumnData = (column: 0|1) => {
+    if (!Array.isArray(self.data[0])) return self.data;
+    return self.data.map((d: any) => d[column]);
+  };
 
   // returns a function to convert a Date to a string, given an axis
   const toDateString = () => {


### PR DESCRIPTION
This PR adds a histogram to the Monte Carlo that can be filled in by passing in a chart from our chart store.  A `HistogramPanel` component contains both the histogram and some accompanying text.  And a new `SvgD3HistogramChart` renders the actual histogram.  A few notes about things that will need to be modified as we move forward:
- at present there is a button to make a histogram.  It generate 300 random data points (from 0 to 400), adds them to a chart in the chart store, and then passes the chart to the histogram component to be displayed.  We will need to remove this fake data and pass in real data to the newly created chart.
- the threshold is currently set to a constant value of 201.  We will need to pass in a threshold defined in a block.
- at present the min and max for the tephra thickness values are set to 0 and 400 - these set the range of the x axis on the histogram.  Since the histogram will be built incrementally by stepping over a program, it is probably best to have a pre-defined tephra thickness range (otherwise if we pull the min/max values from the data, the histogram will render with different ranges each time we add data to the chart - this seems like it will be jarring to the user).  I'm not sure if 400 is a proper max, but this is what was shown in mock-ups
- I left in a button to toggle between a dot plot and a bar graph version of the histogram.  I think the bar graph is much better suited to our needs since we will incrementally add to the histogram and because the container div can be scaled along x or y (it will be much easier to display the bar graph in a predictable manner given the flexibility of the graph).  