### PR TITLE
remove undefined from risk legend and risk options

### DIFF
--- a/src/components/map/map-risk-legend.tsx
+++ b/src/components/map/map-risk-legend.tsx
@@ -16,7 +16,7 @@ const LegendContainer = styled.div`
   top: 35px;
   right: 38px;
   width: 165px;
-  height: 230px;
+  height: 190px;
   border-radius: 5px;
   background-color: white;
   border: solid 2px white;

--- a/src/components/montecarlo/monte-carlo.ts
+++ b/src/components/montecarlo/monte-carlo.ts
@@ -20,13 +20,6 @@ export interface RiskLevel {
 }
 export const RiskLevels: RiskLevel[] = [
   {
-    type: "Undefined",
-    iconColor: "#C4C4C4",
-    iconText: "",
-    min: undefined,
-    max: undefined
-  },
-  {
     type: "Low",
     iconColor: "#63CC19",
     iconText: "",


### PR DESCRIPTION
Remove the undefined risk option from the risk legend. This is no longer used as we no longer have the concept of an unfinished/in-progress dataset.