### PR TITLE
Samples collections

### DIFF
--- a/src/assets/blockly-authoring/toolbox/full-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/full-toolbox.xml
@@ -19,6 +19,8 @@
     <block type="simulate_wind_vei"></block>
     <block type="simulate_wind_height"></block>
     <block type="simulate_wind_2"></block>
+
+    <block type="calculate_tephra_vei_wind"></block>
     <!-- <block type="outputPaintMap"></block> -->
     <!-- <block type="outputPlot"></block> -->
     <!-- <block type="redrawMap"></block> -->

--- a/src/assets/blockly-authoring/toolbox/full-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/full-toolbox.xml
@@ -33,6 +33,11 @@
     <block type="filter_data"></block>
   </category>
 
+  <category name="Samples Collections" colour="240">
+    <block type="create_sample_collection"></block>
+    <block type="add_to_sample_collection"></block>
+  </category>
+
   <category name="Logic" colour="%{BKY_LOGIC_HUE}">
     <block type="controls_if"></block>
     <block type="logic_compare"></block>

--- a/src/assets/blockly-authoring/toolbox/full-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/full-toolbox.xml
@@ -38,6 +38,7 @@
   <category name="Samples Collections" colour="240">
     <block type="create_sample_collection"></block>
     <block type="add_to_sample_collection"></block>
+    <block type="graph_exceedance"></block>
   </category>
 
   <category name="Logic" colour="%{BKY_LOGIC_HUE}">

--- a/src/blockly-blocks/block-calculate-tephra-vei-wind.js
+++ b/src/blockly-blocks/block-calculate-tephra-vei-wind.js
@@ -1,0 +1,39 @@
+Blockly.Blocks['calculate_tephra_vei_wind'] = {
+  init: function() {
+    this.appendDummyInput()
+        .appendField("Compute tephra depth at location")
+    this.appendDummyInput()
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField(new Blockly.FieldDropdown(this.generateOptions), "collections");
+    this.appendValueInput("vei")
+        .setCheck("Number")
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("VEI");
+    this.appendValueInput("wind samples")
+        .setCheck("Dataset")
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("a random wind sample from");
+    this.setOutput(true, "Sample");
+    this.setColour(0);
+    this.setTooltip("");
+    this.setHelpUrl("");
+  },
+
+  generateOptions: function() {
+    if (Blockly.sampleCollections && Blockly.sampleCollections.length > 0) {
+      return Blockly.sampleCollections;
+    } else {
+      return [["<Create collection>",""]];
+    }
+  }
+};
+
+Blockly.JavaScript['calculate_tephra_vei_wind'] = function(block) {
+    var collection = block.getFieldValue('collections');
+    var wind_samples = Blockly.JavaScript.valueToCode(block, 'wind samples', Blockly.JavaScript.ORDER_ATOMIC) || "null";
+    var value_vei = Blockly.JavaScript.valueToCode(block, 'vei', Blockly.JavaScript.ORDER_ATOMIC) || 0;
+
+    var code = `computeTephra({collection: "${collection}", windSamples: ${wind_samples}, vei: ${value_vei}})`;
+
+    return [code, Blockly.JavaScript.ORDER_NONE]
+  };

--- a/src/blockly-blocks/block-create-add-to-sample-collection.js
+++ b/src/blockly-blocks/block-create-add-to-sample-collection.js
@@ -1,0 +1,64 @@
+Blockly.Blocks['create_sample_collection'] = {
+  init: function() {
+    this.appendDummyInput()
+        .appendField("Create a samples collection")
+    this.appendDummyInput()
+        .appendField("for a location named")
+        .appendField(new Blockly.FieldTextInput("Name"), "name");
+    this.appendDummyInput()
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("at x")
+        .appendField(new Blockly.FieldNumber(0), "x");
+    this.appendDummyInput()
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("y")
+        .appendField(new Blockly.FieldNumber(0), "y");
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(240);
+    this.setTooltip("");
+    this.setHelpUrl("");
+  }
+};
+
+Blockly.JavaScript['create_sample_collection'] = function (block) {
+  var value_name = block.getFieldValue('name');
+  var value_x = block.getFieldValue('x');
+  var value_y = block.getFieldValue('y');
+
+  var code = `createSampleCollection({name: "${value_name}", x: ${value_x}, y: ${value_y}});\n`;
+
+  return code;
+}
+
+Blockly.Blocks['add_to_sample_collection'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField("Add sample for")
+    this.appendValueInput('tephra sample')
+      .setAlign(Blockly.ALIGN_RIGHT)
+      .setCheck('Sample')
+      .appendField(new Blockly.FieldDropdown(
+        this.generateOptions), "collections")
+    this.setPreviousStatement(true, null)
+    this.setNextStatement(true, null)
+    this.setColour(240)
+    this.setTooltip('')
+    this.setHelpUrl('')
+  },
+
+  generateOptions: function() {
+    if (Blockly.sampleCollections && Blockly.sampleCollections.length > 0) {
+      return Blockly.sampleCollections;
+    } else {
+      return [["<Create collection>",""]];
+    }
+  }
+}
+Blockly.JavaScript['add_to_sample_collection'] = function (block) {
+  var tephra_sample = Blockly.JavaScript.valueToCode(block, 'tephra sample', Blockly.JavaScript.ORDER_ATOMIC) || null
+  var collection = block.getFieldValue('collections')
+
+  var code = `addToSampleCollection({name: "${collection}", sample: ${tephra_sample}});\n`
+  return code
+}

