### PR TITLE
Hide histogram progress bar

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -389,9 +389,6 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                   <HistogramPanel
                     width={ mapWidth }
                     height={ (height - 90) * .35 }
-                    percentComplete={ this.stores.chartsStore.charts.find(chart => chart.type === "histogram")
-                                      ? 100
-                                      : 0 }
                   />
                 </Simulation>
               </TabPanel>


### PR DESCRIPTION
Hide the histogram progress bar by removing optional props that cause progress bar to be rendered.