### PR TITLE
Show "Map" instead of "Conditions" for tab in Seismic unit

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -30,6 +30,7 @@ import { HistogramPanel } from "./montecarlo/histogram-panel";
 import { uiStore } from "../stores/ui-store";
 import { GPSStationTable } from "./gps-station-table";
 import { DeformationModel } from "./deformation/deformation-model";
+import { UnitNameType } from "../stores/unit-store";
 
 interface IProps extends IBaseProps {}
 
@@ -494,7 +495,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                       backgroundhovercolor={this.getRightTabHoverColor(RightSectionTypes.CONDITIONS)}
                       data-test={this.getRightTabName(RightSectionTypes.CONDITIONS) + "-tab"}
                     >
-                      {this.getRightTabName(RightSectionTypes.CONDITIONS)}
+                      {this.getRightTabName(RightSectionTypes.CONDITIONS, unitName)}
                     </BottomTab>
                   }
                   { showCrossSection &&
@@ -586,8 +587,12 @@ export class AppComponent extends BaseComponent<IProps, IState> {
   private getRightTabHoverColor = (type: RightSectionTypes) => {
     return (type ? kRightTabInfo[type].hoverBackgroundColor : "white");
   }
-  private getRightTabName = (type: RightSectionTypes) => {
-    return (type ? kRightTabInfo[type].name : "");
+  private getRightTabName = (type: RightSectionTypes, unit?: UnitNameType) => {
+    if (!type) return "";
+    if (unit && kRightTabInfo[type].unitDisplayName && kRightTabInfo[type].unitDisplayName![unit]) {
+      return kRightTabInfo[type].unitDisplayName![unit];
+    }
+    return kRightTabInfo[type].name;
   }
 
   private resize = (rect: DOMRect) => {

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -5,6 +5,7 @@ import {
   Tabs as UnstyledTabs,
   TabPanel as UnstyledTabPanel
 } from "react-tabs";
+import { UnitNameType } from "../stores/unit-store";
 
 enum SectionTypes {
   BLOCKS = "blocks",
@@ -50,6 +51,7 @@ enum RightSectionTypes {
 type RightTabInfo = {
   [tab in RightSectionTypes]: {
     name: string;
+    unitDisplayName?: { [unit in UnitNameType ]: string };
     index: number;
     backgroundColor: string;
     hoverBackgroundColor: string;
@@ -58,6 +60,10 @@ type RightTabInfo = {
 const kRightTabInfo: RightTabInfo = {
   conditions: {
     name: "Conditions",
+    unitDisplayName: {
+      Tephra: "Conditions",
+      Seismic: "Map"
+    },
     index: -1,
     backgroundColor: "#b7dcad",
     hoverBackgroundColor: "#add1a2",


### PR DESCRIPTION
This adds this ability in a generic way, so it will be easy to add other custom names for units if needed.