### PR TITLE
Fix updating authoring state when menu changes

### DIFF
--- a/cypress/integration/branch/authoring.test.js
+++ b/cypress/integration/branch/authoring.test.js
@@ -60,13 +60,13 @@ context ('Authoring Options',()=>{
             leftPanel.getControlsTab().click();
             controlsTab.getEruptButton().click();
             //verify tephra is visible at a location south of volcano
-            map.getTephra().last().attribute('d').should('contain',"M326 407L331 412L339 412L352 428L352 461L343 471L343 525L331 541L313 541L301 525L301 471L292 461L292 428L305 412L313 412L322 401z")
+            map.getTephra().last().attribute('d').should('contain', "M361 277L361 374L339 401L313 401L301 385L301 353L309 342L309 320L318 309L318 299L326 288L326 277L331 272L356 272z")
 
             //change conditions to see tephra change without having to erupt again
             var slider="wind-direction", windDirection = 190;
             controlsTab.setSliderValue(slider,windDirection);
             //verify location has not changed north of volcano
-            map.getTephra().last().attribute('d').should('contain',"M326 407L331 412L339 412L352 428L352 461L343 471L343 525L331 541L313 541L301 525L301 471L292 461L292 428L305 412L313 412L322 401z")
+            map.getTephra().last().attribute('d').should('contain', "M361 277L361 374L339 401L313 401L301 385L301 353L309 342L309 320L318 309L318 299L326 288L326 277L331 272L356 272z")
 
             controlsTab.resetModel();//clean up
          })

--- a/package-lock.json
+++ b/package-lock.json
@@ -5310,9 +5310,9 @@
       "dev": true
     },
     "deepmerge": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.1.1.tgz",
-      "integrity": "sha512-+qO5WbNBKBaZez95TffdUDnGIo4+r5kmsX8aOb7PDHvXsTbghAmleuxjs6ytNaf5Eg4FGBXDS5vqO61TRi6BMg=="
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "default-gateway": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "color": "^3.1.0",
     "d3": "^5.15.0",
     "d3-contour": "^1.3.2",
+    "deepmerge": "^4.2.2",
     "iframe-phone": "^1.2.0",
     "immutable": "^3.8.2",
     "js-beautify": "^1.9.1",

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -1,5 +1,6 @@
 import { inject, observer } from "mobx-react";
 import * as React from "react";
+const deepmerge = require("deepmerge");
 import { BaseComponent, IBaseProps } from "./base";
 import { MapComponent, Scenario } from "./map/map-component";
 import { LogComponent } from "./log-component";
@@ -21,7 +22,8 @@ import WidgetPanel from "./widgets/widget-panel";
 import screenfull from "screenfull";
 import ResizeObserver from "react-resize-observer";
 import AuthoringMenu from "./authoring-menu";
-import { getAuthorableSettings, updateStores, serializeState, getSavableState, deserializeState, SerializedState } from "../stores/stores";
+import { getAuthorableSettings, updateStores, serializeState, getSavableState,
+         deserializeState, SerializedState, IStoreish } from "../stores/stores";
 import { ChartPanel } from "./charts/chart-panel";
 import { BlocklyController } from "../blockly/blockly-controller";
 import { HistogramPanel } from "./montecarlo/histogram-panel";
@@ -497,7 +499,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
               toggleShowOptions={this.toggleShowOptions}
               saveStateToLocalStorage={this.saveStateToLocalStorage}
               loadStateFromLocalStorage={this.loadStateFromLocalStorage}
-              handleUpdate={updateStores}
+              handleUpdate={this.updateAuthoring}
             />
           }
         </Row>
@@ -545,6 +547,19 @@ export class AppComponent extends BaseComponent<IProps, IState> {
 
   private handleRightTabSelect(rightTabIndex: number) {
     this.setState({rightTabIndex});
+  }
+
+  private updateAuthoring = (authorMenuState: IStoreish) => {
+    // first get the state from the entire app, including slider values etc
+    const localState = serializeState(getSavableState()).state;
+
+    // delete the initialXml code that was serialized, or we will never update the blocks when
+    // the author changes the initial code
+    delete localState.simulation.initialXmlCode;
+
+    // the the authored state from the authoring menu overwrites local state
+    const mergedState = deepmerge(localState, authorMenuState);
+    updateStores(mergedState);
   }
 
   private saveStateToLocalStorage = () => {


### PR DESCRIPTION
Previously, every time the authoring menu updated, we would load the application store with the properties from the authoring panel, and as a result we would throw all other state away.

This had the result (among other issues) that if an author updated a slider in the control panel and then hid the slider, the sliders would all reset to the initial values.

This fixes that problem by merging the current state of the application into the authoring panel props and loading the application from that merge.

[#169983751]