### PR TITLE
Add fast speed and speed slider

### DIFF
--- a/src/assets/blockly-authoring/code/monte-carlo.xml
+++ b/src/assets/blockly-authoring/code/monte-carlo.xml
@@ -1,0 +1,44 @@
+<xml xmlns="http://www.w3.org/1999/xhtml">
+   <block type="create_sample_collection" id="]c@!uM_F8Yw]Fa_LMS{9" x="120" y="50">
+      <field name="name">Close-by</field>
+      <field name="x">30</field>
+      <field name="y">30</field>
+      <next>
+         <block type="controls_repeat_ext" id="R?F$YDIm5Bb.1LUW`)+L">
+            <value name="TIMES">
+               <shadow type="math_number" id="W]yjMlTa3D`qB!GXlz`:">
+                  <field name="NUM">200</field>
+               </shadow>
+            </value>
+            <statement name="DO">
+               <block type="add_to_sample_collection" id="YMU1B}QLdE?j8=-OE2sv">
+                  <field name="collections">Close-by</field>
+                  <value name="tephra sample">
+                     <block type="calculate_tephra_vei_wind" id="`8h~{fOeN1UCF~^k$15g">
+                        <field name="collections">Close-by</field>
+                        <value name="vei">
+                           <block type="math_number" id="tOhdDtSe|~T7nk!OPFir">
+                              <field name="NUM">6</field>
+                           </block>
+                        </value>
+                        <value name="wind samples">
+                           <block type="all_wind_data" id="k*`?E[@Rp2K[dc%z~Dc_" />
+                        </value>
+                     </block>
+                  </value>
+                  <next>
+                     <block type="graph_exceedance" id="yYniI4@KIx*fK6Kwx/|P">
+                        <field name="locations">Close-by</field>
+                        <value name="threshold">
+                           <block type="math_number" id="lw$y+)7Pn$yXM?=-zrg!">
+                              <field name="NUM">200</field>
+                           </block>
+                        </value>
+                     </block>
+                  </next>
+               </block>
+            </statement>
+         </block>
+      </next>
+   </block>
+</xml>