--- a/src/blockly-blocks/block-create-add-to-sample-collection.js
+++ b/src/blockly-blocks/block-create-add-to-sample-collection.js
@@ -56,7 +56,9 @@ Blockly.Blocks['add_to_sample_collection'] = {
   }
 }
 Blockly.JavaScript['add_to_sample_collection'] = function (block) {
-  var tephra_sample = Blockly.JavaScript.valueToCode(block, 'tephra sample', Blockly.JavaScript.ORDER_ATOMIC) || null
+  // if tephra_sample is null, this ought to throw an error and alert the user,
+  // but we don't yet have a mechanism for that.
+  var tephra_sample = Blockly.JavaScript.valueToCode(block, 'tephra sample', Blockly.JavaScript.ORDER_ATOMIC) || 0
   var collection = block.getFieldValue('collections')
 
   var code = `addToSampleCollection({name: "${collection}", sample: ${tephra_sample}});\n`

--- a/src/blockly-blocks/block-graph-data.js
+++ b/src/blockly-blocks/block-graph-data.js
@@ -71,3 +71,38 @@ Blockly.JavaScript['graph_any_wind_data'] = function (block) {
   var code = `graphArbitraryPlot({dataset: ${value_wind_data}, xAxis: "${value_x_axis}", yAxis: "${value_y_axis}"});\n`
   return code
 }
+
+Blockly.Blocks['graph_exceedance'] = {
+  init: function() {
+    this.appendDummyInput()
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("Graph excedence for");
+    this.appendDummyInput()
+        .appendField("samples from")
+        .appendField(new Blockly.FieldDropdown(this.generateOptions), "locations");
+    this.appendValueInput("threshold")
+        .setCheck(null)
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("exceeding (mm)");
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(230);
+    this.setTooltip("");
+    this.setHelpUrl("");
+  },
+
+  generateOptions: function() {
+    if (Blockly.sampleCollections && Blockly.sampleCollections.length > 0) {
+      return Blockly.sampleCollections;
+    } else {
+      return [["<Create collection>",""]];
+    }
+  }
+}
+Blockly.JavaScript['graph_exceedance'] = function (block) {
+  var location = block.getFieldValue('locations')
+  var threshold = block.getFieldValue('threshold') || 0
+
+  var code = `graphExceedance({location: "${location}", threshold: ${threshold}});\n`
+  return code
+}

--- a/src/blockly-blocks/blocks.js
+++ b/src/blockly-blocks/blocks.js
@@ -24,3 +24,4 @@ import "../blockly-blocks/block-simulate-wind-2";
 import "../blockly-blocks/block-wind-data";
 import "../blockly-blocks/block-graph-data";
 import "../blockly-blocks/block-range";
+import "./block-create-add-to-sample-collection";

--- a/src/blockly-blocks/blocks.js
+++ b/src/blockly-blocks/blocks.js
@@ -25,3 +25,4 @@ import "../blockly-blocks/block-wind-data";
 import "../blockly-blocks/block-graph-data";
 import "../blockly-blocks/block-range";
 import "./block-create-add-to-sample-collection";
+import "./block-calculate-tephra-vei-wind";

--- a/src/blockly/blockly-controller.ts
+++ b/src/blockly/blockly-controller.ts
@@ -43,12 +43,14 @@ export class BlocklyController {
       this.running = true;
     }
     this.stores.chartsStore.reset();
+    this.stores.samplesCollectionsStore.reset();
   }
 
   public reset = () => {
     this.setCode(this.code, this.workspace);
     this.stores.simulation.reset();
     this.stores.chartsStore.reset();
+    this.stores.samplesCollectionsStore.reset();
   }
 
   public stop = () => {

--- a/src/blockly/blockly-controller.ts
+++ b/src/blockly/blockly-controller.ts
@@ -31,6 +31,7 @@ export class BlocklyController {
     this.interpreterController = makeInterpreterController(code, this, this.stores, workspace);
 
     this.stores.simulation.setBlocklyCode(code, workspace);
+    this.parseVariables();
   }
 
   public run = () => {
@@ -108,5 +109,29 @@ export class BlocklyController {
   // called by interpreted block code
   public endStep = () => {
     this.steppingThroughBlock = false;
+  }
+
+  /**
+   * This manually parses code to find fields that the user has named, for use
+   * in pull-down menus or similar. This is essentially doing what Blockly's
+   * variables system does, without the hassle of dealing with Blockly's custom
+   * variable syntax and dynamic creation of blocks to deal with them.
+   *
+   * Currently the only thing we parse for is the "create_sample_collection" block,
+   * so that we can populate the "add_to_samples_collection" dropdowns.
+   *
+   * Note that this process doesn't actually create a samplesCollection, that happens
+   * when the code is actually run.
+   */
+  private parseVariables() {
+    const sampleCollectionsRegex = /createSampleCollection\({name: "([^"]*)"/gm;
+    const sampleCollections = [];
+    let match;
+    // tslint:disable-next-line
+    while ((match = sampleCollectionsRegex.exec(this.code)) !== null) {
+      const collectionName = match[1];
+      if (collectionName) sampleCollections.push([collectionName, collectionName]);   // dropdowns need two strings
+    }
+    (Blockly as any).sampleCollections = sampleCollections;
   }
 }

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -9,7 +9,7 @@ const Interpreter = require("js-interpreter");
 const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore,
                              workspace: IBlocklyWorkspace) => {
 
-  const { simulation, chartsStore } = store;
+  const { simulation, chartsStore, samplesCollectionsStore } = store;
 
   return (interpreter: any, scope: any) => {
     const addVar = (name: string, value: any) => {
@@ -128,6 +128,16 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
 
     addFunc("graphArbitraryPlot", (params: {dataset: Dataset, xAxis: string, yAxis: string}) => {
       chartsStore.addArbitraryChart(params.dataset, params.xAxis, params.yAxis);
+    });
+
+    /** ==== Sample Collections ==== */
+
+    addFunc("createSampleCollection", (params: {name: string, x: number, y: number}) => {
+      samplesCollectionsStore.createSamplesCollection(params);
+    });
+
+    addFunc("addToSampleCollection", (params: {name: string, sample: number}) => {
+      samplesCollectionsStore.addToSamplesCollection(params.name, 0);
     });
 
     /** ==== Utility methods ==== */

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -160,6 +160,15 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
       chartsStore.addArbitraryChart(params.dataset, params.xAxis, params.yAxis);
     });
 
+    addFunc("graphExceedance", (params: {location: string, threshold: number}) => {
+      const { location, threshold } = params;
+      const samplesCollection = samplesCollectionsStore.samplesCollection(location);
+      if (!samplesCollection) {
+        return;
+      }
+      chartsStore.addHistogram(samplesCollection, threshold, `Tephra Thickness at ${samplesCollection.name} (mm)`);
+    });
+
     /** ==== Sample Collections ==== */
 
     addFunc("createSampleCollection", (params: {name: string, x: number, y: number}) => {

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -93,7 +93,9 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
 
       const samplesCollection = samplesCollectionsStore.samplesCollection(collection);
       if (!samplesCollection) {
-        return;
+        return {
+          data: 0       // ought to stop and throw an error to the user
+        };
       }
 
       const VEI = vei || 1;
@@ -165,7 +167,7 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
     });
 
     addFunc("addToSampleCollection", (params: {name: string, sample: number}) => {
-      samplesCollectionsStore.addToSamplesCollection(params.name, 0);
+      samplesCollectionsStore.addToSamplesCollection(params.name, params.sample);
     });
 
     /** ==== Utility methods ==== */

--- a/src/components/charts/svg-d3-histogram-chart.tsx
+++ b/src/components/charts/svg-d3-histogram-chart.tsx
@@ -85,7 +85,7 @@ export const SvgD3HistogramChart = (props: IProps) => {
         .data(binMap)
         .enter()
         .append("circle")
-          .attr("cx", d => (xScale(binIndex) * 10 + dotRadius) )
+          .attr("cx", d => (xScale(binIndex) * (chartMax / numBins) + dotRadius) )
           .attr("cy", d => (yScale(d) - 5) )
           .attr("r", dotRadius)
           .style("fill", "#797979");

--- a/src/components/charts/svg-d3-histogram-chart.tsx
+++ b/src/components/charts/svg-d3-histogram-chart.tsx
@@ -34,7 +34,7 @@ export const SvgD3HistogramChart = (props: IProps) => {
   xScale.range([0, chartWidth]);
 
   // add axes
-  const axisBottom = d3.axisBottom(xScale);
+  const axisBottom = d3.axisBottom(xScale).tickFormat(x => (x === chartMax) ? `${x}+` : `${x}`);
   svg.append("g")
     .attr("transform", "translate(0," + chartHeight + ")")
     .call(axisBottom);
@@ -45,7 +45,8 @@ export const SvgD3HistogramChart = (props: IProps) => {
     .thresholds(xScale.ticks(numBins));
 
   // And apply this function to data to get the bins
-  const bins = histogram(data as number[]);
+  // Add all the cases exceeding the max into the max's bin
+  const bins = histogram((data as number[]).map(d => Math.min(d, xDomain[1] - 1)));
   let max = 0;
   bins.forEach(bin => {
     max = Math.max(max, bin.length);

--- a/src/stores/samples-collections-store.ts
+++ b/src/stores/samples-collections-store.ts
@@ -42,5 +42,6 @@ const SamplesCollectionsStore = types.model("SamplesCollections", {
   },
 }));
 
+export type SamplesCollectionModelType = typeof SamplesCollection.Type;
 export type SamplesCollectionsModelType = typeof SamplesCollectionsStore.Type;
 export const samplesCollectionsStore = SamplesCollectionsStore.create({});

--- a/src/stores/samples-collections-store.ts
+++ b/src/stores/samples-collections-store.ts
@@ -1,0 +1,46 @@
+import { types } from "mobx-state-tree";
+
+/**
+ * For now each sample is a single number.
+ * It is likely that we will want this to eventually be an entire data set row
+ * (e.g. all the inputs (wind data, vei etc.) plus tephra thickness).
+ */
+const SamplesCollection = types.model("SamplesCollection", {
+  name: types.string,
+  x: types.number,
+  y: types.number,
+  samples: types.array(types.number),
+})
+.actions((self) => ({
+  addSample(sample: number) {
+    self.samples.push(sample);
+  }
+}));
+
+const SamplesCollectionsStore = types.model("SamplesCollections", {
+  samplesCollections: types.array(SamplesCollection)
+})
+.views((self) => ({
+  samplesCollection(name: string) {
+    return self.samplesCollections.find(c => c.name === name);
+  }
+}))
+.actions((self) => ({
+  createSamplesCollection(collection: {name: string, x: number, y: number }) {
+    self.samplesCollections.push(SamplesCollection.create(collection));
+  },
+
+  reset() {
+    self.samplesCollections.length = 0;
+  },
+
+  addToSamplesCollection(name: string, sample: number) {
+    const collection = self.samplesCollection(name);
+    if (collection) {
+      collection.addSample(sample);
+    }
+  },
+}));
+
+export type SamplesCollectionsModelType = typeof SamplesCollectionsStore.Type;
+export const samplesCollectionsStore = SamplesCollectionsStore.create({});

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -2,11 +2,13 @@
 import { simulation, SimulationModelType } from "./simulation-store";
 import { uiStore, UIModelType } from "./ui-store";
 import { chartsStore, ChartsModelType } from "./charts-store";
+import { samplesCollectionsStore, SamplesCollectionsModelType } from "./samples-collections-store";
 
 export interface IStore {
   simulation: SimulationModelType;
   uiStore: UIModelType;
   chartsStore: ChartsModelType;
+  samplesCollectionsStore: SamplesCollectionsModelType;
 }
 
 export interface IStoreish {simulation: any; uiStore: any; }
@@ -17,6 +19,7 @@ export const stores: IStore = {
   simulation,
   uiStore,
   chartsStore,
+  samplesCollectionsStore,
 };
 
 // this tuple syntx allows us to declare an array of strings and a type based on


### PR DESCRIPTION
This adds four new blocks for creating a samples collection, adding to a samples collection, computing tephra at a location, and graphing a samples collection. It produces a histogram in the Monte Carlo tab when a collection is graphed.

http://geocode-app.concord.org/branch/samples-collections/index.html

The minimal set up for producing data look like

<img width="1357" alt="Screen Shot 2020-03-05 at 1 07 25 PM" src="https://user-images.githubusercontent.com/35721/76011468-a14cb480-5ee2-11ea-95df-847c0100cf2a.png">

This uses default values for things not filled in (e.g. VEI=1, Wind=0).

A more interesting setup might look more like

<img width="1361" alt="Screen Shot 2020-03-05 at 1 14 10 PM" src="https://user-images.githubusercontent.com/35721/76011849-3ea7e880-5ee3-11ea-99f3-70d1f76b3593.png">

Note that the pull-down options in all the blocks below "Create..." are populated by the values in all the "Create..." blocks in the program (there may be more than one). If a user creates or edits a "Create..." block after they have already added a drop-down block, they will still need to update the values in the drop-downs. If a block contains a reference to a Samples Collection that doesn't exist, the block won't do anything, but also won't throw errors or halt the program.