### PR TITLE
Fix authoring text

### DIFF
--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -39,8 +39,8 @@ const AuthoringMenu: React.SFC<IProps> = (props) => {
 
           <DatFolder title="Right Tabs" key="rightTabsFolder" closed={false}>
             <DatBoolean path="uiStore.showConditions" label="Show conditions?" key="showConditions" />
-            <DatBoolean path="uiStore.showCrossSection" label="Show monte carlo?" key="showMonteCarlo" />
-            <DatBoolean path="uiStore.showMonteCarlo" label="Show cross section?" key="showCrossSection" />
+            <DatBoolean path="uiStore.showMonteCarlo" label="Show monte carlo?" key="showMonteCarlo" />
+            <DatBoolean path="uiStore.showCrossSection" label="Show cross section?" key="showCrossSection" />
             <DatBoolean path="uiStore.showData" label="Show data?" key="showData" />
           </DatFolder>,
 


### PR DESCRIPTION
The monte carlo and cross section text strings were swapped in the authoring panel.