### PR TITLE
Hide the threshold histogram on the data panel

### DIFF
--- a/src/components/charts/chart-panel.tsx
+++ b/src/components/charts/chart-panel.tsx
@@ -73,6 +73,7 @@ export class ChartPanel extends BaseComponent<IProps, IState> {
           <Scroll>
             {
               this.stores.chartsStore.charts.map((chart, i) =>
+                chart.type !== "histogram" ?
                 <div key={"row" + i}>
                   {
                     chart.title &&
@@ -100,6 +101,7 @@ export class ChartPanel extends BaseComponent<IProps, IState> {
                     }
                   </Row>
                 </div>
+                : null
               )
             }
             <Row ref={this.lastScrollEl} />


### PR DESCRIPTION
Might be worth discussion, but for now it seems appropriate to hide the threshold histogram charts when displaying charts on the data panel.