### PR TITLE
Add threshold line to monte carlo panel

### DIFF
--- a/src/components/charts/svg-d3-histogram-chart.tsx
+++ b/src/components/charts/svg-d3-histogram-chart.tsx
@@ -9,10 +9,11 @@ interface IProps {
   width: number;
   height: number;
   showBars: boolean;
+  threshold: number;
 }
 
 export const SvgD3HistogramChart = (props: IProps) => {
-  const { width, height, chart, showBars, chartMin, chartMax } = props;
+  const { width, height, chart, showBars, chartMin, chartMax, threshold } = props;
   const { data, xAxisLabel, yAxisLabel } = chart;
 
   const margin = {top: 15, right: 20, bottom: 35, left: 50};
@@ -100,6 +101,23 @@ export const SvgD3HistogramChart = (props: IProps) => {
       .attr("height", d => (chartHeight - yScale(d.length)))
       .style("fill", "#797979");
   }
+
+  const thresholdX = threshold / (chartMax - chartMin) * chartWidth;
+  svg.append("line")
+    .attr("x1", thresholdX)
+    .attr("y1", 0)
+    .attr("x2", thresholdX)
+    .attr("y2", chartHeight)
+    .attr("stroke", "#4AA9FF")
+    .attr("stroke-width", 3);
+  svg.append("text")
+    .attr("x", thresholdX)
+    .attr("y", -3)
+    .attr("text-anchor", "middle")
+    .style("font-size", "0.8em")
+    .style("font-weight", "bold")
+    .style("fill", "#4AA9FF")
+    .text(threshold.toString());
 
   return div.toReact();
 };

--- a/src/components/montecarlo/histogram-panel.tsx
+++ b/src/components/montecarlo/histogram-panel.tsx
@@ -135,6 +135,7 @@ export class HistogramPanel extends BaseComponent<IProps, IState>{
 
   private renderHistogram = (chart: ChartType) => {
     const { width, height } = this.props;
+    const threshold = kTephraThreshold;
     return (
       <SvgD3HistogramChart
         width={width - 200}
@@ -143,6 +144,7 @@ export class HistogramPanel extends BaseComponent<IProps, IState>{
         chartMin={kTephraMin}
         chartMax={kTephraMax}
         showBars={this.state.showBars}
+        threshold={threshold}
       />
     );
   }


### PR DESCRIPTION
This PR adds a threshold line to the monte carlo panel histogram.  At present, the threshold is stored in the histogram panel component as a constant (201) value that we will need to modify once this value is determined based on a blockly block.