### PR TITLE
Wind direction fixes

### DIFF
--- a/src/assets/blockly-authoring/code/monte-carlo-3-locs.xml
+++ b/src/assets/blockly-authoring/code/monte-carlo-3-locs.xml
@@ -9,8 +9,8 @@
             <field name="locations">City A</field>
             <next>
                <block type="create_sample_location" id="J1O+99A^f[4roxtt6Xw#">
-                  <field name="x">15</field>
-                  <field name="y">15</field>
+                  <field name="x">-10</field>
+                  <field name="y">-10</field>
                   <field name="name">Close-by</field>
                   <next>
                      <block type="create_sample_collection" id="bQ_vJ+7zwNa-.NoOu#OF">
@@ -18,8 +18,8 @@
                         <field name="locations">Close-by</field>
                         <next>
                            <block type="create_sample_location" id="?3wxH?MpM02kliTUGX21">
-                              <field name="x">30</field>
-                              <field name="y">30</field>
+                              <field name="x">-20</field>
+                              <field name="y">-20</field>
                               <field name="name">Midtown</field>
                               <next>
                                  <block type="create_sample_collection" id="DJRU2{K^DrStv+@u.[CH">

--- a/src/blockly-blocks/block-wind-data.js
+++ b/src/blockly-blocks/block-wind-data.js
@@ -95,7 +95,10 @@ Blockly.JavaScript['filter_data'] = function (block) {
     if (filter[key] === "") {
       delete filter[key];
     } else if (!isNaN(parseFloat(filter[key]))) {
-      filter[key] = parseFloat(filter[key]);
+      // Wind data is stored using direction to, but we use direction from. Need to convert.
+      filter[key] = key === "direction"
+        ? parseFloat(filter[key]) < 180 ? parseFloat(filter[key]) + 180 : parseFloat(filter[key]) - 180
+        : parseFloat(filter[key]);
     }
   });
   let filterObj = JSON.stringify(filter);

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -123,8 +123,8 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
 
     // Returns tephra thickness at a specific location, given by a samples collection, with various inputs
     addFunc("computeTephra", (params: {location: string, windSamples?: Dataset, vei?: number}) => {
-      const { location, windSamples, vei } = params;
 
+      const { location, windSamples, vei } = params;
       if (vei === undefined) {
         blocklyController.throwError("You must set a value for the eruption VEI.");
         return;
@@ -146,6 +146,7 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
       if (windSamples && windSamples.length > 0) {
         const windSample = Datasets.getRandomSampleWithReplacement(windSamples, 1)[0];
         windSpeed = windSample.speed;
+        // Wind data is stored using direction to, but we use direction from. Need to convert.
         windDirection = windSample.direction < 180 ? windSample.direction + 180 : windSample.direction - 180;
       }
       simulation.setWindSpeed(windSpeed);
@@ -193,8 +194,11 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
         blocklyController.throwError("You must add a dataset for the wind sample.");
         return;
       }
+      // Wind data is stored using direction to, but we use direction from. Need to convert.
+      const sampleData = Datasets.getRandomSampleWithReplacement(dataset, 1)[0];
+      sampleData.direction = sampleData.direction < 180 ? sampleData.direction + 180 : sampleData.direction - 180;
       return {
-        data: Datasets.getRandomSampleWithReplacement(dataset, 1)[0]
+        data: sampleData
       };
     });
 

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -146,7 +146,7 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
       if (windSamples && windSamples.length > 0) {
         const windSample = Datasets.getRandomSampleWithReplacement(windSamples, 1)[0];
         windSpeed = windSample.speed;
-        windDirection = windSample.direction;
+        windDirection = windSample.direction < 180 ? windSample.direction + 180 : windSample.direction - 180;
       }
       simulation.setWindSpeed(windSpeed);
       simulation.setWindDirection(windDirection);


### PR DESCRIPTION
The sample wind data is stored using direction that the wind is blowing to, but we use the direction the wind is blowing from when sampling a value and using it in the blockly blocks.  This resulted in the following issues that have been fixed in this PRR:
-incorrect wind direction in monte carlo simulation
-incorrect wind direction on radial plot when using filter block
-incorrect wind direction when using "Compute and visualize tephra with random wind sample" and the "Compute and visualize tephra with random wind sample and VEI" blocks 