### PR TITLE
Listen to state changes on unit and blocklyStore

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -79,7 +79,9 @@ phone.addListener("initInteractive", (data: {
   }
   updateStores(initialState);
 
-  onSnapshot(stores.tephraSimulation, saveUserData);       // MobX function called on every store change
+  onSnapshot(stores.unit, saveUserData);                   // MobX function called on every store change
+  onSnapshot(stores.tephraSimulation, saveUserData);
+  onSnapshot(stores.blocklyStore, saveUserData);
   onSnapshot(stores.uiStore, saveUserData);
 });
 


### PR DESCRIPTION
This fixes the issue that making changes only on these stores (e.g. setting the unit to Seismic, then changing the toolbox and dragging out a block) wasn't getting saved.

This can be tested by a LARA Staging admin on this page: https://authoring.staging.concord.org/activities/20811/pages/308056/edit