### PR TITLE
Store current histogram tab and highlight risk icon on map

### DIFF
--- a/src/components/map/map-component.tsx
+++ b/src/components/map/map-component.tsx
@@ -331,13 +331,17 @@ export class MapComponent extends BaseComponent<IProps, IState>{
     const { samplesCollectionsStore } = this.stores;
     const { volcanoLat, volcanoLng } = this.stores.simulation;
     const riskItems: React.ReactElement[] = [];
+    const tabIndex = this.stores.uiStore.currentHistogramTab;
+    const histogramCharts = this.stores.chartsStore.charts.filter(chart => chart.type === "histogram");
+    const currentChart = histogramCharts && histogramCharts[tabIndex];
+    const chartName = currentChart && currentChart.title ? currentChart.title : undefined;
     samplesCollectionsStore.samplesCollections.forEach( (samplesCollection: SamplesCollectionModelType, i) => {
       const riskLevel = RiskLevels.find((risk) => risk.type === samplesCollection.risk);
       const pos = LocalToLatLng({x: samplesCollection.x, y: samplesCollection.y}, L.latLng(volcanoLat, volcanoLng));
       riskLevel && riskItems.push(
         <Marker
           position={[pos.lat, pos.lng]}
-          icon={riskIcon(riskLevel.iconColor, riskLevel.iconText, true)}
+          icon={riskIcon(riskLevel.iconColor, riskLevel.iconText, chartName === samplesCollection.name)}
           key={"risk-" + i}
         />
       );

--- a/src/components/montecarlo/histogram-panel.tsx
+++ b/src/components/montecarlo/histogram-panel.tsx
@@ -129,11 +129,13 @@ export class HistogramPanel extends BaseComponent<IProps, IState>{
     const histogramCharts = this.stores.chartsStore.charts.filter(chart => chart.type === "histogram");
     if (this.state.tabIndex > 0 && histogramCharts && this.state.tabIndex > (histogramCharts.length - 1)) {
       this.setState({tabIndex: 0});
+      this.stores.uiStore.setCurrentHistogramTab(0);
     }
   }
 
   private handleTabSelect(tabIndex: number) {
     this.setState({tabIndex});
+    this.stores.uiStore.setCurrentHistogramTab(tabIndex);
   }
 
   private renderHistogramTab = (histogramChart: ChartType, i: number) => {

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -24,6 +24,7 @@ const UIStore = types.model("UI", {
   showVEI: true,
   // chart demo buttons
   showDemoCharts: false,
+  currentHistogramTab: 0,
 })
 .actions((self) => ({
   setShowOptionsDialog(show: boolean) {
@@ -47,6 +48,9 @@ const UIStore = types.model("UI", {
 
     setSpeed: (speed: number) => {
       self.speed = speed;
+    },
+    setCurrentHistogramTab: (tab: number) => {
+      self.currentHistogramTab = tab;
     },
   };
 });


### PR DESCRIPTION
This PR stores the current histogram tab in the UI store, and then uses this to determine the name of the active histogram and its corresponding samples collection.  This is then used to determine if the risk shown on the map for a given samples collection should receive the blue active border.

This could result in a few odd outlier cases since it relies on the samples collections having unique names (although I couldn't break it when I tested).  The current programming structure is somewhat flexible in what a user can do so there might be a path to create samples collections with duplicate names.  For now, however, I feel the is adequate.  In the future, the the entire blockly ecosystem might benefit from more warnings, errors, or rules that prevent users from doing odd or malicious things. 