### PR TITLE
Force blockly svg resize if container is resized.

### DIFF
--- a/src/components/blockly-container.tsx
+++ b/src/components/blockly-container.tsx
@@ -13,7 +13,10 @@ interface IProps {
   height: number;
 }
 
-interface IState {}
+interface IState {
+  containerWidth: number;
+  containerHeight: number;
+}
 
 const Wrapper = styled.div`
   flex: 1 1 auto;
@@ -35,6 +38,14 @@ export default class BlocklyContainer extends React.Component<IProps, IState> {
   private workSpaceRef = React.createRef<HTMLDivElement>();
   private startBlockRef = React.createRef<HTMLDivElement>();
 
+  constructor(props: IProps) {
+    super(props);
+    this.state = {
+      containerWidth: 0,
+      containerHeight: 0,
+    };
+  }
+
   public render() {
     const {width, height} = this.props;
     return (
@@ -55,6 +66,14 @@ export default class BlocklyContainer extends React.Component<IProps, IState> {
         prevProps.initialCode !== this.props.initialCode ||
         prevProps.initialCodePath !== this.props.initialCodePath) {
       this.setupBlockly();
+    }
+    if (this.workSpaceRef.current) {
+      const { offsetHeight, offsetWidth } = this.workSpaceRef.current;
+      if ((this.state.containerHeight !== offsetHeight || this.state.containerWidth !== offsetWidth) &&
+          (offsetHeight !== 0 && offsetWidth !== 0)) {
+        this.setState({ containerHeight: offsetHeight, containerWidth: offsetWidth });
+        Blockly.svgResize(this.workSpace);
+      }
     }
   }
 


### PR DESCRIPTION
This PR fixes two issues:
- window is resized when blockly tab is not showing. When user returns to blockly tab, blockly div has wrong dimensions (0x0) and does not display content
- in certain cases where the browser screen changes size (such as using fullscreen button, showing/hiding dev tools, maximizing browser, etc.), the blockly div has wrong dimensions and does not take up full container space.

To fix, we monitor the container div size.  If it changes, call `Blockly.svgResize` which resizes the blockly container div to fit our parent div.  The only side effect that I've seen so far is that we might lose the pan when switching tabs, resizing, and returning to the blockly tab.
 