### PR TITLE
171419964 risk block

### DIFF
--- a/src/assets/blockly-authoring/toolbox/full-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/full-toolbox.xml
@@ -40,6 +40,7 @@
     <block type="create_sample_collection"></block>
     <block type="add_to_sample_collection"></block>
     <block type="graph_exceedance"></block>
+    <block type="show_risk"></block>
   </category>
 
   <category name="Logic" colour="%{BKY_LOGIC_HUE}">

--- a/src/blockly-blocks/block-risk-level.js
+++ b/src/blockly-blocks/block-risk-level.js
@@ -1,0 +1,34 @@
+Blockly.Blocks['show_risk'] = {
+  init: function() {
+    this.appendDummyInput()
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("Show risk on graph for");
+    this.appendDummyInput()
+        .appendField("samples from")
+        .appendField(new Blockly.FieldDropdown(this.generateOptions), "locations");
+    this.appendValueInput("threshold")
+        .setCheck(null)
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("exceeding (mm)");
+    this.setPreviousStatement(true, null);
+    this.setNextStatement(true, null);
+    this.setColour(230);
+    this.setTooltip("");
+    this.setHelpUrl("");
+  },
+
+  generateOptions: function() {
+    if (Blockly.sampleCollections && Blockly.sampleCollections.length > 0) {
+      return Blockly.sampleCollections;
+    } else {
+      return [["<Create collection>",""]];
+    }
+  }
+}
+Blockly.JavaScript['show_risk'] = function (block) {
+  var location = block.getFieldValue('locations')
+  var threshold = Blockly.JavaScript.valueToCode(block, 'threshold', Blockly.JavaScript.ORDER_ATOMIC) || 0;
+
+  var code = `showRisk({location: "${location}", threshold: ${threshold}});\n`
+  return code
+}

--- a/src/blockly-blocks/block-risk-level.js
+++ b/src/blockly-blocks/block-risk-level.js
@@ -2,7 +2,7 @@ Blockly.Blocks['show_risk'] = {
   init: function() {
     this.appendDummyInput()
         .setAlign(Blockly.ALIGN_RIGHT)
-        .appendField("Show risk on graph for");
+        .appendField("Show risk on map for");
     this.appendDummyInput()
         .appendField("samples from")
         .appendField(new Blockly.FieldDropdown(this.generateOptions), "locations");

--- a/src/blockly-blocks/blocks.js
+++ b/src/blockly-blocks/blocks.js
@@ -27,3 +27,4 @@ import "../blockly-blocks/block-graph-data";
 import "../blockly-blocks/block-range";
 import "./block-create-add-to-sample-collection";
 import "./block-calculate-tephra-vei-wind";
+import "./block-risk-level";

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -185,6 +185,12 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
       chartsStore.addHistogram(samplesCollection, threshold, `Tephra Thickness at ${samplesCollection.name} (mm)`);
     });
 
