### PR TITLE
Add risk warnings

### DIFF
--- a/src/components/icons.ts
+++ b/src/components/icons.ts
@@ -23,6 +23,13 @@ export function circleIcon(label: string): DivIcon {
     return new DivIcon({ className: "circle-icon", html: label });
 }
 
+export function riskIcon(color: string, label: string, selected: boolean): DivIcon {
+    const iconClass = "diamond-icon " + (selected ? "selected" : "");
+    const iconStyle = "background:" + color + ";";
+    const html = "<div class='" + iconClass + "' style='" + iconStyle + "'><div class='diamond-text'>" + label + "</div></div>";
+    return new DivIcon({ className: "diamond-container", html });
+}
+
 export function getCachedCircleIcon(label: string) {
     const iconKey = "circle-icon" + label;
     if (!iconsCache.get(iconKey)) iconsCache.set(iconKey, circleIcon(label)); // = circleIcon();

--- a/src/components/map/map-component.tsx
+++ b/src/components/map/map-component.tsx
@@ -4,7 +4,7 @@ import * as L from "leaflet";
 import { Map as LeafletMap, TileLayer, Marker, Popup, ScaleControl, Pane } from "react-leaflet";
 import "leaflet/dist/leaflet.css";
 import "../../css/map-component.css";
-import { iconVolcano, iconMarker, getCachedDivIcon } from "../icons";
+import { iconVolcano, iconMarker, getCachedDivIcon, riskIcon } from "../icons";
 
 import { CityType  } from "../../stores/simulation-store";
 import * as Scenarios from "../../assets/maps/scenarios.json";
@@ -20,7 +20,9 @@ import { RightSectionTypes } from "../tabs";
 import KeyButton from "./map-key-button";
 import CompassComponent from "./map-compass";
 import TephraLegendComponent from "./map-tephra-legend";
-import { number } from "mobx-state-tree/dist/internal";
+import RiskLegendComponent from "./map-risk-legend";
+import { kTephraThreshold, ThresholdData, RiskLevel,
+         calculateThresholdData, calculateRisk } from "../montecarlo/monte-carlo";
 
 interface WorkspaceProps {
   width: number;
@@ -192,6 +194,9 @@ export class MapComponent extends BaseComponent<IProps, IState>{
         }
       })
     : null;
+
+    const riskItems = this.getRiskItems();
+
     const { crossPoint1Lat, crossPoint1Lng, crossPoint2Lat, crossPoint2Lng } = this.stores.simulation;
     const volcanoPos = L.latLng(volcanoLat, volcanoLng);
     const corner1 = L.latLng(topLeftLat, topLeftLng);
@@ -260,6 +265,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
             </Marker>
             {cityItems}
             {pinItems}
+            {panelType === RightSectionTypes.MONTE_CARLO && riskItems}
             { isSelectingCrossSection && <CrossSectionDrawLayer
               ref={this.crossRef}
               map={this.state.mapLeafletRef}
@@ -283,7 +289,9 @@ export class MapComponent extends BaseComponent<IProps, IState>{
         />
         { this.state.showKey
           ? <KeyButton onClick={this.onKeyClick}/>
-          : <TephraLegendComponent onClick={this.onTephraClick}/>
+          : panelType === RightSectionTypes.MONTE_CARLO
+            ? <RiskLegendComponent onClick={this.onKeyButtonClick}/>
+            : <TephraLegendComponent onClick={this.onKeyButtonClick}/>
         }
         <CompassComponent/>
       </CanvDiv>
@@ -293,7 +301,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
   private onKeyClick = () => {
     this.setState({showKey: false});
   }
-  private onTephraClick = () => {
+  private onKeyButtonClick = () => {
     this.setState({showKey: true});
   }
 
@@ -317,5 +325,24 @@ export class MapComponent extends BaseComponent<IProps, IState>{
         this.stores.simulation.setViewportParameters(zoom, center.lat, center.lng);
       }
     }
+  }
+
+  private getRiskItems = () => {
+    // TODO: this code adds a risk map item for every sample collection with threshold kTephraThreshold
+    // need to specify correct samples to add risk item and correct threshold
+    const { samplesCollectionsStore } = this.stores;
+    const riskItems: any[] = [];
+    samplesCollectionsStore.samplesCollections.forEach( (samplesCollection: any, i) => {
+      const thresholdData: ThresholdData = calculateThresholdData(samplesCollection.samples, kTephraThreshold);
+      const riskLevel = calculateRisk(thresholdData.greaterThanPercent);
+      riskLevel && riskItems.push(
+        <Marker
+          position={[samplesCollection.x, samplesCollection.y]}
+          icon={riskIcon(riskLevel.iconColor, riskLevel.iconText, true)}
+          key={"risk-" + i}
+        />
+      );
+    });
+    return riskItems;
   }
 }

