### PR TITLE
Add line breaks in longer blocks

### DIFF
--- a/cypress/integration/branch/authoring.test.js
+++ b/cypress/integration/branch/authoring.test.js
@@ -196,34 +196,37 @@ context ('Authoring Options',()=>{
             //Wind data
             blocksTab.getTag('Wind data').click();
             blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 6)
-            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length',18)
+            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length',19)
             blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(0).text().then((text)=>{
                 expect(removeNBSP(text)).to.contain("Graph Wind Data")
             })
             blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(1).text().then((text)=>{
-                expect(removeNBSP(text)).to.contain("Graph Wind Speed and Direction")
+                expect(removeNBSP(text)).to.contain("Graph Wind Speed")
             })
             blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(2).text().then((text)=>{
+              expect(removeNBSP(text)).to.contain("and Direction")
+          })
+            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(3).text().then((text)=>{
                 expect(removeNBSP(text)).to.contain("Graph Wind Data")
             })
-            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(4).should('contain','against')
-            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(6).text().then((text)=>{
+            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(5).should('contain','against')
+            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(7).text().then((text)=>{
                 expect(removeNBSP(text)).to.contain("All Wind Data")
             })
-            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(7).should('contain','sample')
-            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(9).should('contain','items')
-            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(10).should('contain','from')
-            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(11).should('contain','Filter')
-            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(12).text().then((text)=>{
+            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(8).should('contain','sample')
+            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(10).should('contain','items')
+            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(11).should('contain','from')
+            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(12).should('contain','Filter')
+            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(13).text().then((text)=>{
                 expect(removeNBSP(text)).to.contain("Select from")
             })
-            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(13).should('contain','Day')
-            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(14).should('contain','Month')
-            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(15).should('contain','Year')
-            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(16).text().then((text)=>{
+            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(14).should('contain','Day')
+            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(15).should('contain','Month')
+            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(16).should('contain','Year')
+            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(17).text().then((text)=>{
                 expect(removeNBSP(text)).to.contain("Direction (º from North)")
             })
-            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(17).text().then((text)=>{
+            blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(18).text().then((text)=>{
                 expect(removeNBSP(text)).to.contain("Speed (m/s)")
             })
             //Data Collections
@@ -660,7 +663,7 @@ context ('Authoring Options',()=>{
                 controlsTab.getWindSpeedDirectionContainer().find('[data-test="info"]>div>div').should('have.length',3)
                 conditionsTab.getWindSpeedDirectionWidget().should('be.visible')
             })
-            it('verify ejected volume slider shows again',()=>{    
+            it('verify ejected volume slider shows again',()=>{
                 modelOptions.getShowEjectedVolumeOption().click();
                 modelOptions.getShowEjectedVolumeOption().should('be.checked')
                 controlsTab.getEjectedVolumeSlider().should('be.visible')
@@ -676,7 +679,7 @@ context ('Authoring Options',()=>{
                 controlsTab.getVEIContainer().find('[data-test="info"]').should('be.visible')
                 conditionsTab.getVEIWidget().should('be.visible')
             })
-            it('verify column height slider shows again',()=>{    
+            it('verify column height slider shows again',()=>{
                 modelOptions.getShowColumnHeightOption().click();
                 modelOptions.getShowColumnHeightOption().should('be.checked')
                 controlsTab.getColumnHeightSlider().should('be.visible')

--- a/src/blockly-blocks/block-graph-data.js
+++ b/src/blockly-blocks/block-graph-data.js
@@ -19,9 +19,12 @@ Blockly.JavaScript['graph_speed_date_wind_data'] = function (block) {
 
 Blockly.Blocks['graph_speed_direction_wind_data'] = {
   init: function () {
+    this.appendDummyInput()
+      .appendField('Graph Wind Speed ')
+    this.appendDummyInput()
+      .appendField('and Direction')
     this.appendValueInput('wind data')
       .setCheck('Dataset')
-      .appendField('Graph Wind Speed and Direction')
     this.setPreviousStatement(true, null)
     this.setNextStatement(true, null)
     this.setColour(230)
@@ -38,9 +41,10 @@ Blockly.JavaScript['graph_speed_direction_wind_data'] = function (block) {
 
 Blockly.Blocks['graph_any_wind_data'] = {
   init: function () {
+    this.appendDummyInput()
+      .appendField('Graph Wind Data')
     this.appendValueInput('wind data')
       .setCheck('Dataset')
-      .appendField('Graph Wind Data')
       .appendField(new Blockly.FieldDropdown([
           ['speed', 'speed'],
           ['direction', 'direction'],
@@ -76,6 +80,7 @@ Blockly.Blocks['graph_exceedance'] = {
   init: function() {
     this.appendDummyInput()
         .appendField("Graph data collection")
+    this.appendDummyInput()
         .appendField(new Blockly.FieldDropdown(this.generateOptions), "collections");
     this.appendDummyInput()
         .setAlign(Blockly.ALIGN_RIGHT)


### PR DESCRIPTION
This is a very quick adjustment to help with two of the widest blocks by adding some line breaks in the rendering. More nuanced fixes require a deeper dive into Blockly (potentially updating our version of Blockly, which may cause issues elsewhere).