### PR TITLE
174654780 Deformation blocks

### DIFF
--- a/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
@@ -9,8 +9,6 @@
 
   <category name="Deformation Model" colour="15">
     <block type="deformation-create-sim"></block>
-    <block type="set_velocity_block_1"></block>
-    <block type="set_velocity_block_2"></block>
   </category>
 
   <category name="Logic" colour="%{BKY_LOGIC_HUE}">

--- a/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
@@ -7,8 +7,10 @@
     <block type="graph_gps_position"></block>
   </category>
 
-  <category name="Deformation" colour="15">
+  <category name="Deformation Model" colour="15">
     <block type="deformation-create-sim"></block>
+    <block type="set_velocity_block_1"></block>
+    <block type="set_velocity_block_2"></block>
   </category>
 
   <category name="Logic" colour="%{BKY_LOGIC_HUE}">

--- a/src/blockly-blocks/deformation/block-deformation-create-sim.js
+++ b/src/blockly-blocks/deformation/block-deformation-create-sim.js
@@ -1,12 +1,67 @@
 Blockly.Blocks['deformation-create-sim'] = {
     init: function() {
       this.appendDummyInput()
-        .appendField("Run simulation");
+        .appendField("Create Strain Simulation");
       this.setColour(15)
+      this.setPreviousStatement(false, null);
+      this.setNextStatement(true, null);
     }
   };
 
   Blockly.JavaScript['deformation-create-sim'] = function(block) {
     const code ='createDeformationModel();\n';
+    return code;
+  }
+
+  Blockly.Blocks['set_velocity_block_1'] = {
+    init: function() {
+      this.appendDummyInput()
+          .appendField("Set velocity Block 1 with")
+      this.appendValueInput('speed')
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("speed (mm/yr)")
+      this.appendValueInput('direction')
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("direction (degrees)")
+      this.setPreviousStatement(true, null);
+      this.setNextStatement(true, null);
+      this.setColour(240);
+      this.setTooltip("");
+      this.setHelpUrl("");
+    }
+  };
+
+  Blockly.JavaScript['set_velocity_block_1'] = function (block) {
+    var value_speed = block.getFieldValue('speed');
+    var value_direction = block.getFieldValue('direction');
+
+    var code = `setBlockVelocity({block: 1, speed: ${value_speed}, direction: ${value_direction}});\n`;
+    return code;
+  }
+
+  Blockly.Blocks['set_velocity_block_2'] = {
+    init: function() {
+      this.appendDummyInput()
+          .appendField("Set velocity Block 2 with")
+      this.appendValueInput('speed')
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("speed (mm/yr)")
+      this.appendValueInput('direction')
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("direction (degrees)")
+      this.setPreviousStatement(true, null);
+      this.setNextStatement(true, null);
+      this.setColour(240);
+      this.setTooltip("");
+      this.setHelpUrl("");
+    }
+  };
+
+  Blockly.JavaScript['set_velocity_block_2'] = function (block) {
+    var value_speed = block.getFieldValue('speed');
+    var value_direction = block.getFieldValue('direction');
+
+    var code = `setBlockVelocity({block: 2, speed: ${value_speed}, direction: ${value_direction}});\n`;
+
     return code;
   }