--- a/src/assets/blockly-authoring/index.json
+++ b/src/assets/blockly-authoring/index.json
@@ -9,6 +9,7 @@
   },
   "code": {
     "Basic": "./assets/blockly-authoring/code/basic-setup.xml",
-    "Nested loops": "./assets/blockly-authoring/code/nested-loops.xml"
+    "Nested loops": "./assets/blockly-authoring/code/nested-loops.xml",
+    "Monte Carlo": "./assets/blockly-authoring/code/monte-carlo.xml"
   }
 }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -25,6 +25,7 @@ import { getAuthorableSettings, updateStores, serializeState, getSavableState, d
 import { ChartPanel } from "./charts/chart-panel";
 import { BlocklyController } from "../blockly/blockly-controller";
 import { HistogramPanel } from "./montecarlo/histogram-panel";
+import { uiStore } from "../stores/ui-store";
 
 interface IProps extends IBaseProps {}
 
@@ -171,6 +172,8 @@ export class AppComponent extends BaseComponent<IProps, IState> {
         showCrossSection,
         showData,
         showMonteCarlo,
+        showSpeedControls,
+        speed,
       }
     } = this.stores;
     const {
@@ -230,6 +233,8 @@ export class AppComponent extends BaseComponent<IProps, IState> {
 
     const currentTabType = enabledTabTypes[tabIndex || 0];
     const currentRightTabType = enabledRightTabTypes[rightTabIndex || 0];
+
+    const setSpeed = (_speed: number) => uiStore.setSpeed(_speed);
 
     return (
       <App className="app" ref={this.rootComponent}>
@@ -295,7 +300,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                     initialCode={initialXmlCode}
                     initialCodePath={codePath}
                     setBlocklyCode={setCode} />
-                  <RunButtons {...{run, stop, step, reset, running}} />
+                  <RunButtons {...{run, stop, step, reset, running, showSpeedControls, speed, setSpeed}} />
                   { showLog &&
                     <LogComponent
                       width={logWidth}

--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -52,6 +52,8 @@ const AuthoringMenu: React.SFC<IProps> = (props) => {
             <DatBoolean path="uiStore.showVEI" label="Show VEI?" key="showVEI" />
           </DatFolder>,
 
+          <DatBoolean path="uiStore.showSpeedControls" label="Show Speed Controls?" key="showSpeedControls" />,
+
           <DatBoolean path="uiStore.showLog" label="Show Log?" key="showLog" />,
 
           <DatBoolean path="uiStore.showDemoCharts" label="Show Demo Charts?" key="showDemoCharts" />,

--- a/src/components/buttons/run-buttons.tsx
+++ b/src/components/buttons/run-buttons.tsx
@@ -5,6 +5,7 @@ import StopIcon from "../../assets/blockly-icons/stop.svg";
 import ResetIcon from "../../assets/blockly-icons/reset.svg";
 import StepIcon from "../../assets/blockly-icons/step.svg";
 import IconButton from "./icon-button";
+import RangeControl from "../range-control";
 
 interface IProps {
   run: () => void;
@@ -12,6 +13,9 @@ interface IProps {
   step: () => void;
   reset: () => void;
   running?: boolean;
+  showSpeedControls?: boolean;
+  speed?: number;
+  setSpeed?: (speed: number) => void;
 }
 
 interface IState {}
@@ -96,11 +100,36 @@ const ResetButton = (props: IProps) => {
   );
 };
 
+const SpeedSliderContainer = styled.div`
+  margin: 0 50px 0 -100px;
+`;
+
+const SpeedSlider = (props: IProps) => {
+  const { speed, setSpeed } = props;
+  return (
+    <SpeedSliderContainer>
+      <RangeControl
+        min={0}
+        max={3}
+        value={speed!}
+        step={1}
+        tickMap={{0: "Slow", 3: "Fast"}}
+        width={100}
+        onChange={setSpeed!}
+      />
+    </SpeedSliderContainer>
+  );
+};
+
 export default class RunButtons extends React.Component<IProps, IState> {
   public render() {
-    const { running } = this.props;
+    const { running, showSpeedControls, speed, setSpeed } = this.props;
     return (
       <ButtonContainer>
+        {
+          showSpeedControls &&
+          <SpeedSlider {...this.props} />
+        }
         { running
           ? <StopButton   {...this.props} />
           : <RunButton  {...this.props} />

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -57,6 +57,7 @@ const uiAuthorSettingsProps = tuple(
   "showCrossSection",
   "showMonteCarlo",
   "showData",
+  "showSpeedControls",
   "showLog",
   "showDemoCharts",
 );

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -13,6 +13,7 @@ const UIStore = types.model("UI", {
   showMonteCarlo: true,
   showData: true,
   // other ui
+  speed: 0,       // 0-3 (for now)
   showLog: false,
   // slider controls
   showWindSpeed: true,

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -13,6 +13,7 @@ const UIStore = types.model("UI", {
   showMonteCarlo: true,
   showData: true,
   // other ui
+  showSpeedControls: false,
   speed: 0,       // 0-3 (for now)
   showLog: false,
   // slider controls
@@ -35,6 +36,17 @@ const UIStore = types.model("UI", {
       Object.keys(data).forEach((key: UIAuthorSettingsProps) => {
         self[key] = data[key];
       });
+
+      // if author is showing fast speed, set model to fast initially
+      if (self.showSpeedControls) {
+        self.speed = 2;
+      } else {
+        self.speed = 0;
+      }
+    },
+
+    setSpeed: (speed: number) => {
+      self.speed = speed;
     },
   };
 });


### PR DESCRIPTION
This adds a speed slider which can run the model much faster, while still showing the highlighting of the blocks (just flickering at the highest speeds) and the graphs/map update.

The top speed is about the fastest I was able to get it to go on my machine while still allowing the highlighting and React to update in real time.

To show the speed controls, check the box near the bottom of the authoring panel. We may eventually decide not to have all four options, but instead just two or three, but this is added so it can be tried out by the team.

I added an example Monte Carlo model in the Initial Code dropdown. On my machine, running the model for 200 steps takes:

````
Speed  |   Time
  0        4:30
  1        0:58
  2        0:20
  3        0:08
````
While for only 200 steps, the fastest speed seems too fast, for >1000 steps it seems rather more reasonable.