--- a/src/components/map/map-component.tsx
+++ b/src/components/map/map-component.tsx
@@ -331,13 +331,17 @@ export class MapComponent extends BaseComponent<IProps, IState>{
     // TODO: this code adds a risk map item for every sample collection with threshold kTephraThreshold
     // need to specify correct samples to add risk item and correct threshold
     const { samplesCollectionsStore } = this.stores;
+    const { volcanoLat, volcanoLng } = this.stores.simulation;
     const riskItems: any[] = [];
     samplesCollectionsStore.samplesCollections.forEach( (samplesCollection: any, i) => {
       const thresholdData: ThresholdData = calculateThresholdData(samplesCollection.samples, kTephraThreshold);
       const riskLevel = calculateRisk(thresholdData.greaterThanPercent);
+      const x = samplesCollection.x;
+      const y = samplesCollection.y;
+      const riskPos = LocalToLatLng({x, y}, L.latLng(volcanoLat, volcanoLng));
       riskLevel && riskItems.push(
         <Marker
-          position={[samplesCollection.x, samplesCollection.y]}
+          position={[riskPos.lat, riskPos.lng]}
           icon={riskIcon(riskLevel.iconColor, riskLevel.iconText, true)}
           key={"risk-" + i}
         />

--- a/src/components/map/map-risk-legend.tsx
+++ b/src/components/map/map-risk-legend.tsx
@@ -1,0 +1,141 @@
+import * as React from "react";
+import { PureComponent } from "react";
+import styled from "styled-components";
+import { Icon } from "../icon";
+import CloseIcon from "../../assets/map-icons/close.svg";
+import { isNumber } from "util";
+import { RiskLevels, RiskLevel } from "../montecarlo/monte-carlo";
+
+const LegendContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+  position: absolute;
+  box-sizing: border-box;
+  top: 35px;
+  right: 38px;
+  width: 165px;
+  height: 230px;
+  border-radius: 5px;
+  background-color: white;
+  border: solid 2px white;
+  box-shadow: 1px 1px 4px 0 rgba(0, 0, 0, 0.35);
+`;
+
+const LegendTitleText = styled.div`
+  margin: 5px 11px 2px 11px;
+  color: #434343;
+  font-size: 14px;
+  width: 105px;
+  height: 20px;
+  box-sizing: border-box;
+  text-align: center;
+`;
+const LegendTitleSubText = styled.div`
+  margin: 2px 11px 2px 11px;
+  color: #434343;
+  font-size: 11px;
+  width: 120px;
+  height: 30px;
+  box-sizing: border-box;
+  text-align: center;
+  font-style: italic;
+`;
+
+const AbsoluteIcon = styled(Icon)`
+  position: absolute;
+  top: 2px;
+  right: 6px;
+  &:hover {
+    fill: #75cd75;
+  }
+  &:active {
+    fill: #e6f2e4;
+  }
+`;
+
+const RiskContainer = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  width: 140px;
+  height: 34px;
+  margin-top: 5px;
+`;
+
+interface RiskDiamondProps {
+  backgroundColor?: string;
+}
+const RiskDiamond = styled.div`
+  width: 24px;
+  height: 24px;
+  box-sizing: border-box;
+  border: solid 1px #979797;
+  background-color: ${(p: RiskDiamondProps) => `${p.backgroundColor ? `${p.backgroundColor}` : "#white"}`};
+  margin-right: 12px;
+  transform: rotate(45deg);
+  border: 2px solid #A1A1A1;
+  border-radius: 4px;
+`;
+const RiskDiamondText = styled.div`
+  width: 24px;
+  height: 24px;
+  transform: rotate(-45deg);
+  font-size: 20px;
+  font-weight: bold;
+  color: white;
+  line-height: 16px;
+  text-align: center;
+`;
+
+const RiskLabel = styled.div`
+  color: #434343;
+  font-size: 12px;
+`;
+
+interface IProps {
+  onClick: any;
+}
+
+interface IState {}
+
+export default class RiskLegendComponent extends PureComponent<IProps, IState> {
+  public static defaultProps = {
+    onClick: undefined,
+  };
+
+  public render() {
+    const { onClick } = this.props;
+    return (
+      <LegendContainer>
+        <LegendTitleText>Risk Level</LegendTitleText>
+        <LegendTitleSubText>Determined by percents exceeding threshold</LegendTitleSubText>
+        <AbsoluteIcon
+          width={12}
+          height={12}
+          fill={"#b7dcad"}
+          onClick={onClick}
+        >
+          <CloseIcon />
+        </AbsoluteIcon>
+        {RiskLevels.map((riskLevel, index) => {
+            return (
+              <RiskContainer key={"risk" + index}>
+                <RiskDiamond backgroundColor={riskLevel.iconColor}>
+                  <RiskDiamondText>
+                    {riskLevel.iconText}
+                  </RiskDiamondText>
+                </RiskDiamond>
+                { isNumber(riskLevel.max) && isNumber(riskLevel.min)
+                  ? <RiskLabel>{`${riskLevel.level} (${riskLevel.min}-${riskLevel.max}%)`}</RiskLabel>
+                  : <RiskLabel>{riskLevel.level}</RiskLabel>
+                }
+              </RiskContainer>
+            );
+        })}
+      </LegendContainer>
+    );
+  }
+
+}

--- a/src/components/montecarlo/monte-carlo.ts
+++ b/src/components/montecarlo/monte-carlo.ts
@@ -1,0 +1,75 @@
+import { isNumber } from "util";
+
+// TODO threshold and histogram min/max will need to be set elsewhere
+export const kTephraThreshold = 201;
+export const kTephraMin = 0;
+export const kTephraMax = 400;
+
+export interface ThresholdData {
+  greaterThan: number;
+  lessThanEqual: number;
+  greaterThanPercent: number;
+  lessThanEqualPercent: number;
+}
+export interface RiskLevel {
+  level: string;
+  iconColor: string;
+  iconText: string;
+  min: number | undefined;
+  max: number | undefined;
+}
+export const RiskLevels: RiskLevel[] = [
+  {
+    level: "Undefined",
+    iconColor: "#C4C4C4",
+    iconText: "",
+    min: undefined,
+    max: undefined
+  },
+  {
+    level: "Low",
+    iconColor: "#63CC19",
+    iconText: "",
+    min: 0,
+    max: 30
+  },
+  {
+    level: "Medium",
+    iconColor: "#ECA519",
+    iconText: "!",
+    min: 31,
+    max: 79
+  },
+  {
+    level: "High",
+    iconColor: "#FF1919",
+    iconText: "!",
+    min: 80,
+    max: 100
+  },
+];
+
+export const calculateThresholdData = (data: any, threshold: number) => {
+  const thresholdData: ThresholdData = { greaterThan: 0,
+                                         lessThanEqual: 0,
+                                         greaterThanPercent: 0,
+                                         lessThanEqualPercent: 0
+                                        };
+  data && data.forEach((d: number) => {
+    if (d > threshold) {
+      thresholdData.greaterThan++;
+    }
+  });
+  thresholdData.lessThanEqual = data ? data.length - thresholdData.greaterThan : 0;
+  thresholdData.greaterThanPercent = data ? Math.round(thresholdData.greaterThan / data.length * 100) : 0;
+  thresholdData.lessThanEqualPercent = data ? 100 - thresholdData.greaterThanPercent : 0;
+  return thresholdData;
+};
+
+export const calculateRisk = (percentAbove: number) => {
+  const intVal = Math.floor(percentAbove);
+  const riskLevel: RiskLevel | undefined = RiskLevels.find((rl: RiskLevel) => {
+    return ((isNumber(rl.min) && (rl.min <= intVal)) && (isNumber(rl.max) && (rl.max >= intVal)));
+  });
+  return riskLevel;
+};

--- a/src/css/custom-leaflet-icons.css
+++ b/src/css/custom-leaflet-icons.css
@@ -11,7 +11,38 @@
     color: #666;
     z-index: 500 !important;
   }
-  
+
+  .diamond-container {
+    width: 40px !important;
+    height: 40px !important;
+    margin-top: -20px !important;
+    margin-left: -20px !important;
+    z-index: 500 !important;
+  }
+
+  .diamond-icon {
+    opacity: .75;
+    background: #C4C4C4;
+    width: 40px !important;
+    height: 40px !important;
+    transform: rotate(45deg);
+    text-align: center;
+    border: solid 2px #979797;
+    border-radius: 4px;
+  }
+  .diamond-icon.selected {
+    border: 4px solid #3578F4;
+  }
+  .diamond-text {
+    width: 40px !important;
+    height: 40px !important;
+    transform: rotate(-45deg);
+    font-size: 38px;
+    font-weight: bold;
+    color: white;
+    line-height: 38px;
+  }
+
   .div-icon {
     height: 0px;
   }

--- a/src/css/custom-leaflet-icons.css
+++ b/src/css/custom-leaflet-icons.css
@@ -15,8 +15,8 @@
   .diamond-container {
     width: 40px !important;
     height: 40px !important;
-    margin-top: -20px !important;
-    margin-left: -20px !important;
+    margin-top: -24px !important;
+    margin-left: -24px !important;
     z-index: 500 !important;
   }
 


### PR DESCRIPTION
When selected on the monte carlo tab, add a risk warning icon (displayed as a divIcon inside of a leaflet marker) for each item from the samples collection and display a risk level key.  Notes:
- at present all samples collections are shown and risk is computed with the default threshold of 201.  These values eventually need to come from the blocks.
- some useful functions and constants were moved to `monte-carlo.ts` as they need to be accessed from multiple locations