### PR TITLE
Add Latitude / Longitude measuring tool

### DIFF
--- a/cypress/support/elements/Map.js
+++ b/cypress/support/elements/Map.js
@@ -11,6 +11,9 @@ class Map {
     getRulerButton(){
         return cy.get('[data-test=Ruler-button]');
     }
+    getLatlngButton(){
+      return cy.get('[data-test=Latlng-button]');
+    }
     getKeyButton(){
         return cy.get('[data-test=Key-button]');
     }

--- a/src/components/icons.ts
+++ b/src/components/icons.ts
@@ -58,4 +58,12 @@ export function getCachedSampleLocationIcon(label: string) {
     return iconsCache.get(iconKey);
 }
 
+export function latLngIcon(label: string, anchorCorner: string = "top-left"): DivIcon {
+  const html = `<div class='latlng-icon-content ${anchorCorner}'>
+    <div class='content'>${label}</div>
+    <div class='handle'></div>
+  </div>`;
+  return new DivIcon({ className: "div-icon", html });
+}
+
 export { iconVolcano, iconMarker };

--- a/src/components/map/layers/latlng-draw-layer.tsx
+++ b/src/components/map/layers/latlng-draw-layer.tsx
@@ -1,0 +1,115 @@
+import { inject, observer } from "mobx-react";
+import Leaflet from "leaflet";
+import * as L from "leaflet";
+import * as React from "react";
+import { BaseComponent } from "../../base";
+import { getCachedCircleIcon } from "../../icons";
+import { LayerGroup, Marker, Polyline } from "react-leaflet";
+
+const MOUSE_DOWN = "mousedown touchstart";
+const MOUSE_MOVE = "mousemove touchmove";
+const MOUSE_UP = "mouseup touchend";
+
+interface IProps {
+  map: Leaflet.Map | null;
+  p1Lat: number;
+  p1Lng: number;
+  p2Lat: number;
+  p2Lng: number;
+}
+
+interface IState {}
+
+@inject("stores")
+@observer
+export class LatLngDrawLayer extends BaseComponent<IProps, IState> {
+  private _tempPoint1: Leaflet.LatLng;
+
+  constructor(props: IProps) {
+    super(props);
+    this.drawPoints = this.drawPoints.bind(this);
+    this.endDraw = this.endDraw.bind(this);
+    this.setPoint1 = this.setPoint1.bind(this);
+    this.setPoint2 = this.setPoint2.bind(this);
+  }
+
+  public componentDidMount() {
+    const { map } = this.props;
+    if (map !== null) {
+      map.dragging.disable();
+      map.on(MOUSE_DOWN, this.drawPoints);
+      map.on(MOUSE_UP, this.endDraw);
+    }
+  }
+
+  public componentWillUnmount() {
+    const { map } = this.props;
+    if (map !== null) {
+      map.dragging.enable();
+      map.off(MOUSE_DOWN, this.drawPoints);
+    }
+  }
+  public drawPoints(event: Leaflet.LeafletMouseEvent) {
+    const { map } = this.props;
+    const { latLngPoint1Lat } = this.stores.simulation;
+    if (map !== null) {
+      if (latLngPoint1Lat === 0) {
+        map.dragging.disable();
+        this.setPoint1(event);
+        this.setPoint2(event);
+        map.on(MOUSE_MOVE, this.setPoint2);
+      }
+      else {
+        this.setPoint2(event);
+        map.dragging.enable();
+        map.off(MOUSE_MOVE, this.setPoint2);
+      }
+    }
+  }
+  public endDraw() {
+    const { map } = this.props;
+    map.dragging.enable();
+  }
+  public setPoint1(event: Leaflet.LeafletEvent | null) {
+    const { map } = this.props;
+    if (event) {
+      map.dragging.disable();
+      const latLng = (event as Leaflet.LeafletMouseEvent).latlng;
+      this.stores.simulation.setLatLngP1(latLng.lat, latLng.lng);
+    }
+  }
+  public setPoint2(event: Leaflet.LeafletEvent | null) {
+    const { map } = this.props;
+    if (event) {
+      map.dragging.disable();
+      const latLng = (event as Leaflet.LeafletMouseEvent).latlng;
+      this.stores.simulation.setLatLngP2(latLng.lat, latLng.lng);
+    }
+  }
+
+  public render() {
+    const { map } = this.props;
+    const { p1Lat, p1Lng, p2Lat, p2Lng } = this.props;
+    const point1 = L.latLng(p1Lat, p1Lng);
+    const point2 = L.latLng(p2Lat, p2Lng);
+    const point1a = L.latLng(p1Lat, p2Lng);
+    const point2a = L.latLng(p2Lat, p1Lng);
+    const p1Icon = getCachedCircleIcon("P1");
+    const p2Icon = getCachedCircleIcon("P2");
+
+    return (
+      <LayerGroup map={map}>
+        {point1 && <Marker position={point1} draggable={true} icon={p1Icon} onLeafletDrag={this.setPoint1} />}
+        {point2 && <Marker position={point2} draggable={true} icon={p2Icon} onLeafletDrag={this.setPoint2} />}
+        {point1 && point2 &&
+          <Polyline
+            key={"lat-lng-line"}
+            clickable={false}
+            positions={[point1, point1a, point2, point2a, point1]}
+            color="#b263f7"
+            opacity={1}
+          />}
+      </LayerGroup>
+    );
+  }
+}

--- a/src/components/map/layers/latlng-draw-layer.tsx
+++ b/src/components/map/layers/latlng-draw-layer.tsx
@@ -3,7 +3,7 @@ import Leaflet from "leaflet";
 import * as L from "leaflet";
 import * as React from "react";
 import { BaseComponent } from "../../base";
-import { divIcon } from "../../icons";
+import { latLngIcon } from "../../icons";
 import { LayerGroup, Marker, Polyline } from "react-leaflet";
 
 const MOUSE_DOWN = "mousedown touchstart";
@@ -150,8 +150,16 @@ export class LatLngDrawLayer extends BaseComponent<IProps, IState> {
     const point2 = L.latLng(p2Lat, p2Lng);
     const point1a = L.latLng(p1Lat, p2Lng);
     const point2a = L.latLng(p2Lat, p1Lng);
-    const p1Icon = divIcon(`${p1Lat.toFixed(4)}, ${p1Lng.toFixed(4)}`);
-    const p2Icon = divIcon(`${p2Lat.toFixed(4)}, ${p2Lng.toFixed(4)}`);
+    // figure out which corner is in which location
+    const bounds = L.latLngBounds(point1, point2);
+    let flipped = false;
+    if (point1.lat === bounds.getNorthWest().lat && point1.lng === bounds.getNorthWest().lng) {
+      flipped = false;
+    } else {
+      flipped = true;
+    }
+    const p1Icon = latLngIcon(`Latitude: ${p1Lat.toFixed(2)}<br/>Longitude: ${p1Lng.toFixed(2)}`, flipped ? "top-left" : "bottom-right");
+    const p2Icon = latLngIcon(`Latitude: ${p2Lat.toFixed(2)}<br/>Longitude: ${p2Lng.toFixed(2)}`, flipped ? "bottom-right" : "top-left");
 
     return (
       <LayerGroup map={map}>

--- a/src/components/map/map-component.tsx
+++ b/src/components/map/map-component.tsx
@@ -210,13 +210,6 @@ export class MapComponent extends BaseComponent<IProps, IState>{
     const corner1 = L.latLng(topLeftLat, topLeftLng);
     const corner2 = L.latLng(bottomRightLat, bottomRightLng);
     const bounds = L.latLngBounds(corner1, corner2);
-    const currentLatLngMarker = (isSelectingLatlng && crossPoint1Lat !== 0 && crossPoint1Lng !== 0) ?
-      <Marker position={[crossPoint1Lat, crossPoint1Lng]} icon={getCachedCircleIcon("P1")} >
-        <Popup>
-          {`${crossPoint1Lat},${crossPoint1Lng}`}
-        </Popup>
-      </Marker> :
-      undefined;
     let viewportBounds = bounds;
     if (this.map.current) {
       viewportBounds = this.map.current.leafletElement.getBounds();
@@ -283,7 +276,6 @@ export class MapComponent extends BaseComponent<IProps, IState>{
             {pinItems}
             {riskItems}
             {sampleLocations}
-            {currentLatLngMarker}
             {isSelectingLatlng && <LatLngDrawLayer
               ref={this.latlngRef}
               map={this.state.mapLeafletRef}
@@ -292,7 +284,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
               p1Lng={latLngPoint1Lng}
               p2Lng={latLngPoint2Lng}
             /> }
-            { isSelectingCrossSection && <CrossSectionDrawLayer
+            {isSelectingCrossSection && <CrossSectionDrawLayer
               ref={this.crossRef}
               map={this.state.mapLeafletRef}
               p1Lat={crossPoint1Lat}

--- a/src/components/map/map-component.tsx
+++ b/src/components/map/map-component.tsx
@@ -156,7 +156,10 @@ export class MapComponent extends BaseComponent<IProps, IState>{
 
     const {
       isSelectingCrossSection,
-      isSelectingRuler
+      isSelectingRuler,
+      isSelectingLatlng,
+      currentLat,
+      currentLng
     } = this.stores.simulation;
 
     const cityItems = cities.map( (city: CityType) => {
@@ -202,6 +205,13 @@ export class MapComponent extends BaseComponent<IProps, IState>{
     const corner1 = L.latLng(topLeftLat, topLeftLng);
     const corner2 = L.latLng(bottomRightLat, bottomRightLng);
     const bounds = L.latLngBounds(corner1, corner2);
+    const currentLatLngMarker = (isSelectingLatlng && currentLat !== 0 && currentLng !== 0) ?
+      <Marker position={[currentLat, currentLng]} icon={iconVolcano} >
+        <Popup>
+          {`${currentLat},${currentLng}`}
+        </Popup>
+      </Marker> :
+      undefined;
     let viewportBounds = bounds;
     if (this.map.current) {
       viewportBounds = this.map.current.leafletElement.getBounds();
@@ -215,6 +225,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
         <LeafletMap
           className="map"
           ref={this.map}
+          onclick={this.onMapClick}
           ondragend={this.reRenderMap}
           onzoomend={this.reRenderMap}
           center={[volcanoLat, volcanoLng]}
@@ -267,6 +278,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
             {pinItems}
             {riskItems}
             {sampleLocations}
+            {currentLatLngMarker}
             { isSelectingCrossSection && <CrossSectionDrawLayer
               ref={this.crossRef}
               map={this.state.mapLeafletRef}
@@ -283,6 +295,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
         <OverlayControls
           showRuler={isSelectingRuler}
           onRulerClick={this.stores.simulation.rulerClick}
+          onLatLngClick={this.stores.simulation.latlngClick}
           isSelectingCrossSection={isSelectingCrossSection}
           showCrossSection={hasErupted && showCrossSection && panelType === RightSectionTypes.CROSS_SECTION}
           onCrossSectionClick={this.stores.simulation.crossSectionClick}
@@ -315,6 +328,13 @@ export class MapComponent extends BaseComponent<IProps, IState>{
 
       this.map.current.leafletElement.flyTo(L.latLng(volcanoLat, volcanoLng), initialZoom);
     }
+  }
+  private onMapClick = (e: any) => {
+    const { simulation } = this.stores;
+    if (this.stores.simulation.isSelectingLatlng) {
+      console.log(e.latlng);
+      simulation.setLatLng(e.latlng.lat, e.latlng.lng);
+    } else return;
   }
 
   private reRenderMap = () => {

--- a/src/components/overlay-controls.tsx
+++ b/src/components/overlay-controls.tsx
@@ -11,6 +11,7 @@ interface IProps {
     onRulerClick: () => void;
     onLatLngClick: () => void;
     isSelectingCrossSection: boolean;
+    isSelectingLatLng: boolean;
     showCrossSection: boolean;
     onCrossSectionClick: () => void;
     onReCenterClick: () => void;
@@ -26,12 +27,16 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
             onRulerClick,
             onLatLngClick,
             isSelectingCrossSection,
+            isSelectingLatLng,
             showCrossSection,
             onCrossSectionClick,
             onReCenterClick} = this.props;
         const { hasErupted } = this.stores.simulation;
 
         const rulerColor = showRuler ? kRightTabInfo[RightSectionTypes.CONDITIONS].hoverBackgroundColor : "white";
+        const selectingLatLngColor = isSelectingLatLng
+                               ? kRightTabInfo[RightSectionTypes.CROSS_SECTION].hoverBackgroundColor
+                               : "white";
         const selectingColor = isSelectingCrossSection
                                ? kRightTabInfo[RightSectionTypes.CROSS_SECTION].hoverBackgroundColor
                                : "white";
@@ -65,8 +70,8 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
                     <IconButton
                         onClick={onLatLngClick}
                         disabled={false}
-                        label={"LatLng"}
-                        backgroundColor={rulerColor}
+                        label={"Lat-Long"}
+                        backgroundColor={selectingLatLngColor}
                         hoverColor={kRightTabInfo[RightSectionTypes.CONDITIONS].hoverBackgroundColor}
                         activeColor={kRightTabInfo[RightSectionTypes.CONDITIONS].backgroundColor}
                         fill={"black"}

--- a/src/components/overlay-controls.tsx
+++ b/src/components/overlay-controls.tsx
@@ -9,6 +9,7 @@ import { BaseComponent } from "./base";
 interface IProps {
     showRuler: boolean;
     onRulerClick: () => void;
+    onLatLngClick: () => void;
     isSelectingCrossSection: boolean;
     showCrossSection: boolean;
     onCrossSectionClick: () => void;
@@ -23,6 +24,7 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
     public render() {
         const { showRuler,
             onRulerClick,
+            onLatLngClick,
             isSelectingCrossSection,
             showCrossSection,
             onCrossSectionClick,
@@ -59,6 +61,18 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
                         width={26}
                         height={26}
                         dataTest={"Ruler-button"}
+                    />
+                    <IconButton
+                        onClick={onLatLngClick}
+                        disabled={false}
+                        label={"LatLng"}
+                        backgroundColor={rulerColor}
+                        hoverColor={kRightTabInfo[RightSectionTypes.CONDITIONS].hoverBackgroundColor}
+                        activeColor={kRightTabInfo[RightSectionTypes.CONDITIONS].backgroundColor}
+                        fill={"black"}
+                        width={26}
+                        height={26}
+                        dataTest={"Latlng-button"}
                     />
                 </div>
                 <div className="controls bottom right">

--- a/src/css/custom-leaflet-icons.css
+++ b/src/css/custom-leaflet-icons.css
@@ -82,6 +82,36 @@
     border: 1px solid #444;
   }
 
+  .latlng-icon-content {
+    background: #fff;
+    width: max-content !important;
+    height: max-content !important;
+    margin-top: 2px !important;
+    margin-left: 5px !important;
+    padding: 2px !important;
+    border-radius: 0px;
+    box-shadow: 0 0 7px rgba(0,0,0,0.55);
+    text-align: left;
+    line-height: 18px;
+    color: #666;
+    z-index: 200 !important;
+    position: relative;
+  }
+  .latlng-icon-content .content{
+    width: 100%;
+    height: 100%;
+    background-color: white;
+  }
+  .latlng-icon-content .handle{
+    width: 6px;
+    height: 6px;
+    position: absolute;
+    background-color: white;
+    border: 2px solid #999;
+    border-radius: 4px;
+  }
+
+
   .top-left {
     transform: translate(0%, 0%);
   }
@@ -116,4 +146,24 @@
 
   .center-center {
     transform: translate(-50%, -50%);
+  }
+
+  .top-left .handle{
+    top: -2px;
+    left: -4px;
+  }
+
+  .top-right .handle{
+    top: -2px;
+    right: -4px;
+  }
+
+  .bottom-left .handle{
+    bottom: -8px;
+    left: -6px;
+  }
+
+  .bottom-right .handle{
+    bottom: -8px;
+    right: -6px;
   }

--- a/src/stores/simulation-store.test.ts
+++ b/src/stores/simulation-store.test.ts
@@ -61,4 +61,22 @@ describe("simulation-store", () => {
       expect(simulation.stagingVei).toBe(5);
     });
   });
+  describe("overlay controls", () => {
+    it("can switch between standard, ruler, cross-section and lat/long tools", () => {
+      simulation.rulerClick();
+      expect(simulation.isSelectingRuler).toBe(true);
+      expect(simulation.isSelectingCrossSection).toBe(false);
+      expect(simulation.isSelectingLatlng).toBe(false);
+
+      simulation.crossSectionClick();
+      expect(simulation.isSelectingRuler).toBe(false);
+      expect(simulation.isSelectingCrossSection).toBe(true);
+      expect(simulation.isSelectingLatlng).toBe(false);
+
+      simulation.latlngClick();
+      expect(simulation.isSelectingRuler).toBe(false);
+      expect(simulation.isSelectingCrossSection).toBe(false);
+      expect(simulation.isSelectingLatlng).toBe(true);
+    });
+  });
 });

--- a/src/stores/simulation-store.ts
+++ b/src/stores/simulation-store.ts
@@ -119,8 +119,10 @@ export const SimulationStore = types
     isSelectingRuler: false,
     isSelectingCrossSection: false,
     isSelectingLatlng: false,
-    currentLat: 0,
-    currentLng: 0,
+    latLngPoint1Lat: 0,
+    latLngPoint1Lng: 0,
+    latLngPoint2Lat: 0,
+    latLngPoint2Lng: 0,
     // authoring props
     requireEruption: true,
     requirePainting: true,
@@ -160,13 +162,17 @@ export const SimulationStore = types
     rulerClick() {
       self.isSelectingRuler = !self.isSelectingRuler;
       self.isSelectingCrossSection = false;
+      self.isSelectingLatlng = false;
     },
     latlngClick() {
       self.isSelectingLatlng = !self.isSelectingLatlng;
+      self.isSelectingRuler = false;
+      self.isSelectingCrossSection = false;
     },
     crossSectionClick() {
       self.isSelectingCrossSection = !self.isSelectingCrossSection;
       self.isSelectingRuler = false;
+      self.isSelectingLatlng = false;
     },
     setIsSelectingRuler(val: boolean) {
       self.isSelectingRuler = val;
@@ -187,9 +193,13 @@ export const SimulationStore = types
       self.viewportCenterLat = viewportCenterLat;
       self.viewportCenterLng = viewportCenterLng;
     },
-    setLatLng(lat: number, lng: number) {
-      self.currentLat = lat;
-      self.currentLng = lng;
+    setLatLngP1(lat: number, lng: number) {
+      self.latLngPoint1Lat = lat;
+      self.latLngPoint1Lng = lng;
+    },
+    setLatLngP2(lat: number, lng: number) {
+      self.latLngPoint2Lat = lat;
+      self.latLngPoint2Lng = lng;
     },
     reset() {
       self.hasErupted = false;

--- a/src/stores/simulation-store.ts
+++ b/src/stores/simulation-store.ts
@@ -168,6 +168,13 @@ export const SimulationStore = types
       self.isSelectingLatlng = !self.isSelectingLatlng;
       self.isSelectingRuler = false;
       self.isSelectingCrossSection = false;
+      if (!self.isSelectingLatlng) {
+        // clear original points
+        self.latLngPoint1Lat = 0;
+        self.latLngPoint1Lng = 0;
+        self.latLngPoint2Lat = 0;
+        self.latLngPoint2Lng = 0;
+      }
     },
     crossSectionClick() {
       self.isSelectingCrossSection = !self.isSelectingCrossSection;

--- a/src/stores/simulation-store.ts
+++ b/src/stores/simulation-store.ts
@@ -118,6 +118,9 @@ export const SimulationStore = types
     hasErupted: false,
     isSelectingRuler: false,
     isSelectingCrossSection: false,
+    isSelectingLatlng: false,
+    currentLat: 0,
+    currentLng: 0,
     // authoring props
     requireEruption: true,
     requirePainting: true,
@@ -158,6 +161,9 @@ export const SimulationStore = types
       self.isSelectingRuler = !self.isSelectingRuler;
       self.isSelectingCrossSection = false;
     },
+    latlngClick() {
+      self.isSelectingLatlng = !self.isSelectingLatlng;
+    },
     crossSectionClick() {
       self.isSelectingCrossSection = !self.isSelectingCrossSection;
       self.isSelectingRuler = false;
@@ -180,6 +186,10 @@ export const SimulationStore = types
       self.viewportZoom = zoom;
       self.viewportCenterLat = viewportCenterLat;
       self.viewportCenterLng = viewportCenterLng;
+    },
+    setLatLng(lat: number, lng: number) {
+      self.currentLat = lat;
+      self.currentLng = lng;
     },
     reset() {
       self.hasErupted = false;


### PR DESCRIPTION
Latitude / Longitude tool now added as a button to the map, the points are created with two clicks / taps and should work on mouse or on touch screen devices.
Lat/lng marker text will flip to display outside of the box if you drag one point over / beyond the other.
Coordinates are rounded to two decimal places