### PR TITLE
Add reset to Seismic store

### DIFF
--- a/src/blockly/blockly-controller.ts
+++ b/src/blockly/blockly-controller.ts
@@ -52,6 +52,7 @@ export class BlocklyController {
   public reset = () => {
     this.setCode(this.code, this.workspace);
     this.stores.tephraSimulation.reset();
+    this.stores.seismicSimulation.reset();
     this.stores.chartsStore.reset();
     this.stores.samplesCollectionsStore.reset();
   }

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -25,6 +25,11 @@ export const SeismicSimulationStore = types
     },
     setShowVelocityArrows(show: boolean) {
       self.showVelocityArrows = show;
+    },
+    reset() {
+      self.visibleGPSStationIds.clear();
+      self.selectedGPSStationId = undefined;
+      self.showVelocityArrows = false;
     }
   }))
   .views((self) => ({


### PR DESCRIPTION
This resets store props to their defaults (no stations visible or selected).

As the store evolves, we haver to remember to keep this up to date.