+    /** ==== Risk level ==== */
+
+    addFunc("showRisk", (params: {location: string, threshold: number}) => {
+      samplesCollectionsStore.setSamplesCollectionRiskLevel(params.location, params.threshold);
+    });
+
     /** ==== Sample Collections ==== */
 
     addFunc("createSampleCollection", (params: {name: string, x: number, y: number}) => {

--- a/src/components/map/map-component.tsx
+++ b/src/components/map/map-component.tsx
@@ -22,7 +22,7 @@ import CompassComponent from "./map-compass";
 import TephraLegendComponent from "./map-tephra-legend";
 import RiskLegendComponent from "./map-risk-legend";
 import { SamplesCollectionModelType } from "../../stores/samples-collections-store";
-import { kTephraThreshold, ThresholdData, calculateThresholdData, calculateRisk } from "../montecarlo/monte-carlo";
+import { RiskLevels } from "../montecarlo/monte-carlo";
 
 interface WorkspaceProps {
   width: number;
@@ -328,14 +328,11 @@ export class MapComponent extends BaseComponent<IProps, IState>{
   }
 
   private getRiskItems = () => {
-    // TODO: this code adds a risk map item for every sample collection with threshold kTephraThreshold
-    // need to specify correct samples to add risk item and correct threshold
     const { samplesCollectionsStore } = this.stores;
     const { volcanoLat, volcanoLng } = this.stores.simulation;
     const riskItems: React.ReactElement[] = [];
     samplesCollectionsStore.samplesCollections.forEach( (samplesCollection: SamplesCollectionModelType, i) => {
-      const thresholdData: ThresholdData = calculateThresholdData(samplesCollection.samples, kTephraThreshold);
-      const riskLevel = calculateRisk(thresholdData.greaterThanPercent);
+      const riskLevel = RiskLevels.find((risk) => risk.type === samplesCollection.risk);
       const pos = LocalToLatLng({x: samplesCollection.x, y: samplesCollection.y}, L.latLng(volcanoLat, volcanoLng));
       riskLevel && riskItems.push(
         <Marker

--- a/src/components/map/map-risk-legend.tsx
+++ b/src/components/map/map-risk-legend.tsx
@@ -128,8 +128,8 @@ export default class RiskLegendComponent extends PureComponent<IProps, IState> {
                   </RiskDiamondText>
                 </RiskDiamond>
                 { isNumber(riskLevel.max) && isNumber(riskLevel.min)
-                  ? <RiskLabel>{`${riskLevel.level} (${riskLevel.min}-${riskLevel.max}%)`}</RiskLabel>
-                  : <RiskLabel>{riskLevel.level}</RiskLabel>
+                  ? <RiskLabel>{`${riskLevel.type} (${riskLevel.min}-${riskLevel.max}%)`}</RiskLabel>
+                  : <RiskLabel>{riskLevel.type}</RiskLabel>
                 }
               </RiskContainer>
             );

--- a/src/components/map/map-risk-legend.tsx
+++ b/src/components/map/map-risk-legend.tsx
@@ -4,7 +4,7 @@ import styled from "styled-components";
 import { Icon } from "../icon";
 import CloseIcon from "../../assets/map-icons/close.svg";
 import { isNumber } from "util";
-import { RiskLevels, RiskLevel } from "../montecarlo/monte-carlo";
+import { RiskLevels } from "../montecarlo/monte-carlo";
 
 const LegendContainer = styled.div`
   display: flex;

--- a/src/components/montecarlo/histogram-panel.tsx
+++ b/src/components/montecarlo/histogram-panel.tsx
@@ -101,7 +101,7 @@ export class HistogramPanel extends BaseComponent<IProps, IState>{
             </PanelStat>
             <PanelStat>
               {`Risk: ${data && riskLevel && (!percentComplete || percentComplete === 100)
-                        ? riskLevel.level
+                        ? riskLevel
                         : "---"}`}
             </PanelStat>
           </VerticalContainer>

--- a/src/components/montecarlo/monte-carlo.ts
+++ b/src/components/montecarlo/monte-carlo.ts
@@ -1,8 +1,7 @@
 import { isNumber } from "util";
 import { RiskLevelType } from "../../stores/samples-collections-store";
 
-// TODO threshold and histogram min/max will need to be set elsewhere
-export const kTephraThreshold = 201;
+// TODO histogram min/max ideally set elsewhere
 export const kTephraMin = 0;
 export const kTephraMax = 400;
 

--- a/src/components/montecarlo/monte-carlo.ts
+++ b/src/components/montecarlo/monte-carlo.ts
@@ -1,4 +1,5 @@
 import { isNumber } from "util";
+import { RiskLevelType } from "../../stores/samples-collections-store";
 
 // TODO threshold and histogram min/max will need to be set elsewhere
 export const kTephraThreshold = 201;
@@ -12,7 +13,7 @@ export interface ThresholdData {
   lessThanEqualPercent: number;
 }
 export interface RiskLevel {
-  level: string;
+  type: RiskLevelType;
   iconColor: string;
   iconText: string;
   min: number | undefined;
@@ -20,28 +21,28 @@ export interface RiskLevel {
 }
 export const RiskLevels: RiskLevel[] = [
   {
-    level: "Undefined",
+    type: "Undefined",
     iconColor: "#C4C4C4",
     iconText: "",
     min: undefined,
     max: undefined
   },
   {
-    level: "Low",
+    type: "Low",
     iconColor: "#63CC19",
     iconText: "",
     min: 0,
     max: 30
   },
   {
-    level: "Medium",
+    type: "Medium",
     iconColor: "#ECA519",
     iconText: "!",
     min: 31,
     max: 79
   },
   {
-    level: "High",
+    type: "High",
     iconColor: "#FF1919",
     iconText: "!",
     min: 80,
@@ -71,5 +72,5 @@ export const calculateRisk = (percentAbove: number) => {
   const riskLevel: RiskLevel | undefined = RiskLevels.find((rl: RiskLevel) => {
     return ((isNumber(rl.min) && (rl.min <= intVal)) && (isNumber(rl.max) && (rl.max >= intVal)));
   });
-  return riskLevel;
+  return riskLevel && riskLevel.type;
 };


### PR DESCRIPTION
This PR adds a new "show risk" blockly block that allows a user to specify if the risk level for a given sample will be displayed on the monte carlo tab map with a user-defined threshold.  

One note, the risk level is added as an optional property on the `SamplesCollection`.  We could go an alternate route and create a new store that just holds risk levels, but this seemed like overkill and could create some linkage issues if samples collections are reset, deleted, etc.  