### PR TITLE
Improvements to the threshold histogram graph

### DIFF
--- a/src/components/charts/svg-d3-histogram-chart.tsx
+++ b/src/components/charts/svg-d3-histogram-chart.tsx
@@ -48,10 +48,15 @@ export const SvgD3HistogramChart = (props: IProps) => {
   // And apply this function to data to get the bins
   // Add all the cases exceeding the max into the max's bin
   const bins = histogram((data as number[]).map(d => Math.min(d, xDomain[1] - 1)));
-  let max = 0;
+  let binMax = 0;
   bins.forEach(bin => {
-    max = Math.max(max, bin.length);
+    binMax = Math.max(binMax, bin.length);
   });
+  const radius = Math.min(chartWidth / numBins * .45, chartHeight / binMax * .45);
+  const max = chartHeight / binMax * .45 > chartWidth / numBins * .45
+              ? Math.floor(chartHeight / radius * .45)
+              : binMax;
+
   const yScale = d3.scaleLinear();
   yScale.range([chartHeight, 0]);
   yScale.domain([0, max]);
@@ -87,10 +92,10 @@ export const SvgD3HistogramChart = (props: IProps) => {
         .data(binMap)
         .enter()
         .append("circle")
-          .attr("cx", d => (xScale(binIndex) * (chartMax / numBins) + dotRadius) )
-          .attr("cy", d => (yScale(d) - 5) )
+          .attr("cx", d => (1 + xScale(binIndex) * (chartMax / numBins) + dotRadius) )
+          .attr("cy", d => (yScale(d) - dotRadius) )
           .attr("r", dotRadius)
-          .style("fill", "#797979");
+          .style("fill", "#448878");
     });
   } else {
     svg.selectAll("rect")
@@ -101,7 +106,7 @@ export const SvgD3HistogramChart = (props: IProps) => {
       .attr("transform", d => "translate(" + xScale(d.x0 as number) + "," + (yScale(d.length)) + ")")
       .attr("width", d => (Math.max(0, xScale(d.x1 as number) - xScale(d.x0 as number) - 1)))
       .attr("height", d => (chartHeight - yScale(d.length)))
-      .style("fill", "#797979");
+      .style("fill", "#448878");
   }
 
   const thresholdX = threshold / (chartMax - chartMin) * chartWidth;

--- a/src/components/charts/svg-d3-histogram-chart.tsx
+++ b/src/components/charts/svg-d3-histogram-chart.tsx
@@ -86,14 +86,14 @@ export const SvgD3HistogramChart = (props: IProps) => {
   }
   if (kShowDotPlot) {
     const dotRadius = Math.min(chartWidth / numBins * .45, chartHeight / max * .45);
-    bins.forEach((bin, binIndex) => {
+    bins.forEach((bin) => {
       const binMap = bin.map((x, i) => i);
       svg.append("g")
         .selectAll("dot")
         .data(binMap)
         .enter()
         .append("circle")
-          .attr("cx", d => (1 + xScale(binIndex) * (chartMax / numBins) + dotRadius) )
+          .attr("cx", d => (1 + xScale(bin.x0 as number) + dotRadius) )
           .attr("cy", d => (yScale(d) - dotRadius) )
           .attr("r", dotRadius)
           .style("fill", "#448878");

--- a/src/components/charts/svg-d3-histogram-chart.tsx
+++ b/src/components/charts/svg-d3-histogram-chart.tsx
@@ -45,13 +45,14 @@ export const SvgD3HistogramChart = (props: IProps) => {
     .domain([ xDomain[0], xDomain[1] ])
     .thresholds(xScale.ticks(numBins));
 
-  // And apply this function to data to get the bins
   // Add all the cases exceeding the max into the max's bin
   const bins = histogram((data as number[]).map(d => Math.min(d, xDomain[1] - 1)));
   let binMax = 0;
   bins.forEach(bin => {
     binMax = Math.max(binMax, bin.length);
   });
+  // if the binMax is small and will result in excess vertical space,
+  // increase the y max so dots will stack directly on top of one another
   const radius = Math.min(chartWidth / numBins * .45, chartHeight / binMax * .45);
   const max = chartHeight / binMax * .45 > chartWidth / numBins * .45
               ? Math.floor(chartHeight / radius * .45)

--- a/src/components/montecarlo/histogram-panel.tsx
+++ b/src/components/montecarlo/histogram-panel.tsx
@@ -6,7 +6,7 @@ import { HorizontalContainer, VerticalContainer } from "../styled-containers";
 import { SvgD3HistogramChart } from "../charts/svg-d3-histogram-chart";
 import { ChartType } from "../../stores/charts-store";
 import { RiskDiamond, RiskDiamondText } from "../map/map-risk-legend";
-import { kTephraMin, kTephraMax, ThresholdData, calculateThresholdData, calculateRisk, RiskLevel, RiskLevels } from "./monte-carlo";
+import { ThresholdData, calculateThresholdData, calculateRisk, RiskLevel, RiskLevels } from "./monte-carlo";
 import { Tab, HistogramTabs, TabList, TabPanel } from "../tabs";
 
 interface PanelProps {
@@ -211,8 +211,8 @@ export class HistogramPanel extends BaseComponent<IProps, IState>{
         width={width - 200}
         height={height - 40}
         chart={chart}
-        chartMin={kTephraMin}
-        chartMax={kTephraMax}
+        chartMin={0}
+        chartMax={threshold * 2}
         threshold={threshold}
       />
     );

--- a/src/components/montecarlo/monte-carlo.ts
+++ b/src/components/montecarlo/monte-carlo.ts
@@ -1,10 +1,6 @@
 import { isNumber } from "util";
 import { RiskLevelType } from "../../stores/samples-collections-store";
 
-// TODO histogram min/max ideally set elsewhere
-export const kTephraMin = 0;
-export const kTephraMax = 400;
-
 export interface ThresholdData {
   greaterThan: number;
   lessThanEqual: number;


### PR DESCRIPTION
This PR makes the following improvements to the threshold histogram plot:
- x axis maximum value is double the threshold
- improve y positions of dots by setting setting a higher y axis max when we have a small number of dots (previously in these cases the dots would have large vertical spacing between them instead of being drawn directly stacked on one another due to the y axis max)
- improve y positions of dots by using dot radius (rather than constant) to compute position offset from x axis line
- add small, single pixel x offset to dots so they can be more clearly distinguished from y axis line when dots are very small 
- update color to match other graphs and make dots more visible