--- a/src/blockly-blocks/deformation/block-deformation-create-sim.js
+++ b/src/blockly-blocks/deformation/block-deformation-create-sim.js
@@ -20,9 +20,11 @@ Blockly.Blocks['deformation-create-sim'] = {
       this.appendValueInput('speed')
         .setAlign(Blockly.ALIGN_RIGHT)
         .appendField("speed (mm/yr)")
+        .setCheck(['Number'])
       this.appendValueInput('direction')
         .setAlign(Blockly.ALIGN_RIGHT)
         .appendField("direction (degrees)")
+        .setCheck(['Number'])
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
       this.setColour(240);
@@ -32,8 +34,8 @@ Blockly.Blocks['deformation-create-sim'] = {
   };
 
   Blockly.JavaScript['set_velocity_block_1'] = function (block) {
-    var value_speed = block.getFieldValue('speed');
-    var value_direction = block.getFieldValue('direction');
+    var value_speed = Blockly.JavaScript.valueToCode(block, 'speed', Blockly.JavaScript.ORDER_ATOMIC) || 0;
+    var value_direction = Blockly.JavaScript.valueToCode(block, 'direction', Blockly.JavaScript.ORDER_ATOMIC) || 0;
 
     var code = `setBlockVelocity({block: 1, speed: ${value_speed}, direction: ${value_direction}});\n`;
     return code;
@@ -58,10 +60,9 @@ Blockly.Blocks['deformation-create-sim'] = {
   };
 
   Blockly.JavaScript['set_velocity_block_2'] = function (block) {
-    var value_speed = block.getFieldValue('speed');
-    var value_direction = block.getFieldValue('direction');
+    var value_speed = Blockly.JavaScript.valueToCode(block, 'speed', Blockly.JavaScript.ORDER_ATOMIC) || 0;
+    var value_direction = Blockly.JavaScript.valueToCode(block, 'direction', Blockly.JavaScript.ORDER_ATOMIC) || 0;
 
     var code = `setBlockVelocity({block: 2, speed: ${value_speed}, direction: ${value_direction}});\n`;
-
     return code;
   }

--- a/src/blockly-blocks/deformation/block-deformation-create-sim.js
+++ b/src/blockly-blocks/deformation/block-deformation-create-sim.js
@@ -2,67 +2,38 @@ Blockly.Blocks['deformation-create-sim'] = {
     init: function() {
       this.appendDummyInput()
         .appendField("Create Strain Simulation");
+      this.appendDummyInput()
+        .appendField("Set velocity of Block 1 with")
+      this.appendValueInput('speed1')
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("speed (mm/yr)")
+        .setCheck(['Number'])
+      this.appendValueInput('direction1')
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("direction (degrees)")
+        .setCheck(['Number'])
+      this.appendDummyInput()
+        .appendField("Set velocity of Block 2 with")
+      this.appendValueInput('speed2')
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("speed (mm/yr)")
+      this.appendValueInput('direction2')
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("direction (degrees)")
       this.setColour(15)
       this.setPreviousStatement(false, null);
-      this.setNextStatement(true, null);
+      this.setNextStatement(false, null);
     }
   };
 
   Blockly.JavaScript['deformation-create-sim'] = function(block) {
-    const code ='createDeformationModel();\n';
-    return code;
-  }
+    var value_speed_1 = Blockly.JavaScript.valueToCode(block, 'speed1', Blockly.JavaScript.ORDER_ATOMIC) || 0;
+    var value_direction_1 = Blockly.JavaScript.valueToCode(block, 'direction1', Blockly.JavaScript.ORDER_ATOMIC) || 0;
+    var value_speed_2 = Blockly.JavaScript.valueToCode(block, 'speed2', Blockly.JavaScript.ORDER_ATOMIC) || 0;
+    var value_direction_2 = Blockly.JavaScript.valueToCode(block, 'direction2', Blockly.JavaScript.ORDER_ATOMIC) || 0;
 
-  Blockly.Blocks['set_velocity_block_1'] = {
-    init: function() {
-      this.appendDummyInput()
-          .appendField("Set velocity Block 1 with")
-      this.appendValueInput('speed')
-        .setAlign(Blockly.ALIGN_RIGHT)
-        .appendField("speed (mm/yr)")
-        .setCheck(['Number'])
-      this.appendValueInput('direction')
-        .setAlign(Blockly.ALIGN_RIGHT)
-        .appendField("direction (degrees)")
-        .setCheck(['Number'])
-      this.setPreviousStatement(true, null);
-      this.setNextStatement(true, null);
-      this.setColour(240);
-      this.setTooltip("");
-      this.setHelpUrl("");
-    }
-  };
-
-  Blockly.JavaScript['set_velocity_block_1'] = function (block) {
-    var value_speed = Blockly.JavaScript.valueToCode(block, 'speed', Blockly.JavaScript.ORDER_ATOMIC) || 0;
-    var value_direction = Blockly.JavaScript.valueToCode(block, 'direction', Blockly.JavaScript.ORDER_ATOMIC) || 0;
-
-    var code = `setBlockVelocity({block: 1, speed: ${value_speed}, direction: ${value_direction}});\n`;
-    return code;
-  }
-
-  Blockly.Blocks['set_velocity_block_2'] = {
-    init: function() {
-      this.appendDummyInput()
-          .appendField("Set velocity Block 2 with")
-      this.appendValueInput('speed')
-        .setAlign(Blockly.ALIGN_RIGHT)
-        .appendField("speed (mm/yr)")
-      this.appendValueInput('direction')
-        .setAlign(Blockly.ALIGN_RIGHT)
-        .appendField("direction (degrees)")
-      this.setPreviousStatement(true, null);
-      this.setNextStatement(true, null);
-      this.setColour(240);
-      this.setTooltip("");
-      this.setHelpUrl("");
-    }
-  };
-
-  Blockly.JavaScript['set_velocity_block_2'] = function (block) {
-    var value_speed = Blockly.JavaScript.valueToCode(block, 'speed', Blockly.JavaScript.ORDER_ATOMIC) || 0;
-    var value_direction = Blockly.JavaScript.valueToCode(block, 'direction', Blockly.JavaScript.ORDER_ATOMIC) || 0;
-
-    var code = `setBlockVelocity({block: 2, speed: ${value_speed}, direction: ${value_direction}});\n`;
+    var code ='createDeformationModel();\n';
+    code += `setBlockVelocity({block: 1, speed: ${value_speed_1}, direction: ${value_direction_1}});\n`;
+    code += `setBlockVelocity({block: 2, speed: ${value_speed_2}, direction: ${value_direction_2}});\n`;
     return code;
   }

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -326,9 +326,7 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
       seismicSimulation.startDeformationModel();
     });
     addFunc("setBlockVelocity", (params: { block: number, speed: number, direction: number }) => {
-      // TODO: fix!
-      // seismicSimulation.setBlockVelocity(params.block, params.speed, params.direction);
-      seismicSimulation.setBlockVelocity(1, 4, 25);
+      seismicSimulation.setBlockVelocity(params.block, params.speed, params.direction);
     });
     /** ==== Utility methods ==== */
 

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -325,7 +325,11 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
     addFunc("createDeformationModel", () => {
       seismicSimulation.startDeformationModel();
     });
