### PR TITLE
Use user-defined threshold from block when displaying histogram

### DIFF
--- a/src/blockly-blocks/block-graph-data.js
+++ b/src/blockly-blocks/block-graph-data.js
@@ -101,7 +101,7 @@ Blockly.Blocks['graph_exceedance'] = {
 }
 Blockly.JavaScript['graph_exceedance'] = function (block) {
   var location = block.getFieldValue('locations')
-  var threshold = block.getFieldValue('threshold') || 0
+  var threshold = Blockly.JavaScript.valueToCode(block, 'threshold', Blockly.JavaScript.ORDER_ATOMIC) || 0;
 
   var code = `graphExceedance({location: "${location}", threshold: ${threshold}});\n`
   return code

--- a/src/components/montecarlo/histogram-panel.tsx
+++ b/src/components/montecarlo/histogram-panel.tsx
@@ -5,8 +5,7 @@ import { BaseComponent, IBaseProps } from "../base";
 import { HorizontalContainer, VerticalContainer } from "../styled-containers";
 import { SvgD3HistogramChart } from "../charts/svg-d3-histogram-chart";
 import { ChartType } from "../../stores/charts-store";
-import { kTephraThreshold, kTephraMin, kTephraMax, ThresholdData,
-         calculateThresholdData, calculateRisk } from "./monte-carlo";
+import { kTephraMin, kTephraMax, ThresholdData, calculateThresholdData, calculateRisk } from "./monte-carlo";
 
 interface PanelProps {
   height: number;
@@ -77,7 +76,7 @@ export class HistogramPanel extends BaseComponent<IProps, IState>{
     const {width, height, percentComplete} = this.props;
     const histogramChart = this.stores.chartsStore.charts.find(chart => chart.type === "histogram");
     const data = histogramChart && histogramChart.data;
-    const threshold = kTephraThreshold;
+    const threshold = histogramChart && histogramChart.threshold ? histogramChart.threshold : 0;
     const thresholdData: ThresholdData = calculateThresholdData(data, threshold);
     const riskLevel = calculateRisk(thresholdData.greaterThanPercent);
     return (

--- a/src/stores/charts-store.ts
+++ b/src/stores/charts-store.ts
@@ -22,6 +22,7 @@ const Chart = types.model("Chart", {
   xAxisLabel: types.maybe(types.string),
   yAxisLabel: types.maybe(types.string),
   dateLabelFormat: types.maybe(types.string),
+  threshold: types.maybe(types.number),
 })
 .views((self) => {
   const isDate = (column: 0|1) => {
@@ -159,6 +160,7 @@ const ChartsStore = types.model("Charts", {
       });
     }
     chart.data = samplesCollection.samples.toJS() as any;
+    chart.threshold = threshold;
 }
 }));
 


### PR DESCRIPTION
This PR takes the threshold defined on the graph excedence block, stores it in the chart store, and uses it to display the threshold line on the histogram.  If no threshold is defined on the excedence block, then 0 is used.  Previously we were always showing a threshold of 201 on the histogram.