### PR TITLE
Change risk text color

### DIFF
--- a/src/components/map/map-risk-legend.tsx
+++ b/src/components/map/map-risk-legend.tsx
@@ -67,7 +67,7 @@ const RiskContainer = styled.div`
 interface RiskDiamondProps {
   backgroundColor?: string;
 }
-const RiskDiamond = styled.div`
+export const RiskDiamond = styled.div`
   width: 24px;
   height: 24px;
   box-sizing: border-box;
@@ -78,7 +78,7 @@ const RiskDiamond = styled.div`
   border: 2px solid #A1A1A1;
   border-radius: 4px;
 `;
-const RiskDiamondText = styled.div`
+export const RiskDiamondText = styled.div`
   width: 24px;
   height: 24px;
   transform: rotate(-45deg);

--- a/src/components/montecarlo/histogram-panel.tsx
+++ b/src/components/montecarlo/histogram-panel.tsx
@@ -5,7 +5,7 @@ import { BaseComponent, IBaseProps } from "../base";
 import { HorizontalContainer, VerticalContainer } from "../styled-containers";
 import { SvgD3HistogramChart } from "../charts/svg-d3-histogram-chart";
 import { ChartType } from "../../stores/charts-store";
-import { kTephraMin, kTephraMax, ThresholdData, calculateThresholdData, calculateRisk } from "./monte-carlo";
+import { kTephraMin, kTephraMax, ThresholdData, calculateThresholdData, calculateRisk, RiskLevel, RiskLevels } from "./monte-carlo";
 
 interface PanelProps {
   height: number;
@@ -68,7 +68,9 @@ export class HistogramPanel extends BaseComponent<IProps, IState>{
     const data = histogramChart && histogramChart.data;
     const threshold = histogramChart && histogramChart.threshold ? histogramChart.threshold : 0;
     const thresholdData: ThresholdData = calculateThresholdData(data, threshold);
-    const riskLevel = calculateRisk(thresholdData.greaterThanPercent);
+    const riskLevelType = calculateRisk(thresholdData.greaterThanPercent);
+    const riskLevel: RiskLevel | undefined = RiskLevels.find((risk) => risk.type === riskLevelType);
+    const riskStyle = riskLevel && {color: riskLevel.iconColor};
     return (
       <Panel height={height} width={width}>
         <HorizontalContainer>
@@ -100,9 +102,11 @@ export class HistogramPanel extends BaseComponent<IProps, IState>{
               {`Count above threshold: ${thresholdData.greaterThan} (${thresholdData.greaterThanPercent}%)`}
             </PanelStat>
             <PanelStat>
-              {`Risk: ${data && riskLevel && (!percentComplete || percentComplete === 100)
-                        ? riskLevel
-                        : "---"}`}
+              {"Risk: "}
+              {data && riskLevelType && (!percentComplete || percentComplete === 100)
+                ? <span style={riskStyle}>{riskLevelType}</span>
+                : "---"
+              }
             </PanelStat>
           </VerticalContainer>
         </HorizontalContainer>

--- a/src/components/montecarlo/histogram-panel.tsx
+++ b/src/components/montecarlo/histogram-panel.tsx
@@ -6,6 +6,7 @@ import { HorizontalContainer, VerticalContainer } from "../styled-containers";
 import { SvgD3HistogramChart } from "../charts/svg-d3-histogram-chart";
 import { ChartType } from "../../stores/charts-store";
 import { kTephraMin, kTephraMax, ThresholdData, calculateThresholdData, calculateRisk, RiskLevel, RiskLevels } from "./monte-carlo";
+import { RiskDiamond, RiskDiamondText } from "../map/map-risk-legend";
 
 interface PanelProps {
   height: number;
@@ -23,9 +24,16 @@ const PanelHistogramDiv = styled.div`
   min-width: ${(p: PanelProps) => `${p.width}px`};
   height: ${(p: PanelProps) => `${p.height}px`};
 `;
+interface PanelStatProps {
+  marginRight?: number;
+}
 const PanelStat = styled.div`
   margin: 5px;
   font-size: 14px;
+  margin-right: ${(p: PanelStatProps) => `${p.marginRight ? p.marginRight : 5}px`};
+`;
+const RiskContainer = styled(HorizontalContainer)`
+  margin-top: 15px;
 `;
 const PanelPercent = styled.div`
   height: 15px;
@@ -101,13 +109,22 @@ export class HistogramPanel extends BaseComponent<IProps, IState>{
             <PanelStat>
               {`Count above threshold: ${thresholdData.greaterThan} (${thresholdData.greaterThanPercent}%)`}
             </PanelStat>
-            <PanelStat>
-              {"Risk: "}
-              {data && riskLevelType && (!percentComplete || percentComplete === 100)
-                ? <span style={riskStyle}>{riskLevelType}</span>
-                : "---"
+            <RiskContainer>
+              <PanelStat marginRight={10}>
+                {"Risk:"}
+                {data && riskLevelType && (!percentComplete || percentComplete === 100)
+                  ? <span style={riskStyle}>{` ${riskLevelType}`}</span>
+                  : " ---"
+                }
+              </PanelStat>
+              {data && riskLevel &&
+                <RiskDiamond backgroundColor={riskLevel.iconColor}>
+                  <RiskDiamondText>
+                    {riskLevel.iconText}
+                  </RiskDiamondText>
+                </RiskDiamond>
               }
-            </PanelStat>
+            </RiskContainer>
           </VerticalContainer>
         </HorizontalContainer>
       </Panel>


### PR DESCRIPTION
This PR colors the risk text on the histogram panel using the same color system (green, yellow, red) used on the risk level warnings placed on the map and in the legend.  It also adds the same diamond risk icon seen on the map to the histogram panel.