-
+    addFunc("setBlockVelocity", (params: { block: number, speed: number, direction: number }) => {
+      // TODO: fix!
+      // seismicSimulation.setBlockVelocity(params.block, params.speed, params.direction);
+      seismicSimulation.setBlockVelocity(1, 4, 25);
+    });
     /** ==== Utility methods ==== */
 
     addFunc("log", (params) => {

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -25,6 +25,11 @@ export const SeismicSimulationStore = types
     deformationModelEndStep: 500,
     showVelocityArrows: false,
 
+    deformationBlock1Speed: 0,
+    deformationBlock1Direction: 0,
+    deformationBlock2Speed: 0,
+    deformationBlock2Direction: 0
+
   })
   .actions((self) => ({
     showGPSStations(stations: StationData[]) {
@@ -62,6 +67,15 @@ export const SeismicSimulationStore = types
 
       window.requestAnimationFrame(updateStep);
     },
+    setBlockVelocity(block: number, speed: number, direction: number) {
+      if (block === 1) {
+        self.deformationBlock1Speed = speed;
+        self.deformationBlock1Direction = direction;
+      } else {
+        self.deformationBlock2Speed = speed;
+        self.deformationBlock2Direction = direction;
+      }
+    }
   }))
   .views((self) => ({
     get allGPSStations() {


### PR DESCRIPTION
Building on the tab PR, this one adds the three blocks to create the strain simulation and to set velocity for both blocks.

I've used a placeholder in the store to capture the speed and direction values, I wasn't sure if the connections from the "create the sim" felt right, I don't have a good set of guidelines for that aspect (should it be above, to the left, etc?) so any feedback on this would be great.