### PR TITLE
Setup seismic model

### DIFF
--- a/cypress/integration/branch/authoring.test.js
+++ b/cypress/integration/branch/authoring.test.js
@@ -31,6 +31,11 @@ beforeEach(()=>{
 context ('Authoring Options',()=>{
     before(() => {
         cy.visit("");
+        // show controls and code tabs
+        modelOptions.getModelOptionsMenu().click();
+        modelOptions.getShowControlsOption().click();
+        modelOptions.getShowCodeOption().click();
+        modelOptions.getModelOptionsMenu().click();
       });
     describe('Model Option panel visibility',()=>{
         it('verify Options Menu panel shows',()=>{
@@ -660,7 +665,7 @@ context ('Authoring Options',()=>{
                 controlsTab.getWindSpeedDirectionContainer().find('[data-test="info"]>div>div').should('have.length',3)
                 conditionsTab.getWindSpeedDirectionWidget().should('be.visible')
             })
-            it('verify ejected volume slider shows again',()=>{    
+            it('verify ejected volume slider shows again',()=>{
                 modelOptions.getShowEjectedVolumeOption().click();
                 modelOptions.getShowEjectedVolumeOption().should('be.checked')
                 controlsTab.getEjectedVolumeSlider().should('be.visible')
@@ -676,7 +681,7 @@ context ('Authoring Options',()=>{
                 controlsTab.getVEIContainer().find('[data-test="info"]').should('be.visible')
                 conditionsTab.getVEIWidget().should('be.visible')
             })
-            it('verify column height slider shows again',()=>{    
+            it('verify column height slider shows again',()=>{
                 modelOptions.getShowColumnHeightOption().click();
                 modelOptions.getShowColumnHeightOption().should('be.checked')
                 controlsTab.getColumnHeightSlider().should('be.visible')

--- a/cypress/integration/branch/condition-panel.test.js
+++ b/cypress/integration/branch/condition-panel.test.js
@@ -1,9 +1,11 @@
+import ModelOptions from "../../support/elements/ModelOptionPanel";
 import LeftPanel from "../../support/elements/LeftPanel"
 import ControlsTab from "../../support/elements/ControlsTab"
 import RightPanel from "../../support/elements/RightPanel";
 import ConditionsTab from "../../support/elements/ConditionsTab"
 import Map from "../../support/elements/Map"
 
+const modelOptions = new ModelOptions;
 const leftPanel = new LeftPanel;
 const controlsTab = new ControlsTab;
 const rightPanel = new RightPanel;
@@ -19,9 +21,14 @@ context("Controls panel", () => {
     var evSlider="ejected-volume", volume = '2', evHeight='17.5';
     var chSlider="column-height", cHeight = '15', visualHeight='28.8';
 
-
     before(() => {
       cy.visit("");
+
+      // show controls tab
+      modelOptions.getModelOptionsMenu().click();
+      modelOptions.getShowControlsOption().click();
+      modelOptions.getModelOptionsMenu().click();
+
       leftPanel.getControlsTab().should('be.visible').click();
       controlsTab.setSliderValue(wsSlider,windSpeed);
       controlsTab.setSliderValue(wdSlider,windDirection);

--- a/cypress/integration/branch/control-panel.test.js
+++ b/cypress/integration/branch/control-panel.test.js
@@ -1,6 +1,8 @@
+import ModelOptions from "../../support/elements/ModelOptionPanel";
 import LeftPanel from "../../support/elements/LeftPanel"
 import ControlsTab from "../../support/elements/ControlsTab"
 
+const modelOptions = new ModelOptions;
 const leftPanel = new LeftPanel;
 const controlsTab = new ControlsTab;
 beforeEach(()=>{
@@ -9,38 +11,43 @@ beforeEach(()=>{
 context("Controls panel", () => {
     before(() => {
       cy.visit("");
+      // show controls tab
+      modelOptions.getModelOptionsMenu().click();
+      modelOptions.getShowControlsOption().click();
+      modelOptions.getModelOptionsMenu().click();
+
       leftPanel.getControlsTab().should('be.visible').click();
     });
     describe('slider/widget tests',()=>{
         it('verify wind speed slider',()=>{
             var slider='wind-speed', windSpeed = 19;
             controlsTab.setSliderValue(slider,windSpeed);
-            controlsTab.getWindSpeedDirectionContainer().find('[data-test=info]').should('contain',windSpeed +' m/s')    
+            controlsTab.getWindSpeedDirectionContainer().find('[data-test=info]').should('contain',windSpeed +' m/s')
         })
         it('verify wind direction slider',()=>{
             var slider="wind-direction", windDirection = 190;
             controlsTab.setSliderValue(slider,windDirection);
-            controlsTab.getWindSpeedDirectionContainer().find('[data-test=info]').should('contain',windDirection)    
+            controlsTab.getWindSpeedDirectionContainer().find('[data-test=info]').should('contain',windDirection)
             controlsTab.getWindSymbol().parent().parent().should('have.attr','rotate',windDirection.toString())
         })
         it('verify ejected volumne slider',()=>{
             var slider="ejected-volume", volume = '2', height='17.5';
             controlsTab.setSliderValue(slider,volume);
-            controlsTab.getEjectedVolumeContainer().find('[data-test=info]').should('contain',volume)    
+            controlsTab.getEjectedVolumeContainer().find('[data-test=info]').should('contain',volume)
             controlsTab.getEjectedVolumeHeightVisual().siblings('div').should('have.attr','height',height, {multiple:true})
         })
         it('verify column height slider',()=>{
             var slider="column-height", height = '15', visualHeight='28.8';
             controlsTab.setSliderValue(slider, height)
-            controlsTab.getColumnHeightContainer().find('[data-test=info]').should('contain',height)    
+            controlsTab.getColumnHeightContainer().find('[data-test=info]').should('contain',height)
             controlsTab.getColumnHeightVisual().should('have.attr','height',visualHeight)
         })
-        it('verify VEI slider',()=>{ 
+        it('verify VEI slider',()=>{
             var slider='vei', sliderValue=-0.1, value='1';
             controlsTab.setSliderValue(slider,sliderValue)
             cy.get('@veiMap').then((veiMap)=>{
                 cy.log(veiMap.map[value-1].type)
-                controlsTab.getVEIContainer().find('[data-test=info] div:nth-of-type(2)').should('contain',veiMap.map[value-1].value+': '+veiMap.map[value-1].type)    
+                controlsTab.getVEIContainer().find('[data-test=info] div:nth-of-type(2)').should('contain',veiMap.map[value-1].value+': '+veiMap.map[value-1].type)
             })
             controlsTab.getVEIContainer().find('[data-test=info] svg').should('have.attr','data-name','VEI '+value+" - orange")
         })
@@ -49,7 +56,7 @@ context("Controls panel", () => {
             controlsTab.setSliderValue('ejected-volume',3)
             cy.get('@veiMap').then((veiMap)=>{
                 cy.log(veiMap.map[expectedVEI-1].type)
-                controlsTab.getVEIContainer().find('[data-test=info] div:nth-of-type(2)').should('contain',veiMap.map[expectedVEI-1].value+': '+veiMap.map[expectedVEI-1].type)    
+                controlsTab.getVEIContainer().find('[data-test=info] div:nth-of-type(2)').should('contain',veiMap.map[expectedVEI-1].value+': '+veiMap.map[expectedVEI-1].type)
             })
             controlsTab.getVEIContainer().find('[data-test=info] svg').should('have.attr','data-name','VEI '+expectedVEI+" - orange")
         })
@@ -58,7 +65,7 @@ context("Controls panel", () => {
             controlsTab.setSliderValue('column-height',20)
             cy.get('@veiMap').then((veiMap)=>{
                 cy.log(veiMap.map[expectedVEI-1].type)
-                controlsTab.getVEIContainer().find('[data-test=info] div:nth-of-type(2)').should('contain',veiMap.map[expectedVEI-1].value+': '+veiMap.map[expectedVEI-1].type)    
+                controlsTab.getVEIContainer().find('[data-test=info] div:nth-of-type(2)').should('contain',veiMap.map[expectedVEI-1].value+': '+veiMap.map[expectedVEI-1].type)
             })
             controlsTab.getVEIContainer().find('[data-test=info] svg').should('have.attr','data-name','VEI '+expectedVEI+" - orange")
         })
@@ -67,11 +74,11 @@ context("Controls panel", () => {
             controlsTab.setSliderValue('vei',vei)
             cy.get('@veiMap').then((veiMap)=>{
                 cy.log("column: "+veiMap.map[vei-1].column+" ejected volume: "+veiMap.map[vei-1].ejectedVolume)
-                controlsTab.getVEIContainer().find('[data-test=info] div:nth-of-type(2)').should('contain',veiMap.map[vei-1].value+': '+veiMap.map[vei-1].type) 
-                controlsTab.getColumnHeightContainer().find('[data-test=info]').should('contain',veiMap.map[vei-1].column) 
-                controlsTab.getEjectedVolumeContainer().find('[data-test=info]').should('contain',veiMap.map[vei-1].ejectedVolume)       
+                controlsTab.getVEIContainer().find('[data-test=info] div:nth-of-type(2)').should('contain',veiMap.map[vei-1].value+': '+veiMap.map[vei-1].type)
+                controlsTab.getColumnHeightContainer().find('[data-test=info]').should('contain',veiMap.map[vei-1].column)
+                controlsTab.getEjectedVolumeContainer().find('[data-test=info]').should('contain',veiMap.map[vei-1].ejectedVolume)
             })
             controlsTab.getVEIContainer().find('[data-test=info] svg').should('have.attr','data-name','VEI '+vei+" - orange")
         })
     })
-})    
+})

--- a/cypress/integration/branch/data-blocks-code.test.js
+++ b/cypress/integration/branch/data-blocks-code.test.js
@@ -1,7 +1,9 @@
+import ModelOptions from "../../support/elements/ModelOptionPanel";
 import BlocksTab from "../../support/elements/BlocksTab";
 import CodeTab from "../../support/elements/CodeTab";
 import LeftPanel from "../../support/elements/LeftPanel";
 
+const modelOptions = new ModelOptions;
 const leftPanel = new LeftPanel;
 const blocksTab = new BlocksTab;
 const codeTab = new CodeTab;
@@ -10,6 +12,11 @@ const DataRegEx = /Data$/gm;        // regex to ignore "Data Samples"
 
 before(() => {
     cy.visit("");
+    // show code tab
+    modelOptions.getModelOptionsMenu().click();
+    modelOptions.getShowCodeOption().click();
+    modelOptions.getModelOptionsMenu().click();
+
     leftPanel.getBlocksTab().should('be.visible').click();
   });
 

--- a/cypress/integration/smoke/code-panel-ui.test.js
+++ b/cypress/integration/smoke/code-panel-ui.test.js
@@ -1,15 +1,21 @@
+import ModelOptions from "../../support/elements/ModelOptionPanel";
 import LeftPanel from "../../support/elements/LeftPanel"
 import CodeTab from "../../support/elements/CodeTab"
 
+const modelOptions = new ModelOptions;
 const leftPanel = new LeftPanel;
 const codeTab = new CodeTab;
 
 context("Code panel", () => {
     before(() => {
       cy.visit("");
+      modelOptions.getModelOptionsMenu().click();
+      modelOptions.getShowCodeOption().click();
+      modelOptions.getModelOptionsMenu().click();
+
       leftPanel.getCodeTab().should('be.visible').click();
     });
-  
+
     describe("Code panel ui", () => {
       it('verify Code tab shows correct elements',()=>{
         codeTab.getCodePanel().should('be.visible');

--- a/cypress/integration/smoke/controls-panel-ui.test.js
+++ b/cypress/integration/smoke/controls-panel-ui.test.js
@@ -1,15 +1,21 @@
+import ModelOptions from "../../support/elements/ModelOptionPanel";
 import LeftPanel from "../../support/elements/LeftPanel"
 import ControlsTab from "../../support/elements/ControlsTab"
 
+const modelOptions = new ModelOptions;
 const leftPanel = new LeftPanel;
 const controlsTab = new ControlsTab;
 
 context("Controls panel", () => {
     before(() => {
       cy.visit("");
+      modelOptions.getModelOptionsMenu().click();
+      modelOptions.getShowControlsOption().click();
+      modelOptions.getModelOptionsMenu().click();
+
       leftPanel.getControlsTab().should('be.visible').click();
     });
-  
+
     describe("Controls panel ui", () => {
       it('verify Controls tab shows correct elements',()=>{
         controlsTab.getControlsPanel().should('be.visible');

--- a/cypress/integration/smoke/workspace-ui.test.js
+++ b/cypress/integration/smoke/workspace-ui.test.js
@@ -12,8 +12,8 @@ context("Test app workspace", () => {
   describe("left side workspace", () => {
     it("verify correct tabs are visible", () => {
         leftPanel.getBlocksTab().should('be.visible');
-        leftPanel.getCodeTab().should('be.visible');
-        leftPanel.getControlsTab().should('be.visible');
+        leftPanel.getCodeTab().should('not.be.visible');
+        leftPanel.getControlsTab().should('not.be.visible');
         rightPanel.getConditionsTab().should('be.visible');
         rightPanel.getMonteCarloTab().should('be.visible');
         rightPanel.getDataTab().should('be.visible')

--- a/package-lock.json
+++ b/package-lock.json
@@ -6780,22 +6780,6 @@
         }
       }
     },
-    "css-tree": {
-      "version": "1.0.0-alpha.33",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.33.tgz",
-      "integrity": "sha512-SPt57bh5nQnpsTBsx/IXbO14sRc9xXu5MtMAVuo0BaQQmyf0NupNPPSoMaqiAF5tDFafYsTkfeH4Q/HCKXkg4w==",
-      "requires": {
-        "mdn-data": "2.0.4",
-        "source-map": "^0.5.3"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-        }
-      }
-    },
     "css-vendor": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.7.tgz",

--- a/src/blockly/blockly-controller.ts
+++ b/src/blockly/blockly-controller.ts
@@ -33,7 +33,7 @@ export class BlocklyController {
     this.workspace = workspace;
     this.interpreterController = makeInterpreterController(code, this, this.stores, workspace);
 
-    this.stores.simulation.setBlocklyCode(code, workspace);
+    this.stores.tephraSimulation.setBlocklyCode(code, workspace);
     this.parseVariables();
   }
 
@@ -51,7 +51,7 @@ export class BlocklyController {
 
   public reset = () => {
     this.setCode(this.code, this.workspace);
-    this.stores.simulation.reset();
+    this.stores.tephraSimulation.reset();
     this.stores.chartsStore.reset();
     this.stores.samplesCollectionsStore.reset();
   }

--- a/src/blockly/blockly-controller.ts
+++ b/src/blockly/blockly-controller.ts
@@ -33,7 +33,7 @@ export class BlocklyController {
     this.workspace = workspace;
     this.interpreterController = makeInterpreterController(code, this, this.stores, workspace);
 
-    this.stores.tephraSimulation.setBlocklyCode(code, workspace);
+    this.stores.blocklyStore.setBlocklyCode(code, workspace);
     this.parseVariables();
   }
 

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -1,6 +1,6 @@
-import { IModelParams, SimOutput, SimulationVariable, SimulationStore } from "../stores/simulation-store";
+import { ITephraModelParams, SimOutput, SimulationVariable, TephraSimulationStore } from "../stores/tephra-simulation-store";
 import { BlocklyController } from "./blockly-controller";
-import { SimulationModelType } from "../stores/simulation-store";
+import { TephraSimulationModelType } from "../stores/tephra-simulation-store";
 import { IBlocklyWorkspace } from "../interfaces";
 import { IStore } from "../stores/stores";
 import { Datasets, Dataset, Filter } from "../stores/data-sets";
@@ -9,7 +9,7 @@ const Interpreter = require("js-interpreter");
 const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore,
                              workspace: IBlocklyWorkspace) => {
 
-  const { simulation, chartsStore, samplesCollectionsStore } = store;
+  const { tephraSimulation, chartsStore, samplesCollectionsStore } = store;
 
   return (interpreter: any, scope: any) => {
     const addVar = (name: string, value: any) => {
@@ -48,15 +48,15 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
 
     /** ==== Tephra simulation model setters ==== */
 
-    addFunc("setModelParams", (params: IModelParams) => {
-      simulation.setModelParams(params);
+    addFunc("setModelParams", (params: ITephraModelParams) => {
+      tephraSimulation.setModelParams(params);
     });
     addFunc("setWindDirection", (direction: number) => {
       if (direction === undefined) {
         blocklyController.throwError("You must set a value for the wind direction.");
         return;
       }
-      simulation.setWindDirection(direction);
+      tephraSimulation.setWindDirection(direction);
     });
 
     addFunc("setWindspeed", (speed: number) => {
@@ -64,13 +64,13 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
         blocklyController.throwError("You must set a value for the wind speed.");
         return;
       }
-      simulation.setWindSpeed(speed);
+      tephraSimulation.setWindSpeed(speed);
     });
 
     addFunc("setWindspeedAndDirection", (windSample?: any) => {
       if (windSample) {
-        simulation.setWindSpeed(windSample.speed);
-        simulation.setWindDirection(windSample.direction);
+        tephraSimulation.setWindSpeed(windSample.speed);
+        tephraSimulation.setWindDirection(windSample.direction);
       } else {
         blocklyController.throwError("You must add a dataset for the wind sample.");
         return;
@@ -82,7 +82,7 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
         blocklyController.throwError("You must set a value for the eruption mass.");
         return;
       }
-      simulation.setMass(mass);
+      tephraSimulation.setMass(mass);
     });
 
     addFunc("setVolume", (volume: number) => {
@@ -92,7 +92,7 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
       }
       // +9 km^3 to m^3, +3 m^3 to kg
       const massInKilograms = volume * Math.pow(10, 9 + 3);
-      simulation.setMass(massInKilograms);
+      tephraSimulation.setMass(massInKilograms);
     });
 
     addFunc("setVEI", (vei: number) => {
@@ -100,7 +100,7 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
         blocklyController.throwError("You must set a value for the eruption VEI.");
         return;
       }
-      simulation.setVEI(vei);
+      tephraSimulation.setVEI(vei);
     });
 
     addFunc("setColumnHeight", (height: number) => {
@@ -108,17 +108,17 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
         blocklyController.throwError("You must set a value for the eruption column height.");
         return;
       }
-      simulation.setColumnHeight(height);
+      tephraSimulation.setColumnHeight(height);
     });
 
     addFunc("setVolcano", (params: {x: number, y: number}) => {
-      simulation.setVolcano(params.x, params.y);
+      tephraSimulation.setVolcano(params.x, params.y);
     });
 
     /** ==== Run tephra simulation model ==== */
 
     addFunc("erupt", () => {
-      simulation.erupt();
+      tephraSimulation.erupt();
     });
 
     // Returns tephra thickness at a specific location, given by a samples collection, with various inputs
@@ -149,11 +149,11 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
         // Wind data is stored using direction to, but we use direction from. Need to convert.
         windDirection = windSample.direction < 180 ? windSample.direction + 180 : windSample.direction - 180;
       }
-      simulation.setWindSpeed(windSpeed);
-      simulation.setWindDirection(windDirection);
-      simulation.setVEI(VEI);
+      tephraSimulation.setWindSpeed(windSpeed);
+      tephraSimulation.setWindDirection(windDirection);
+      tephraSimulation.setVEI(VEI);
 
-      const thickness = simulation.calculateTephraAtLocation(samplesLocation.x, samplesLocation.y);
+      const thickness = tephraSimulation.calculateTephraAtLocation(samplesLocation.x, samplesLocation.y);
 
       return {
         data: thickness
@@ -163,11 +163,11 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
     /** ==== Draw on tephra map ==== */
 
     addFunc("paintMap", () => {
-      simulation.paintMap();
+      tephraSimulation.paintMap();
     });
 
     addFunc("addCity", (params: {x: number, y: number, name: string}) => {
-      simulation.addCity(params.x, params.y, params.name);
+      tephraSimulation.addCity(params.x, params.y, params.name);
     });
 
     /** ==== Data and graphing ==== */
@@ -284,12 +284,12 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
 
     addFunc("logInfo", (params: any) => {
       if (params) {
-        simulation.logInfo(params);
+        tephraSimulation.logInfo(params);
       }
     });
 
     addFunc("stringConcat", (params: {lv: any, rv: any}) => {
-      return simulation.stringConcat(params.lv, params.rv);
+      return tephraSimulation.stringConcat(params.lv, params.rv);
     });
 
     /** ==== Used under the hood to control highlighting and stepping ==== */

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -157,7 +157,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
 
   public render() {
     const {
-      simulation: {
+      tephraSimulation: {
         clearLog,
         initialXmlCode,
         initialCodeTitle,
@@ -211,7 +211,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     const blocklyHeight = Math.floor(height - 90 - (showLog ? logHeight : 0));
     const scenarioData = (Scenarios as {[key: string]: Scenario})[scenario];
 
-    this.stores.simulation.setVolcano(scenarioData.volcanoLat, scenarioData.volcanoLng);
+    this.stores.tephraSimulation.setVolcano(scenarioData.volcanoLat, scenarioData.volcanoLng);
 
     kTabInfo.blocks.index = showBlocks ? 0 : -1;
     kTabInfo.code.index = showCode ? kTabInfo.blocks.index + 1 : -1;
@@ -557,7 +557,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
 
     // delete the initialXml code that was serialized, or we will never update the blocks when
     // the author changes the initial code
-    delete localState.simulation.initialXmlCode;
+    delete localState.tephraSimulation.initialXmlCode;
 
     // the the authored state from the authoring menu overwrites local state
     const mergedState = deepmerge(localState, authorMenuState);

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -159,10 +159,12 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     const {
       tephraSimulation: {
         clearLog,
+        scenario
+      },
+      blocklyStore: {
         initialXmlCode,
         initialCodeTitle,
         toolbox,
-        scenario
       },
       uiStore: {
         showOptionsDialog,
@@ -557,7 +559,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
 
     // delete the initialXml code that was serialized, or we will never update the blocks when
     // the author changes the initial code
-    delete localState.tephraSimulation.initialXmlCode;
+    delete localState.blocklyStore.initialXmlCode;
 
     // the the authored state from the authoring menu overwrites local state
     const mergedState = deepmerge(localState, authorMenuState);

--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -22,13 +22,13 @@ const AuthoringMenu: React.SFC<IProps> = (props) => {
       <DatButton label="Model options" onClick={props.toggleShowOptions}/>
       { props.expandOptionsDialog &&
         [
-          <DatBoolean path="simulation.requireEruption" label="Require eruption?" key="requireEruption" />,
-          <DatBoolean path="simulation.requirePainting" label="Require painting?" key="requirePainting" />,
-          <DatSelect path="simulation.scenario" label="Map Scenario"
+          <DatBoolean path="tephraSimulation.requireEruption" label="Require eruption?" key="requireEruption" />,
+          <DatBoolean path="tephraSimulation.requirePainting" label="Require painting?" key="requirePainting" />,
+          <DatSelect path="tephraSimulation.scenario" label="Map Scenario"
             options={Object.keys(Scenarios)} key="background" />,
-          <DatSelect path="simulation.toolbox" label="Code toolbox"
+          <DatSelect path="tephraSimulation.toolbox" label="Code toolbox"
             options={Object.keys(BlocklyAuthoring.toolbox)} key="toolbox" />,
-          <DatSelect path="simulation.initialCodeTitle" label="Initial code"
+          <DatSelect path="tephraSimulation.initialCodeTitle" label="Initial code"
             options={Object.keys(BlocklyAuthoring.code)} key="code" />,
 
           <DatFolder title="Left Tabs" key="leftTabsFolder" closed={false}>

--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -26,9 +26,9 @@ const AuthoringMenu: React.SFC<IProps> = (props) => {
           <DatBoolean path="tephraSimulation.requirePainting" label="Require painting?" key="requirePainting" />,
           <DatSelect path="tephraSimulation.scenario" label="Map Scenario"
             options={Object.keys(Scenarios)} key="background" />,
-          <DatSelect path="tephraSimulation.toolbox" label="Code toolbox"
+          <DatSelect path="blocklyStore.toolbox" label="Code toolbox"
             options={Object.keys(BlocklyAuthoring.toolbox)} key="toolbox" />,
-          <DatSelect path="tephraSimulation.initialCodeTitle" label="Initial code"
+          <DatSelect path="blocklyStore.initialCodeTitle" label="Initial code"
             options={Object.keys(BlocklyAuthoring.code)} key="code" />,
 
           <DatFolder title="Left Tabs" key="leftTabsFolder" closed={false}>

--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -21,6 +21,10 @@ const AuthoringMenu: React.SFC<IProps> = (props) => {
     <DatGui data={props.options} onUpdate={props.handleUpdate} data-test="Model-option-toggle">
       <DatButton label="Model options" onClick={props.toggleShowOptions}/>
       { props.expandOptionsDialog &&
+        <DatSelect path="unit.name" label="Unit"
+          options={["Tephra", "Seismic"]} key="unit" />
+      }
+      { (props.expandOptionsDialog && props.options.unit.name === "Tephra") &&
         [
           <DatBoolean path="tephraSimulation.requireEruption" label="Require eruption?" key="requireEruption" />,
           <DatBoolean path="tephraSimulation.requirePainting" label="Require painting?" key="requirePainting" />,
@@ -50,8 +54,34 @@ const AuthoringMenu: React.SFC<IProps> = (props) => {
             <DatBoolean path="uiStore.showEjectedVolume" label="Show Ejected Volume?" key="showEruptionMass" />
             <DatBoolean path="uiStore.showColumnHeight" label="Show Column Height?" key="showColumnHeight" />
             <DatBoolean path="uiStore.showVEI" label="Show VEI?" key="showVEI" />
+          </DatFolder>
+        ]
+      }
+
+      { (props.expandOptionsDialog && props.options.unit.name === "Seismic") &&
+        [
+          <DatSelect path="blocklyStore.toolbox" label="Code toolbox"
+            options={Object.keys(BlocklyAuthoring.toolbox)} key="toolbox" />,
+          <DatSelect path="blocklyStore.initialCodeTitle" label="Initial code"
+            options={Object.keys(BlocklyAuthoring.code)} key="code" />,
+
+          <DatFolder title="Left Tabs" key="leftTabsFolder" closed={false}>
+            <DatBoolean path="uiStore.showBlocks" label="Show blocks?" key="showBlocks" />
+            <DatBoolean path="uiStore.showCode" label="Show code?" key="showCode" />
+            <DatBoolean path="uiStore.showControls" label="Show controls?" key="showControls" />
           </DatFolder>,
 
+          <DatFolder title="Right Tabs" key="rightTabsFolder" closed={false}>
+            <DatBoolean path="uiStore.showConditions" label="Show conditions?" key="showConditions" />
+            <DatBoolean path="uiStore.showMonteCarlo" label="Show monte carlo?" key="showMonteCarlo" />
+            <DatBoolean path="uiStore.showData" label="Show data?" key="showData" />
+          </DatFolder>
+        ]
+      }
+
+      {
+        props.expandOptionsDialog &&
+        [
           <DatBoolean path="uiStore.showSpeedControls" label="Show Speed Controls?" key="showSpeedControls" />,
 
           <DatBoolean path="uiStore.showBarHistogram" label="Show Bar Histogram?" key="showBarHistogram" />,
@@ -65,7 +95,7 @@ const AuthoringMenu: React.SFC<IProps> = (props) => {
             key="generate" />,
           <DatButton label="Load state from local storage"
             onClick={props.loadStateFromLocalStorage}
-            key="generate" />,
+            key="generate" />
         ]
       }
     </DatGui>

--- a/src/components/controls.tsx
+++ b/src/components/controls.tsx
@@ -79,7 +79,7 @@ export class Controls extends BaseComponent<IProps, IState> {
       stagingWindSpeed,
       stagingVei,
       reset
-    } = this.stores.simulation;
+    } = this.stores.tephraSimulation;
 
     const {
       showWindSpeed,
@@ -252,34 +252,34 @@ export class Controls extends BaseComponent<IProps, IState> {
   }
 
   private changeWindDirection = (direction: number) => {
-    this.stores.simulation.setWindDirection(direction);
+    this.stores.tephraSimulation.setWindDirection(direction);
   }
 
   private changeWindSpeed = (speed: number) => {
-    this.stores.simulation.setWindSpeed(speed);
+    this.stores.tephraSimulation.setWindSpeed(speed);
   }
 
   private changeColumnHeight = (heightInKilometers: number) => {
-    this.stores.simulation.setColumnHeight(heightInKilometers);
+    this.stores.tephraSimulation.setColumnHeight(heightInKilometers);
   }
 
   private changeMass = (zeroBasedPower: number) => {
     // -4 index conversion, +9 km^3 to m^3, +3 m^3 to kg
     const massInKilograms = Math.pow(10, zeroBasedPower - 4 + 9 + 3);
-    this.stores.simulation.setMass(massInKilograms);
+    this.stores.tephraSimulation.setMass(massInKilograms);
   }
 
   private changeSize = (size: number) => {
-    this.stores.simulation.setParticleSize(size);
+    this.stores.tephraSimulation.setParticleSize(size);
   }
 
   private changeVEI = (vei: number) => {
-    this.stores.simulation.setVEI(vei);
+    this.stores.tephraSimulation.setVEI(vei);
   }
 
   private erupt = () => {
-    this.stores.simulation.erupt();
-    this.stores.simulation.paintMap();
+    this.stores.tephraSimulation.erupt();
+    this.stores.tephraSimulation.paintMap();
 
     // This code is used for waiting for the animation to complete and then painting
     // if (this.state.animate) {

--- a/src/components/crosssection/cross-section-component.tsx
+++ b/src/components/crosssection/cross-section-component.tsx
@@ -56,7 +56,7 @@ export class CrossSectionComponent extends BaseComponent<IProps, IState>{
       colHeight,
       mass,
       isSelectingCrossSection
-    } = this.stores.simulation;
+    } = this.stores.tephraSimulation;
 
     const { width } = this.metrics;
 

--- a/src/components/log-component.tsx
+++ b/src/components/log-component.tsx
@@ -48,7 +48,7 @@ export class LogComponent extends BaseComponent<IProps, IState> {
 
     public render() {
         const { height, width, clear } = this.props;
-        const { log } = this.stores.simulation;
+        const { log } = this.stores.tephraSimulation;
 
         return(
             <CanvDiv ref={this.ref} height={height} width={width}>

--- a/src/components/map/layers/cross-section-draw-layer.tsx
+++ b/src/components/map/layers/cross-section-draw-layer.tsx
@@ -90,9 +90,9 @@ export class CrossSectionDrawLayer extends BaseComponent<IProps, IState> {
     }
     if (point !== null) {
         if (index === 0) {
-          this.stores.simulation.setPoint1Pos(point.lat, point.lng);
+          this.stores.tephraSimulation.setPoint1Pos(point.lat, point.lng);
         } else {
-          this.stores.simulation.setPoint2Pos(point.lat, point.lng);
+          this.stores.tephraSimulation.setPoint2Pos(point.lat, point.lng);
         }
     }
   }

--- a/src/components/map/layers/latlng-draw-layer.tsx
+++ b/src/components/map/layers/latlng-draw-layer.tsx
@@ -59,7 +59,7 @@ export class LatLngDrawLayer extends BaseComponent<IProps, IState> {
   }
   public drawPoints(event: Leaflet.LeafletMouseEvent) {
     const { map } = this.props;
-    const { latLngPoint1Lat } = this.stores.simulation;
+    const { latLngPoint1Lat } = this.stores.tephraSimulation;
     if (map !== null) {
       if (latLngPoint1Lat === 0) {
         map.dragging.disable();
@@ -99,7 +99,7 @@ export class LatLngDrawLayer extends BaseComponent<IProps, IState> {
       map.dragging.disable();
       let latLng = (event as Leaflet.LeafletMouseEvent).latlng;
       if (!latLng) latLng = event.target.getLatLng(); // for when we are dragging
-      this.stores.simulation.setLatLngP1(latLng.lat, latLng.lng);
+      this.stores.tephraSimulation.setLatLngP1(latLng.lat, latLng.lng);
     }
   }
 
@@ -109,7 +109,7 @@ export class LatLngDrawLayer extends BaseComponent<IProps, IState> {
       map.dragging.disable();
       let latLng = (event as Leaflet.LeafletMouseEvent).latlng;
       if (!latLng) latLng = event.target.getLatLng(); // for when we are dragging
-      this.stores.simulation.setLatLngP2(latLng.lat, latLng.lng);
+      this.stores.tephraSimulation.setLatLngP2(latLng.lat, latLng.lng);
     }
   }
 

--- a/src/components/map/layers/ruler-draw-layer.tsx
+++ b/src/components/map/layers/ruler-draw-layer.tsx
@@ -33,7 +33,7 @@ export class RulerDrawLayer extends BaseComponent<IProps, IState> {
     this.drawEnd = this.drawEnd.bind(this);
     this.setPoint = this.setPoint.bind(this);
 
-    const { volcanoLat, volcanoLng } = this.stores.simulation;
+    const { volcanoLat, volcanoLng } = this.stores.tephraSimulation;
 
     const initialState: IState = {
         pointLat: volcanoLat,
@@ -94,7 +94,7 @@ export class RulerDrawLayer extends BaseComponent<IProps, IState> {
   public render() {
     const { map } = this.props;
     const { pointLat, pointLng, hasDrawn } = this.state;
-    const { volcanoLat, volcanoLng } = this.stores.simulation;
+    const { volcanoLat, volcanoLng } = this.stores.tephraSimulation;
     const point1 = L.latLng(volcanoLat, volcanoLng);
     const point2 = L.latLng(pointLat, pointLng);
     const point3 = L.latLng(volcanoLat, pointLng);

--- a/src/components/map/map-component.tsx
+++ b/src/components/map/map-component.tsx
@@ -6,7 +6,7 @@ import "leaflet/dist/leaflet.css";
 import "../../css/map-component.css";
 import { iconVolcano, iconMarker, getCachedDivIcon, getCachedCircleIcon, riskIcon, getCachedSampleLocationIcon } from "../icons";
 
-import { CityType  } from "../../stores/simulation-store";
+import { CityType  } from "../../stores/tephra-simulation-store";
 import * as Scenarios from "../../assets/maps/scenarios.json";
 import styled from "styled-components";
 import { observer, inject } from "mobx-react";
@@ -91,20 +91,20 @@ export class MapComponent extends BaseComponent<IProps, IState>{
   }
 
   public handleDragEnter(e: React.MouseEvent<HTMLDivElement>) {
-    this.stores.simulation.setPoint1Pos(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
-    this.stores.simulation.setPoint2Pos(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
+    this.stores.tephraSimulation.setPoint1Pos(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
+    this.stores.tephraSimulation.setPoint2Pos(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
     this.setState({moveMouse: true});
   }
 
   public handleDragMove(e: React.MouseEvent<HTMLDivElement>) {
     const { moveMouse } = this.state;
     if (moveMouse) {
-      this.stores.simulation.setPoint2Pos(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
+      this.stores.tephraSimulation.setPoint2Pos(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
     }
   }
 
   public handleDragExit(e: React.MouseEvent<HTMLDivElement>) {
-    this.stores.simulation.setPoint2Pos(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
+    this.stores.tephraSimulation.setPoint2Pos(e.nativeEvent.offsetX, e.nativeEvent.offsetY);
     this.setState({moveMouse: false});
   }
 
@@ -142,7 +142,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
       mass,
       hasErupted,
       scenario,
-    } = this.stores.simulation;
+    } = this.stores.tephraSimulation;
 
     const { showCrossSection } = this.stores.uiStore;
 
@@ -162,8 +162,8 @@ export class MapComponent extends BaseComponent<IProps, IState>{
     const {
       isSelectingCrossSection,
       isSelectingRuler,
-      isSelectingLatlng
-    } = this.stores.simulation;
+      isSelectingLatlng,
+    } = this.stores.tephraSimulation;
 
     const cityItems = cities.map( (city: CityType) => {
       const {x, y, name} = city;
@@ -205,7 +205,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
 
     const { crossPoint1Lat, crossPoint1Lng, crossPoint2Lat, crossPoint2Lng,
             latLngPoint1Lat, latLngPoint1Lng, latLngPoint2Lat, latLngPoint2Lng } =
-      this.stores.simulation;
+      this.stores.tephraSimulation;
     const volcanoPos = L.latLng(volcanoLat, volcanoLng);
     const corner1 = L.latLng(topLeftLat, topLeftLng);
     const corner2 = L.latLng(bottomRightLat, bottomRightLng);
@@ -299,12 +299,12 @@ export class MapComponent extends BaseComponent<IProps, IState>{
         </LeafletMap>
         <OverlayControls
           showRuler={isSelectingRuler}
-          onRulerClick={this.stores.simulation.rulerClick}
-          onLatLngClick={this.stores.simulation.latlngClick}
+          onRulerClick={this.stores.tephraSimulation.rulerClick}
+          onLatLngClick={this.stores.tephraSimulation.latlngClick}
           isSelectingCrossSection={isSelectingCrossSection}
           isSelectingLatLng={isSelectingLatlng}
           showCrossSection={hasErupted && showCrossSection && panelType === RightSectionTypes.CROSS_SECTION}
-          onCrossSectionClick={this.stores.simulation.crossSectionClick}
+          onCrossSectionClick={this.stores.tephraSimulation.crossSectionClick}
           onReCenterClick={this.onRecenterClick}
         />
         { this.state.showKey
@@ -328,7 +328,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
 
   private onRecenterClick = () => {
     if (this.map.current) {
-      const { volcanoLat, volcanoLng, scenario } = this.stores.simulation;
+      const { volcanoLat, volcanoLng, scenario } = this.stores.tephraSimulation;
       const scenarioData = (Scenarios as {[key: string]: Scenario})[scenario];
       const { initialZoom } = scenarioData;
 
@@ -336,9 +336,9 @@ export class MapComponent extends BaseComponent<IProps, IState>{
     }
   }
   private onMapClick = (e: any) => {
-    const { simulation } = this.stores;
-    if (this.stores.simulation.isSelectingLatlng) {
-      simulation.setPoint1Pos(e.latlng.lat, e.latlng.lng);
+    const { tephraSimulation } = this.stores;
+    if (tephraSimulation.isSelectingLatlng) {
+      tephraSimulation.setPoint1Pos(e.latlng.lat, e.latlng.lng);
     } else return;
   }
 
@@ -349,14 +349,14 @@ export class MapComponent extends BaseComponent<IProps, IState>{
       if (this.map.current) {
         const center = this.map.current.leafletElement.getCenter();
         const zoom = this.map.current.leafletElement.getZoom();
-        this.stores.simulation.setViewportParameters(zoom, center.lat, center.lng);
+        this.stores.tephraSimulation.setViewportParameters(zoom, center.lat, center.lng);
       }
     }
   }
 
   private getSampleLocations = () => {
     const { samplesCollectionsStore } = this.stores;
-    const { volcanoLat, volcanoLng } = this.stores.simulation;
+    const { volcanoLat, volcanoLng } = this.stores.tephraSimulation;
     const locations: React.ReactElement[] = [];
     samplesCollectionsStore.samplesLocations.forEach( (samplesLocation: SamplesLocationModelType, i) => {
       const pos = LocalToLatLng({x: samplesLocation.x, y: samplesLocation.y}, L.latLng(volcanoLat, volcanoLng));
@@ -373,7 +373,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
 
   private getRiskItems = () => {
     const { samplesCollectionsStore } = this.stores;
-    const { volcanoLat, volcanoLng } = this.stores.simulation;
+    const { volcanoLat, volcanoLng } = this.stores.tephraSimulation;
     const riskItems: React.ReactElement[] = [];
     const tabIndex = this.stores.uiStore.currentHistogramTab;
     const histogramCharts = this.stores.chartsStore.charts.filter(chart => chart.type === "histogram");

--- a/src/components/overlay-controls.tsx
+++ b/src/components/overlay-controls.tsx
@@ -31,7 +31,7 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
             showCrossSection,
             onCrossSectionClick,
             onReCenterClick} = this.props;
-        const { hasErupted } = this.stores.simulation;
+        const { hasErupted } = this.stores.tephraSimulation;
 
         const rulerColor = showRuler ? kRightTabInfo[RightSectionTypes.CONDITIONS].hoverBackgroundColor : "white";
         const selectingLatLngColor = isSelectingLatLng

--- a/src/components/widgets/widget-panel.tsx
+++ b/src/components/widgets/widget-panel.tsx
@@ -54,7 +54,7 @@ export default class WidgetPanel extends BaseComponent<IProps, IState> {
 
   public render() {
     const { showVEI, showEjectedVolume, showColumnHeight, showWindSpeed, showWindDirection } = this.stores.uiStore;
-    const { vei, mass, colHeight, windDirection, windSpeed } = this.stores.simulation;
+    const { vei, mass, colHeight, windDirection, windSpeed } = this.stores.tephraSimulation;
     return (
       <WidgetBar>
         { (showWindSpeed || showWindDirection) && <WidgetContainer data-test="wind-info-widget">

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -79,7 +79,7 @@ phone.addListener("initInteractive", (data: {
   }
   updateStores(initialState);
 
-  onSnapshot(stores.simulation, saveUserData);       // MobX function called on every store change
+  onSnapshot(stores.tephraSimulation, saveUserData);       // MobX function called on every store change
   onSnapshot(stores.uiStore, saveUserData);
 });
 

--- a/src/stores/blockly-store.ts
+++ b/src/stores/blockly-store.ts
@@ -1,0 +1,32 @@
+import { types, getSnapshot } from "mobx-state-tree";
+import { BlocklyStoreAuthorSettings, BlocklyStoreAuthorSettingsProps } from "./stores";
+
+export const BlocklyStore = types
+  .model("blockly", {
+    xmlCode: "",                // current blockly xml code
+    initialXmlCode: "",         // initial blockly xml code
+    toolbox: "Everything",
+    initialCodeTitle: "Basic",
+  })
+  .actions((self) => ({
+    setBlocklyCode(code: string, workspace: any) {
+      self.xmlCode = Blockly.Xml.domToPrettyText(Blockly.Xml.workspaceToDom(workspace));
+    },
+    setInitialXmlCode(xmlCode: string) {
+      self.initialXmlCode = xmlCode;
+    },
+  }))
+  .actions((self) => {
+    return {
+      loadAuthorSettingsData: (data: BlocklyStoreAuthorSettings) => {
+        Object.keys(data).forEach((key: BlocklyStoreAuthorSettingsProps) => {
+          // annoying `as any ... as any` is needed because we're mixing bool and non-bool props, which combine to never
+          // see https://github.com/microsoft/TypeScript/issues/31663
+          (self[key] as any) = data[key] as any;
+        });
+      },
+    };
+  });
+export const blocklyStore = BlocklyStore.create({});
+
+export type BlocklyStoreModelType = typeof BlocklyStore.Type;

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -1,0 +1,9 @@
+import { types } from "mobx-state-tree";
+
+export const SeismicSimulationStore = types
+  .model("seismicSimulation", {
+    gpsStations: types.array(types.number)
+  });
+export const seismicSimulation = SeismicSimulationStore.create({});
+
+export type SeismicSimulationModelType = typeof SeismicSimulationStore.Type;

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -1,22 +1,22 @@
 
-import { simulation, SimulationModelType } from "./simulation-store";
+import { tephraSimulation, TephraSimulationModelType } from "./tephra-simulation-store";
 import { uiStore, UIModelType } from "./ui-store";
 import { chartsStore, ChartsModelType } from "./charts-store";
 import { samplesCollectionsStore, SamplesCollectionsModelType } from "./samples-collections-store";
 
 export interface IStore {
-  simulation: SimulationModelType;
+  tephraSimulation: TephraSimulationModelType;
   uiStore: UIModelType;
   chartsStore: ChartsModelType;
   samplesCollectionsStore: SamplesCollectionsModelType;
 }
 
-export interface IStoreish {simulation: any; uiStore: any; }
+export interface IStoreish {tephraSimulation: any; uiStore: any; }
 
 export interface SerializedState {version: number; state: IStoreish; }
 
 export const stores: IStore = {
-  simulation,
+  tephraSimulation,
   uiStore,
   chartsStore,
   samplesCollectionsStore,
@@ -27,7 +27,7 @@ export const stores: IStore = {
 const tuple = <T extends string[]>(...args: T) => args;
 
 // props settable from authoring menu
-const simulationAuthorSettingsProps = tuple(
+const tephraSimulationAuthorSettingsProps = tuple(
   "requireEruption",
   "requirePainting",
   "scenario",
@@ -35,7 +35,7 @@ const simulationAuthorSettingsProps = tuple(
   "initialCodeTitle",
 );
 // additional props directly from current model that author will save
-const simulationAuthorStateProps = (simulationAuthorSettingsProps as string[]).concat(tuple(
+const tephraSimulationAuthorStateProps = (tephraSimulationAuthorSettingsProps as string[]).concat(tuple(
   "xmlCode",
   "initialXmlCode",
   "stagingWindSpeed",
@@ -63,11 +63,11 @@ const uiAuthorSettingsProps = tuple(
   "showDemoCharts",
 );
 
-export type SimulationAuthorSettingsProps = typeof simulationAuthorSettingsProps[number];
+export type TephraSimulationAuthorSettingsProps = typeof tephraSimulationAuthorSettingsProps[number];
 export type UIAuthorSettingsProps = typeof uiAuthorSettingsProps[number];
 
-export type SimulationAuthorSettings = {
-  [key in SimulationAuthorSettingsProps]?: any;
+export type TephraSimulationAuthorSettings = {
+  [key in TephraSimulationAuthorSettingsProps]?: any;
 };
 export type UIAuthorSettings = {
   [key in UIAuthorSettingsProps]?: any;
@@ -79,19 +79,19 @@ const pick = (keys: string[]) => (o: any) => keys.reduce((a, e) => ({ ...a, [e]:
 // returns a selection of the properties of the store
 function getStoreSubstate(simulationProps: string[], uiProps: string[]): () => IStoreish {
   return () => {
-    const authoredSimulation = pick(simulationProps)(simulation);
+    const authoredTephraSimulation = pick(simulationProps)(tephraSimulation);
     const authoredUi = pick(uiProps)(uiStore);
     return {
-      simulation: authoredSimulation,
+      tephraSimulation: authoredTephraSimulation,
       uiStore: authoredUi
     };
   };
 }
 
 // gets the current stores state in a version appropriate for the authoring menu
-export const getAuthorableSettings = getStoreSubstate(simulationAuthorSettingsProps, uiAuthorSettingsProps);
+export const getAuthorableSettings = getStoreSubstate(tephraSimulationAuthorSettingsProps, uiAuthorSettingsProps);
 // gets the current store state to be saved by an author or student
-export const getSavableState = getStoreSubstate(simulationAuthorStateProps, uiAuthorSettingsProps);
+export const getSavableState = getStoreSubstate(tephraSimulationAuthorStateProps, uiAuthorSettingsProps);
 
 // makes state appropriate for saving to e.g. LARA. Changes keys or values as needed. Adds a version number
 export const serializeState = (state: any): SerializedState => {
@@ -99,8 +99,8 @@ export const serializeState = (state: any): SerializedState => {
 
   // we copy simulation.xmlCode (the current blockly code) to simulation.initialXmlCode (how we want
   // to initialize blockly) when we save state
-  serializedState.simulation.initialXmlCode = serializedState.simulation.xmlCode;
-  delete serializedState.simulation.xmlCode;
+  serializedState.tephraSimulation.initialXmlCode = serializedState.tephraSimulation.xmlCode;
+  delete serializedState.tephraSimulation.xmlCode;
 
   return {
     version: 1,
@@ -112,13 +112,14 @@ export const deserializeState = (serializedState: SerializedState): IStoreish =>
   if (serializedState.version === 1) {
     return serializedState.state;
   }
-  return {simulation: {}, uiStore: {}};
+  return {tephraSimulation: {}, uiStore: {}};
 };
 
 export function updateStores(state: IStoreish) {
-  const simulationStoreSettings: SimulationAuthorSettings = pick(simulationAuthorStateProps)(state.simulation);
+  const tephraSimulationStoreSettings: TephraSimulationAuthorSettings =
+    pick(tephraSimulationAuthorStateProps)(state.tephraSimulation);
   const uiStoreSettings: UIAuthorSettings = pick(uiAuthorSettingsProps)(state.uiStore);
 
-  simulation.loadAuthorSettingsData(simulationStoreSettings);
+  tephraSimulation.loadAuthorSettingsData(tephraSimulationStoreSettings);
   uiStore.loadAuthorSettingsData(uiStoreSettings);
 }

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -1,25 +1,37 @@
 
 import { tephraSimulation, TephraSimulationModelType } from "./tephra-simulation-store";
+import { seismicSimulation, SeismicSimulationModelType } from "./seismic-simulation-store";
 import { uiStore, UIModelType } from "./ui-store";
 import { chartsStore, ChartsModelType } from "./charts-store";
 import { samplesCollectionsStore, SamplesCollectionsModelType } from "./samples-collections-store";
 import { BlocklyStoreModelType, blocklyStore } from "./blockly-store";
+import { UnitStoreType, unitStore } from "./unit-store";
 
 export interface IStore {
+  unit: UnitStoreType;
   blocklyStore: BlocklyStoreModelType;
   tephraSimulation: TephraSimulationModelType;
+  seismicSimulation: SeismicSimulationModelType;
   uiStore: UIModelType;
   chartsStore: ChartsModelType;
   samplesCollectionsStore: SamplesCollectionsModelType;
 }
 
-export interface IStoreish {blocklyStore: any; tephraSimulation: any; uiStore: any; }
+export interface IStoreish {
+  unit: {name: "Tephra" | "Seismic"};
+  blocklyStore: any;
+  tephraSimulation: any;
+  seismicSimulation: any;
+  uiStore: any;
+}
 
 export interface SerializedState {version: number; state: IStoreish; }
 
 export const stores: IStore = {
+  unit: unitStore,
   blocklyStore,
   tephraSimulation,
+  seismicSimulation,
   uiStore,
   chartsStore,
   samplesCollectionsStore,
@@ -98,8 +110,10 @@ const pick = (keys: string[]) => (o: any) => keys.reduce((a, e) => ({ ...a, [e]:
 function getStoreSubstate(blocklyStoreProps: string[], tephraSimulationProps: string[], uiProps: string[]) {
   return (): IStoreish => {
     return {
+      unit: { name: stores.unit.name },
       blocklyStore: pick(blocklyStoreProps)(blocklyStore),
       tephraSimulation: pick(tephraSimulationProps)(tephraSimulation),
+      seismicSimulation: {},      // nothing to save yet
       uiStore: pick(uiProps)(uiStore)
     };
   };
@@ -131,7 +145,7 @@ export const deserializeState = (serializedState: SerializedState): IStoreish =>
   if (serializedState.version === 1) {
     return serializedState.state;
   }
-  return {blocklyStore: {}, tephraSimulation: {}, uiStore: {}};
+  return {unit: {name: "Tephra"}, blocklyStore: {}, tephraSimulation: {}, seismicSimulation: {}, uiStore: {}};
 };
 
 export function updateStores(state: IStoreish) {
@@ -141,6 +155,7 @@ export function updateStores(state: IStoreish) {
     pick(tephraSimulationAuthorStateProps)(state.tephraSimulation);
   const uiStoreSettings: UIAuthorSettings = pick(uiAuthorSettingsProps)(state.uiStore);
 
+  unitStore.setUnit(state.unit.name);
   blocklyStore.loadAuthorSettingsData(blocklyStoreSettings);
   tephraSimulation.loadAuthorSettingsData(tephraSimulationStoreSettings);
   uiStore.loadAuthorSettingsData(uiStoreSettings);

--- a/src/stores/tephra-simulation-store.test.ts
+++ b/src/stores/tephra-simulation-store.test.ts
@@ -1,10 +1,10 @@
-import { SimulationStore, SimulationModelType } from "./simulation-store";
+import { TephraSimulationStore, TephraSimulationModelType } from "./tephra-simulation-store";
 
 describe("simulation-store", () => {
-  let simulation: SimulationModelType;
+  let simulation: TephraSimulationModelType;
 
   beforeEach(() => {
-    simulation = SimulationStore.create({});
+    simulation = TephraSimulationStore.create({});
   });
 
   describe("vei", () => {

--- a/src/stores/tephra-simulation-store.ts
+++ b/src/stores/tephra-simulation-store.ts
@@ -1,12 +1,12 @@
 import { types, getSnapshot } from "mobx-state-tree";
 import { kVEIIndexInfo } from "../utilities/vei";
-import { SimulationAuthorSettings, SimulationAuthorSettingsProps } from "./stores";
+import { TephraSimulationAuthorSettings, TephraSimulationAuthorSettingsProps } from "./stores";
 import gridTephraCalc from "../tephra2";
 
 let _cityCounter = 0;
 const genCityId = () => `city_${_cityCounter++}`;
 
-export interface IModelParams {
+export interface ITephraModelParams {
   mass: number;
   windSpeed: number;
   colHeight: number;
@@ -83,8 +83,8 @@ export function getGridIndexForLocation(x: number, y: number, numRows: number) {
   return y + x * numRows;
 }
 
-export const SimulationStore = types
-  .model("simulation", {
+export const TephraSimulationStore = types
+  .model("tephraSimulation", {
     windSpeed: 6,
     windDirection: 0,    // from north
     mass: 10000000000000,
@@ -340,7 +340,7 @@ export const SimulationStore = types
           self.erupt();
         }
       },
-      setModelParams(params: IModelParams) {
+      setModelParams(params: ITephraModelParams) {
         self.stagingWindSpeed = params.windSpeed;
         self.stagingColHeight = params.colHeight;
         self.stagingMass = params.mass;
@@ -385,8 +385,8 @@ export const SimulationStore = types
   })
   .actions((self) => {
     return {
-      loadAuthorSettingsData: (data: SimulationAuthorSettings) => {
-        Object.keys(data).forEach((key: SimulationAuthorSettingsProps) => {
+      loadAuthorSettingsData: (data: TephraSimulationAuthorSettings) => {
+        Object.keys(data).forEach((key: TephraSimulationAuthorSettingsProps) => {
           // annoying `as any ... as any` is needed because we're mixing bool and non-bool props, which combine to never
           // see https://github.com/microsoft/TypeScript/issues/31663
           (self[key] as any) = data[key] as any;
@@ -401,7 +401,7 @@ export const SimulationStore = types
       },
     };
   });
-export const simulation = SimulationStore.create({});
+export const tephraSimulation = TephraSimulationStore.create({});
 
-export type SimulationModelType = typeof SimulationStore.Type;
+export type TephraSimulationModelType = typeof TephraSimulationStore.Type;
 export type CityType = typeof City.Type;

--- a/src/stores/tephra-simulation-store.ts
+++ b/src/stores/tephra-simulation-store.ts
@@ -111,8 +111,6 @@ export const TephraSimulationStore = types
     viewportCenterLat: 0,
     viewportCenterLng: 0,
     cities: types.array(City),
-    xmlCode: "",                // current blockly xml code
-    initialXmlCode: "",         // initial blockly xml code
     log: "",
     plotData: types.optional(PlotData, getSnapshot(plotData)),
     hasErupted: false,
@@ -127,8 +125,6 @@ export const TephraSimulationStore = types
     requireEruption: true,
     requirePainting: true,
     scenario: "Cerro Negro",
-    toolbox: "Everything",
-    initialCodeTitle: "Basic",
   })
   .views((self) => {
     const getVei = (mass: number, colHeight: number) => {
@@ -189,12 +185,6 @@ export const TephraSimulationStore = types
     }
   }))
   .actions((self) => ({
-    setBlocklyCode(code: string, workspace: any) {
-      self.xmlCode = Blockly.Xml.domToPrettyText(Blockly.Xml.workspaceToDom(workspace));
-    },
-    setInitialXmlCode(xmlCode: string) {
-      self.initialXmlCode = xmlCode;
-    },
     setViewportParameters(zoom: number, viewportCenterLat: number, viewportCenterLng: number) {
       self.viewportZoom = zoom;
       self.viewportCenterLat = viewportCenterLat;

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -5,8 +5,8 @@ const UIStore = types.model("UI", {
   showOptionsDialog: true,
   // left tabs
   showBlocks: true,
-  showCode: true,
-  showControls: true,
+  showCode: false,
+  showControls: false,
   // right tabs
   showConditions: true,
   showCrossSection: false,

--- a/src/stores/unit-store.ts
+++ b/src/stores/unit-store.ts
@@ -1,0 +1,23 @@
+/**
+ * This just holds a single prop, but by making it a store we get MST observations.
+ * This could eventually hold more top-level props
+ */
+
+import { types } from "mobx-state-tree";
+
+export const UnitName = types.enumeration("type", ["Tephra", "Seismic"]);
+export type UnitNameType = typeof UnitName.Type;
+
+export const UnitStore = types
+  .model("unit", {
+    name: UnitName
+  })
+  .actions((self) => ({
+    setUnit(name: UnitNameType) {   // if we add more props, we will want loadAuthorSettingsData instead
+      self.name = name;
+    }
+  }));
+
+export const unitStore = UnitStore.create({ name: "Tephra" });
+
+export type UnitStoreType = typeof UnitStore.Type;


### PR DESCRIPTION
This splits the simulations store into the blockly store, tephra simulation, and seismic simulation stores, and unit store to know which one is active.

This seemed clearer and simpler than putting it all in one store, or doing something clever where the "simulation" could switch between being the tephra simulation and seismic simulation. It does mean that an author will save properties in both simulation stores, even when they aren't being used, but that should be fine (and also allows an author to accidentally switch units and not lose all their authoring).

@dstrawberrygirl I left the lat-long tool in the tephra store for the moment, because the various tools act as radio buttons and selecting one deselects the other, which would be messier to orchestrate between stores. But this will mean that if the seismic store wants to know the current values, it will have to ask the tephra store. I think the best solution will be to eventually put all the measuring tools in their own stores, but I didn't want to pre-architect before we saw what we'll actually use the tool for.