### PR TITLE
Strain rate map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4084,11 +4084,6 @@
         }
       }
     },
-    "@types/tinycolor2": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/tinycolor2/-/tinycolor2-1.4.2.tgz",
-      "integrity": "sha512-PeHg/AtdW6aaIO2a+98Xj7rWY4KC1E6yOy7AFknJQ7VXUGNrMlyxDFxJo7HqLtjQms/ZhhQX52mLVW/EX3JGOw=="
-    },
     "@types/uuid": {
       "version": "3.4.5",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-3.4.5.tgz",
@@ -17086,15 +17081,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
       "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
-    },
-    "tinygradient": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/tinygradient/-/tinygradient-1.1.2.tgz",
-      "integrity": "sha512-yIwbBfJOOHW3whamF00ZcxGWY794GNsAGjaCkDQJJNufXAcfUwbQwrVjwV1BKqArXFVg+JgMoECXFn/jfqSWsg==",
-      "requires": {
-        "@types/tinycolor2": "^1.4.0",
-        "tinycolor2": "^1.0.0"
-      }
     },
     "tmp": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -169,7 +169,6 @@
     "recharts": "^1.5.0",
     "screenfull": "^4.2.0",
     "styled-components": "^5.1.1",
-    "tinygradient": "^1.1.2",
     "transformation-matrix": "^1.15.3",
     "uuid": "^3.3.2",
     "wait-on": "^3.2.0"

--- a/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
@@ -6,6 +6,9 @@
     <block type="seismic_filter_data"></block>
     <block type="graph_gps_position"></block>
     <block type="seismic_compute_strain"></block>
+    <block type="seismic_render_strain_triangles"></block>
+    <block type="seismic_logarithmic"></block>
+    <block type="seismic_equal_interval"></block>
   </category>
 
   <category name="Deformation Model" colour="15">

--- a/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
@@ -5,6 +5,7 @@
     <block type="seismic_sample_data"></block>
     <block type="seismic_filter_data"></block>
     <block type="graph_gps_position"></block>
+    <block type="seismic_compute_strain"></block>
   </category>
 
   <category name="Deformation Model" colour="15">

--- a/src/blockly-blocks/blocks.js
+++ b/src/blockly-blocks/blocks.js
@@ -30,4 +30,5 @@ import "./tephra/block-calculate-tephra-vei-wind";
 import "./tephra/block-risk-level";
 import "./seismic/block-seismic-gps-stations";
 import "./seismic/block-seismic-graph-gps-position";
+import "./seismic/block-seismic-strain-rate";
 import "./deformation/block-deformation-create-sim";

--- a/src/blockly-blocks/seismic/block-seismic-strain-rate.js
+++ b/src/blockly-blocks/seismic/block-seismic-strain-rate.js
@@ -1,0 +1,51 @@
+Blockly.Blocks['seismic_compute_strain'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('Compute strain rate')
+    this.appendValueInput('min_lat')
+      .setCheck(['Number'])
+      .setAlign(Blockly.ALIGN_RIGHT)
+      .appendField('Min Latitude')
+    this.appendValueInput('max_lat')
+      .setCheck(['Number'])
+      .setAlign(Blockly.ALIGN_RIGHT)
+      .appendField('Max Latitude')
+    this.appendValueInput('min_long')
+      .setCheck(['Number'])
+      .setAlign(Blockly.ALIGN_RIGHT)
+      .appendField('Min Longitude')
+    this.appendValueInput('max_long')
+      .setCheck(['Number'])
+      .setAlign(Blockly.ALIGN_RIGHT)
+      .appendField('Max Longitude')
+    this.setInputsInline(false)
+
+    this.setPreviousStatement(true, null)
+    this.setNextStatement(true, null)
+    this.setColour(230)
+    this.setTooltip('Compute strain rate')
+    this.setHelpUrl('')
+  }
+}
+Blockly.JavaScript['seismic_compute_strain'] = function (block) {
+  var value_min_long = Blockly.JavaScript.valueToCode(block, 'min_long', Blockly.JavaScript.ORDER_ATOMIC)
+  var value_max_long = Blockly.JavaScript.valueToCode(block, 'max_long', Blockly.JavaScript.ORDER_ATOMIC)
+  var value_min_lat = Blockly.JavaScript.valueToCode(block, 'min_lat', Blockly.JavaScript.ORDER_ATOMIC)
+  var value_max_lat = Blockly.JavaScript.valueToCode(block, 'max_lat', Blockly.JavaScript.ORDER_ATOMIC)
+
+  var filter = {
+    longitude: {min: value_min_long || -180, max: value_max_long || 180},
+    latitude: {min: value_min_lat || -90, max: value_max_lat || 90},
+  };
+
+  // remove all defaults by hand if both min and max are defaults
+  if (filter.longitude.min === -180 && filter.longitude.max === 180) delete filter.longitude;
+  if (filter.latitude.min === -90 && filter.latitude.max === 90) delete filter.latitude;
+
+  let filterObj = JSON.stringify(filter);
+  filterObj = filterObj.replace(/\"/g, "");
+
+  var code = `computeStrainRate(${filterObj});`
+  // TODO: Change ORDER_NONE to the correct strength.
+  return code;
+}

--- a/src/blockly-blocks/seismic/block-seismic-strain-rate.js
+++ b/src/blockly-blocks/seismic/block-seismic-strain-rate.js
@@ -49,3 +49,60 @@ Blockly.JavaScript['seismic_compute_strain'] = function (block) {
   // TODO: Change ORDER_NONE to the correct strength.
   return code;
 }
+
+Blockly.Blocks['seismic_logarithmic'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('Logarithmic')
+    this.setOutput(true, 'Color_method')
+    this.setColour("%{BKY_LISTS_HUE}")
+    this.setTooltip('')
+    this.setHelpUrl('')
+  }
+}
+Blockly.JavaScript['seismic_logarithmic'] = function (block) {
+  // TODO: Assemble JavaScript into code variable.
+  var code = '"logarithmic"';
+  // TODO: Change ORDER_NONE to the correct strength.
+  return [code, Blockly.JavaScript.ORDER_NONE]
+}
+
+Blockly.Blocks['seismic_equal_interval'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('Equal Interval')
+    this.setOutput(true, 'Color_method')
+    this.setColour("%{BKY_LISTS_HUE}")
+    this.setTooltip('')
+    this.setHelpUrl('')
+  }
+}
+Blockly.JavaScript['seismic_equal_interval'] = function (block) {
+  // TODO: Assemble JavaScript into code variable.
+  var code = '"equalInterval"';
+  // TODO: Change ORDER_NONE to the correct strength.
+  return [code, Blockly.JavaScript.ORDER_NONE]
+}
+
+Blockly.Blocks['seismic_render_strain_triangles'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('Color the map by strain rate')
+    this.appendValueInput('color_method')
+      .setAlign(Blockly.ALIGN_RIGHT)
+      .setCheck(['Color_method'])
+      .appendField('Method')
+    this.setInputsInline(false)
+
+    this.setPreviousStatement(true, null)
+    this.setNextStatement(true, null)
+    this.setColour(230)
+    this.setTooltip('Color the map by strain rate')
+    this.setHelpUrl('')
+  }
+}
+Blockly.JavaScript['seismic_render_strain_triangles'] = function (block) {
+  var value_color_method = Blockly.JavaScript.valueToCode(block, 'color_method', Blockly.JavaScript.ORDER_ATOMIC)
+  var code = value_color_method ? `renderStrainRate${value_color_method};` : "renderStrainRate();";
+  return code;
+}

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -322,6 +322,10 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
       chartsStore.addArbitraryChart(dataset, "East (mm)", "North (mm)", `${params.station} Position over Time`, true);
     });
 
+    addFunc("computeStrainRate", (filter: Filter) => {
+      seismicSimulation.setStrainMapBounds(filter);
+    });
+
     addFunc("runDeformationModel", () => {
       seismicSimulation.startDeformationModel();
     });

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -5,6 +5,7 @@ import { IBlocklyWorkspace } from "../interfaces";
 import { IStore } from "../stores/stores";
 import { Datasets, Dataset, Filter, ProtoTimeRange, TimeRange } from "../stores/data-sets";
 import { StationData } from "../strain";
+import { ColorMethod } from "../stores/seismic-simulation-store";
 const Interpreter = require("js-interpreter");
 
 const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore,
@@ -324,6 +325,14 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
 
     addFunc("computeStrainRate", (filter: Filter) => {
       seismicSimulation.setStrainMapBounds(filter);
+    });
+
+    addFunc("renderStrainRate", (method: ColorMethod) => {
+      if (!method) {
+        blocklyController.throwError(`You must include a method by which to color the strain map.`);
+        return;
+      }
+      seismicSimulation.setRenderStrainMap(method);
     });
 
     addFunc("runDeformationModel", () => {

--- a/src/components/map/map-component.tsx
+++ b/src/components/map/map-component.tsx
@@ -152,11 +152,6 @@ export class MapComponent extends BaseComponent<IProps, IState>{
 
     const {
       scenario: seismicScenario,
-      strainMapMinLat,
-      strainMapMinLng,
-      strainMapMaxLat,
-      strainMapMaxLng,
-      paintStrainMap,
     } = this.stores.seismicSimulation;
 
     const scenario = isTephraUnit ? tephraScenario : seismicScenario;
@@ -329,11 +324,6 @@ export class MapComponent extends BaseComponent<IProps, IState>{
               <MapTriangulatedStrainLayer
                 key="strain-layer"
                 map={this.state.mapLeafletRef}
-                minLat={strainMapMinLat}
-                maxLat={strainMapMaxLat}
-                minLng={strainMapMinLng}
-                maxLng={strainMapMaxLng}
-                paintTriangles={paintStrainMap}
               />,
               <MapGPSStationsLayer
                 key="gps-layer"

--- a/src/components/map/map-component.tsx
+++ b/src/components/map/map-component.tsx
@@ -151,7 +151,12 @@ export class MapComponent extends BaseComponent<IProps, IState>{
     } = this.stores.tephraSimulation;
 
     const {
-      scenario: seismicScenario
+      scenario: seismicScenario,
+      strainMapMinLat,
+      strainMapMinLng,
+      strainMapMaxLat,
+      strainMapMaxLng,
+      paintStrainMap,
     } = this.stores.seismicSimulation;
 
     const scenario = isTephraUnit ? tephraScenario : seismicScenario;
@@ -321,16 +326,15 @@ export class MapComponent extends BaseComponent<IProps, IState>{
           {
             !isTephraUnit &&
             [
-              // <Pane key="strain-layer"
-              //   style={{zIndex: 2}}>
-              //   <MapTriangulatedStrainLayer
-              //     map={this.state.mapLeafletRef}
-              //     minLat={35}
-              //     maxLat={37}
-              //     minLng={-124}
-              //     maxLng={-119}
-              //   />
-              // </Pane>,
+              <MapTriangulatedStrainLayer
+                key="strain-layer"
+                map={this.state.mapLeafletRef}
+                minLat={strainMapMinLat}
+                maxLat={strainMapMaxLat}
+                minLng={strainMapMinLng}
+                maxLng={strainMapMaxLng}
+                paintTriangles={paintStrainMap}
+              />,
               <MapGPSStationsLayer
                 key="gps-layer"
                 map={this.state.mapLeafletRef}

--- a/src/components/map/map-component.tsx
+++ b/src/components/map/map-component.tsx
@@ -20,11 +20,12 @@ import { RulerDrawLayer } from "./layers/ruler-draw-layer";
 import { RightSectionTypes } from "../tabs";
 import KeyButton from "./map-key-button";
 import CompassComponent from "./map-compass";
-import { LegendComponent } from "./map-legend";
+import { LegendComponent, LegendType } from "./map-legend";
 import { SamplesCollectionModelType, SamplesLocationModelType } from "../../stores/samples-collections-store";
 import { RiskLevels } from "../montecarlo/monte-carlo";
 import { LatLngDrawLayer } from "./layers/latlng-draw-layer";
 import { MapGPSStationsLayer } from "./map-gps-stations-layer";
+import { ColorMethod } from "../../stores/seismic-simulation-store";
 
 interface WorkspaceProps {
   width: number;
@@ -152,6 +153,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
 
     const {
       scenario: seismicScenario,
+      strainMapColorMethod,
     } = this.stores.seismicSimulation;
 
     const scenario = isTephraUnit ? tephraScenario : seismicScenario;
@@ -159,6 +161,10 @@ export class MapComponent extends BaseComponent<IProps, IState>{
     const { showCrossSection } = this.stores.uiStore;
 
     const scenarioData = (Scenarios as {[key: string]: Scenario})[scenario];
+
+    const legendType: LegendType = isTephraUnit ?
+                        panelType !== RightSectionTypes.MONTE_CARLO ? "Tephra" : "Risk" :
+                        "Strain";
 
     const {
       initialZoom,
@@ -356,7 +362,8 @@ export class MapComponent extends BaseComponent<IProps, IState>{
           ? <KeyButton onClick={this.onKeyClick}/>
           : <LegendComponent
               onClick={this.onKeyButtonClick}
-              showTephra={panelType !== RightSectionTypes.MONTE_CARLO}
+              legendType={legendType}
+              colorMethod={strainMapColorMethod as ColorMethod}
             />
         }
         <CompassComponent/>

--- a/src/components/map/map-legend.tsx
+++ b/src/components/map/map-legend.tsx
@@ -4,6 +4,8 @@ import styled from "styled-components";
 import IconButton from "../buttons/icon-button";
 import TephraLegendComponent from "./map-tephra-legend";
 import RiskLegendComponent from "./map-risk-legend";
+import StrainLegendComponent from "./map-strain-legend";
+import { ColorMethod } from "../../stores/seismic-simulation-store";
 
 const LegendContainer = styled.div`
   display: flex;
@@ -20,55 +22,62 @@ const LegendContainer = styled.div`
   padding-bottom: 5px;
 `;
 
+export type LegendType = "Tephra" | "Risk" | "Strain";
+
 interface IProps extends IBaseProps {
   onClick: any;
-  showTephra: boolean;
+  legendType: LegendType;
+  colorMethod: ColorMethod;
 }
 
 interface IState {
-  showTephra: boolean;
+  toggledToSecondary: boolean;
 }
 
 export class LegendComponent extends BaseComponent<IProps, IState> {
 
-  constructor(props: IProps) {
-    super(props);
-
-    const initialState: IState = {
-      showTephra: this.props.showTephra,
-    };
-
-    this.state = initialState;
-  }
+  public state = {
+    toggledToSecondary: false
+  };
 
   public render() {
-    const { onClick } = this.props;
+    const { onClick, legendType, colorMethod } = this.props;
+    const { toggledToSecondary } = this.state;
+    const currentLegendType = legendType === "Tephra" && toggledToSecondary ? "Risk" :
+                              legendType === "Risk" && toggledToSecondary ? "Tephra" :
+                              legendType;
+    const legend = currentLegendType === "Tephra" ? <TephraLegendComponent onClick={onClick} /> :
+                    currentLegendType === "Risk" ? <RiskLegendComponent onClick={onClick} /> :
+                    <StrainLegendComponent onClick={onClick} colorMethod={colorMethod} />;
+    const showToggle = legendType === "Tephra" || legendType === "Risk";
     return (
       <LegendContainer data-test="key-container">
-        { this.state.showTephra
-          ? <TephraLegendComponent onClick={onClick}/>
-          : <RiskLegendComponent onClick={onClick}/>
+        {
+          legend
         }
-        <IconButton
-          onClick={this.onLegendModeClick}
-          disabled={false}
-          label={this.state.showTephra ? "Show Risk" : "Show Tephra"}
-          borderColor={"#ADD1A2"}
-          hoverColor={"#ADD1A2"}
-          activeColor={"#B7DCAD"}
-          fontSize={"13px"}
-          fill={"black"}
-          width={26}
-          height={26}
-          dataTest={"map-key-toggle"}
-        />
+        {
+          showToggle &&
+          <IconButton
+            onClick={this.onLegendModeClick}
+            disabled={false}
+            label={`Show ${currentLegendType === "Tephra" ? "Risk" : "Tephra"}`}
+            borderColor={"#ADD1A2"}
+            hoverColor={"#ADD1A2"}
+            activeColor={"#B7DCAD"}
+            fontSize={"13px"}
+            fill={"black"}
+            width={26}
+            height={26}
+            dataTest={"map-key-toggle"}
+          />
+        }
       </LegendContainer>
     );
   }
 
   private onLegendModeClick = () => {
     this.setState(prevState => ({
-      showTephra: !prevState.showTephra
+      toggledToSecondary: !prevState.toggledToSecondary
     }));
   }
 

--- a/src/components/map/map-strain-legend.tsx
+++ b/src/components/map/map-strain-legend.tsx
@@ -39,3 +39,49 @@ for (let i = 0; i < buckets; i++) {
     max: (i < buckets - 1) ? MIN_LOG_STRAIN + (logStepSize * (i + 1)) : undefined
   });
 }
+
+interface IProps {
+  onClick: any;
+  colorMethod: ColorMethod;
+}
+
+interface IState {}
+
+export default class StrainLegendComponent extends PureComponent<IProps, IState> {
+  public static defaultProps = {
+    onClick: undefined,
+  };
+
+  public render() {
+    const { onClick, colorMethod } = this.props;
+    const isLog = colorMethod === "logarithmic";
+    const ranges = isLog ? logarithmicStrainRanges : equalIntervalStrainRanges;
+    const round = (val: number) => isLog ? Math.pow(10, val).toFixed(2) : Math.round(val);
+    return (
+      <LegendContainer>
+        <LegendTitleText>Strain rate{isLog ? " (log)" : ""}</LegendTitleText>
+        <AbsoluteIcon
+          width={12}
+          height={12}
+          fill={"#b7dcad"}
+          onClick={onClick}
+        >
+          <CloseIcon />
+        </AbsoluteIcon>
+        {ranges.map((range, index) => {
+            return (
+              <TephraContainer key={index} data-test="tephra-key">
+                <TephraBox backgroundColor={range.color}/>
+                { range.max
+                  ? <TephraLabel>{` ${round(range.min)}—${round(range.max)}`}</TephraLabel>
+                  : <TephraLabel>{` >${round(range.min)}`}</TephraLabel>
+                }
+              </TephraContainer>
+            );
+        })}
+
+      </LegendContainer>
+    );
+  }
+
+}

--- a/src/components/map/map-strain-legend.tsx
+++ b/src/components/map/map-strain-legend.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import { PureComponent } from "react";
+import CloseIcon from "../../assets/map-icons/close.svg";
+import { LegendContainer, LegendTitleText, AbsoluteIcon,
+  TephraContainer, TephraBox, TephraLabel } from "./map-tephra-legend";
+import { ColorMethod } from "../../stores/seismic-simulation-store";
+
+// actual data ranges from 0 to 127000, but with only 4 values above 160
+const MIN_STRAIN = 0;
+const MAX_STRAIN = 140;
+
+const MIN_LOG_STRAIN = Math.log10(0.00001);
+const MAX_LOG_STRAIN = Math.log10(1000);
+
+const buckets = 7;
+
+export interface StrainRange {
+  color: string;
+  min: number;
+  max: number | undefined;
+}
+const colors = ["#EEE270", "#FFBF4E", "#FF754B", "#E94E83", "#AE4ED3", "#7B58AE", "#515A94"];
+
+const stepSize = (MAX_STRAIN - MIN_STRAIN) / buckets;
+const logStepSize = (MAX_LOG_STRAIN - MIN_LOG_STRAIN) / buckets;
+
+export const equalIntervalStrainRanges: StrainRange[] = [];
+export const logarithmicStrainRanges: StrainRange[] = [];
+
+for (let i = 0; i < buckets; i++) {
+  equalIntervalStrainRanges.push({
+    color: colors[i],
+    min: MIN_STRAIN + (stepSize * i),
+    max: (i < buckets - 1) ? MIN_STRAIN + (stepSize * (i + 1)) : undefined
+  });
+  logarithmicStrainRanges.push({
+    color: colors[i],
+    min: MIN_LOG_STRAIN + (logStepSize * i),
+    max: (i < buckets - 1) ? MIN_LOG_STRAIN + (logStepSize * (i + 1)) : undefined
+  });
+}

--- a/src/components/map/map-tephra-legend.tsx
+++ b/src/components/map/map-tephra-legend.tsx
@@ -47,7 +47,7 @@ export const TephraRanges: TephraRange[] = [
   },
 ];
 
-const LegendContainer = styled.div`
+export const LegendContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
@@ -56,7 +56,7 @@ const LegendContainer = styled.div`
   height: 227px;
 `;
 
-const LegendTitleText = styled.div`
+export const LegendTitleText = styled.div`
   margin: 5px 11px 2px 11px;
   color: #434343;
   font-size: 14px;
@@ -66,7 +66,7 @@ const LegendTitleText = styled.div`
   text-align: center;
 `;
 
-const AbsoluteIcon = styled(Icon)`
+export const AbsoluteIcon = styled(Icon)`
   position: absolute;
   top: 2px;
   right: 6px;
@@ -78,7 +78,7 @@ const AbsoluteIcon = styled(Icon)`
   }
 `;
 
-const TephraContainer = styled.div`
+export const TephraContainer = styled.div`
   display: flex;
   justify-content: flex-start;
   align-items: flex-start;
@@ -86,10 +86,10 @@ const TephraContainer = styled.div`
   margin-top: 5px;
 `;
 
-interface TephraBoxProps {
+export interface TephraBoxProps {
   backgroundColor?: string;
 }
-const TephraBox = styled.div`
+export const TephraBox = styled.div`
   width: 25px;
   height: 20px;
   box-sizing: border-box;
@@ -98,7 +98,7 @@ const TephraBox = styled.div`
   margin-right: 2px;
 `;
 
-const TephraLabel = styled.div`
+export const TephraLabel = styled.div`
   color: #434343;
   font-size: 12px;
 `;

--- a/src/components/map/map-triangulated-strain-layer.tsx
+++ b/src/components/map/map-triangulated-strain-layer.tsx
@@ -5,22 +5,14 @@ import "leaflet-kmz";
 
 import { inject, observer } from "mobx-react";
 import { BaseComponent } from "../base";
-import Delaunator from "delaunator";
 import axios from "axios";
-import strainCalc from "../../strain";
-import { StationData, StrainOutput } from "../../strain";
+import { StationData } from "../../strain";
 import "../../css/custom-leaflet-icons.css";
 import * as tinygradient from "tinygradient";
-import { parseOfflineUNAVCOData } from "../../utilities/unavco-data";
 import { LayerGroup, Polygon } from "react-leaflet";
 
 interface IProps {
   map: Leaflet.Map | null;
-  minLat: number;
-  maxLat: number;
-  minLng: number;
-  maxLng: number;
-  paintTriangles: boolean;
 }
 
 interface IState {
@@ -67,97 +59,15 @@ export class MapTriangulatedStrainLayer extends BaseComponent<IProps, IState> {
   }
 
   public render() {
-    const { map, paintTriangles } = this.props;
+    const { map } = this.props;
+    const { delaunayTriangles, delaunayTriangleStrains, paintStrainMap } = this.stores.seismicSimulation;
 
-    if (!map || !paintTriangles) return null;
-
-    const { minLat, maxLat, minLng, maxLng } = this.props;
-
-    const data = parseOfflineUNAVCOData(minLat, maxLat, minLng, maxLng);    // FIXME stationDate
-
-    // const { data } = this.state;
-
-    // Proximity based point removal
-    // GPS points that are very close to each other will produce extremely high strain values
-    // By removing these points, it becomes easier to plot the data using an infinite scale
-    // Other methods of solving this problem would be by plotting the data in a bucketed gradient
-    // e.g. 0 - 5: Blue, 5 - 50: Green, 50 - 250: Yellow, 250+: Red
-    const removablePoints: Set<string> = new Set<string>();
-    for (let i = 0; i < data.length; i++) {
-      for (let k = i + 1; k < data.length; k++) {
-        const dist = Math.sqrt(Math.pow(data[i].latitude - data[k].latitude, 2) +
-                    Math.pow(data[i].longitude - data[k].longitude, 2));
-        if (dist < 0.1) {
-          removablePoints.add(data[i].id);
-          break;
-        }
-      }
-    }
-
-    const filteredData: StationData[] = data.filter((obj: StationData) => !removablePoints.has(obj.id));
-
-    const points: number[][] = [];
-    const coords: number[] = [];
-    for (const station of filteredData) {
-      const lat = station.latitude;
-      const lng = station.longitude;
-
-      coords.push(lat);
-      coords.push(lng);
-      points.push([lat, lng]);
-
-    }
-
-    // Delaunator takes in a 1D array of coordinates organized [x1, y1, x2, y2, ...]
-    // It outputs a 2D array containing sets of vertices
-    // Each vertex is returned as an index to an array of coordinates
-    const mesh = new Delaunator(coords);
-    const strainOutputs: StrainOutput[] = [];
-    const adjustedStrainValues: number[] = [];
-    let strainMin: number = 0;
-    let strainMax: number = 0;
-
-    for (let i = 0; i < mesh.triangles.length; i += 3) {
-      const strainOutput: StrainOutput = strainCalc({data: [ filteredData[mesh.triangles[i]],
-        filteredData[mesh.triangles[i + 1]],
-        filteredData[mesh.triangles[i + 2]],
-      ]});
-
-      const strain = strainOutput.secondInvariant;
-      // const strain = Math.log10(strainOutput.maxShearStrain);
-      // strain = Math.sign(strain) * Math.log10(Math.abs(strain));
-      strainOutputs.push(strainOutput);
-      adjustedStrainValues.push(strain);
-      if (i === 0) {
-        strainMin = strain;
-        strainMax = strain;
-      } else {
-        strainMax = strain > strainMax ? strain : strainMax;
-        strainMin = strain < strainMin ? strain : strainMin;
-      }
-    }
-
-    for (let i = 0; i < strainOutputs.length; i++) {
-      const percent = (adjustedStrainValues[i] - strainMin) / (strainMax - strainMin);
-      adjustedStrainValues[i] = percent * (1) + 0;
-      adjustedStrainValues[i] = Number.isNaN(adjustedStrainValues[i]) ? strainMin : adjustedStrainValues[i];
-
-    }
+    if (!map || !paintStrainMap) return null;
 
     const triangles = [];
-    for (let i = 0; i < mesh.triangles.length; i += 3) {
-      const p1 = Leaflet.latLng(
-        points[mesh.triangles[i]][0],
-        points[mesh.triangles[i]][1]
-      );
-      const p2 = Leaflet.latLng(
-        points[mesh.triangles[i + 1]][0],
-        points[mesh.triangles[i + 1]][1]
-      );
-      const p3 = Leaflet.latLng(
-        points[mesh.triangles[i + 2]][0],
-        points[mesh.triangles[i + 2]][1]
-      );
+    for (let i = 0; i < delaunayTriangles.length; i++) {
+      const triangle = delaunayTriangles[i];
+      const [p1, p2, p3] = triangle.map(p => Leaflet.latLng(p[0], p[1]));
 
       triangles.push(<Polygon
         positions={[p1, p2, p3]} key={`triangle-${i}`}
@@ -165,8 +75,36 @@ export class MapTriangulatedStrainLayer extends BaseComponent<IProps, IState> {
         color="#FFF"
         weight={1}
         fillOpacity={0.8}
-        fillColor={this.gradient.rgbAt(adjustedStrainValues[(i - i % 3) / 3]).toRgbString()}
+        fillColor={this.gradient.rgbAt(delaunayTriangleStrains[i]).toRgbString()}
       />);
+
+      // triangles.push(Leaflet.polygon(
+      //   [p1, p2, p3],
+        // {
+        //   stroke: true,
+        //   color: "#FFF",
+        //   weight: 1,
+        //   fillOpacity: 0.8,
+        //   fillColor: this.gradient.rgbAt(adjustedStrainValues[(i - i % 3) / 3]).toRgbString()
+        // }
+      //   ));
+
+      // // calculate the "incenter" of the triangle
+      // const perim1 = Math.sqrt(((p1.lat - p2.lat) ** 2) + ((p1.lng - p2.lng) ** 2));
+      // const perim2 = Math.sqrt(((p2.lat - p3.lat) ** 2) + ((p2.lng - p3.lng) ** 2));
+      // const perim3 = Math.sqrt(((p3.lat - p1.lat) ** 2) + ((p3.lng - p1.lng) ** 2));
+      // const perimiter = perim1 + perim2 + perim3;
+      // const centLat = ((p1.lat * perim2) + (p2.lat * perim3) + p3.lat * perim1) / perimiter;
+      // const centLng = ((p1.lng * perim2) + (p2.lng * perim3) + p3.lng * perim1) / perimiter;
+      // const incenter = Leaflet.latLng(centLat, centLng);
+
+      // // Leaflet.divIcon({iconAnchor: incenter})
+      // Leaflet.circle(incenter, {radius: 1})
+      //   .bindTooltip("" + (Math.round(adjustedStrainValues[(i - i % 3) / 3] * 10000) / 10000), {
+      //     permanent: true,
+      //     className: "plain-label"
+      //   })
+      //   .addTo(map);
     }
     return (
       <LayerGroup>

--- a/src/components/map/map-triangulated-strain-layer.tsx
+++ b/src/components/map/map-triangulated-strain-layer.tsx
@@ -1,3 +1,4 @@
+import * as React from "react";
 import * as Leaflet from "leaflet";
 
 import "leaflet-kmz";
@@ -11,25 +12,27 @@ import { StationData, StrainOutput } from "../../strain";
 import "../../css/custom-leaflet-icons.css";
 import * as tinygradient from "tinygradient";
 import { parseOfflineUNAVCOData } from "../../utilities/unavco-data";
+import { LayerGroup, Polygon } from "react-leaflet";
 
 interface IProps {
-    map: Leaflet.Map | null;
-    minLat: number;
-    maxLat: number;
-    minLng: number;
-    maxLng: number;
+  map: Leaflet.Map | null;
+  minLat: number;
+  maxLat: number;
+  minLng: number;
+  maxLng: number;
+  paintTriangles: boolean;
 }
 
 interface IState {
-    data: StationData[];
+  data: StationData[];
 }
 
 // UNAVCO servers often throw 500 errors. This catches and resolves them, allowing the code to continue
 axios.interceptors.response.use(
-    response => response,
-    error => {
-      console.log(error.message);
-      return Promise.resolve(error);
+  response => response,
+  error => {
+    console.log(error.message);
+    return Promise.resolve(error);
   }
 );
 
@@ -37,157 +40,139 @@ axios.interceptors.response.use(
 @observer
 export class MapTriangulatedStrainLayer extends BaseComponent<IProps, IState> {
 
-    // Gradient used for strain triangle coloration
-    // Usually data has outliers which skew the data up towards the top
-    // Most of the gradient is also skewed towards the top (0.97 and above)
-    // This is not an ideal solution because changing the plotted boundaries yields extremely varying results
-    // depending on how extreme the outliers are
-    // Using standard deviation or some normalization method could fix this
-    private gradient: tinygradient.Instance = tinygradient([
-        {color: "rgb(238, 226, 112)", pos: 0},
-        {color: "rgb(255, 191, 78)", pos: 0.97},
-        {color: "rgb(255, 117, 75)", pos: 0.976},
-        {color: "rgb(233, 78, 131)", pos: 0.982},
-        {color: "rgb(174, 78, 211)", pos: 0.988},
-        {color: "rgb(123, 88, 174)", pos: 0.994},
-        {color: "rgb(81, 90, 148)", pos: 1}
-    ]);
+  // Gradient used for strain triangle coloration
+  // Usually data has outliers which skew the data up towards the top
+  // Most of the gradient is also skewed towards the top (0.97 and above)
+  // This is not an ideal solution because changing the plotted boundaries yields extremely varying results
+  // depending on how extreme the outliers are
+  // Using standard deviation or some normalization method could fix this
+  private gradient: tinygradient.Instance = tinygradient([
+    {color: "rgb(238, 226, 112)", pos: 0},
+    {color: "rgb(255, 191, 78)", pos: 0.97},
+    {color: "rgb(255, 117, 75)", pos: 0.976},
+    {color: "rgb(233, 78, 131)", pos: 0.982},
+    {color: "rgb(174, 78, 211)", pos: 0.988},
+    {color: "rgb(123, 88, 174)", pos: 0.994},
+    {color: "rgb(81, 90, 148)", pos: 1}
+  ]);
 
-    constructor(props: IProps) {
-        super(props);
+  constructor(props: IProps) {
+    super(props);
 
-        // this.getUNAVCOData();
+    const initialState: IState = {
+      data: [],
+    };
 
-        const initialState: IState = {
-          data: [],
-        };
+    this.state = initialState;
+  }
 
-        this.state = initialState;
+  public render() {
+    const { map, paintTriangles } = this.props;
+
+    if (!map || !paintTriangles) return null;
+
+    const { minLat, maxLat, minLng, maxLng } = this.props;
+
+    const data = parseOfflineUNAVCOData(minLat, maxLat, minLng, maxLng);    // FIXME stationDate
+
+    // const { data } = this.state;
+
+    // Proximity based point removal
+    // GPS points that are very close to each other will produce extremely high strain values
+    // By removing these points, it becomes easier to plot the data using an infinite scale
+    // Other methods of solving this problem would be by plotting the data in a bucketed gradient
+    // e.g. 0 - 5: Blue, 5 - 50: Green, 50 - 250: Yellow, 250+: Red
+    const removablePoints: Set<string> = new Set<string>();
+    for (let i = 0; i < data.length; i++) {
+      for (let k = i + 1; k < data.length; k++) {
+        const dist = Math.sqrt(Math.pow(data[i].latitude - data[k].latitude, 2) +
+                    Math.pow(data[i].longitude - data[k].longitude, 2));
+        if (dist < 0.1) {
+          removablePoints.add(data[i].id);
+          break;
+        }
+      }
     }
 
-    public componentDidMount() {
-        const { minLat, maxLat, minLng, maxLng } = this.props;
-        const stationData = parseOfflineUNAVCOData(minLat, maxLat, minLng, maxLng);
-        this.setState({data: stationData});
-        this.buildMesh(stationData);
+    const filteredData: StationData[] = data.filter((obj: StationData) => !removablePoints.has(obj.id));
+
+    const points: number[][] = [];
+    const coords: number[] = [];
+    for (const station of filteredData) {
+      const lat = station.latitude;
+      const lng = station.longitude;
+
+      coords.push(lat);
+      coords.push(lng);
+      points.push([lat, lng]);
+
     }
 
-    // Polygon data is added to the map directly, so there is no react render
-    // This might want to be changed in the future
-    public render() {
-        return null;
+    // Delaunator takes in a 1D array of coordinates organized [x1, y1, x2, y2, ...]
+    // It outputs a 2D array containing sets of vertices
+    // Each vertex is returned as an index to an array of coordinates
+    const mesh = new Delaunator(coords);
+    const strainOutputs: StrainOutput[] = [];
+    const adjustedStrainValues: number[] = [];
+    let strainMin: number = 0;
+    let strainMax: number = 0;
+
+    for (let i = 0; i < mesh.triangles.length; i += 3) {
+      const strainOutput: StrainOutput = strainCalc({data: [ filteredData[mesh.triangles[i]],
+        filteredData[mesh.triangles[i + 1]],
+        filteredData[mesh.triangles[i + 2]],
+      ]});
+
+      const strain = strainOutput.secondInvariant;
+      // const strain = Math.log10(strainOutput.maxShearStrain);
+      // strain = Math.sign(strain) * Math.log10(Math.abs(strain));
+      strainOutputs.push(strainOutput);
+      adjustedStrainValues.push(strain);
+      if (i === 0) {
+        strainMin = strain;
+        strainMax = strain;
+      } else {
+        strainMax = strain > strainMax ? strain : strainMax;
+        strainMin = strain < strainMin ? strain : strainMin;
+      }
     }
 
-    // This method creates and displays a mesh based on the GPS stations acquired from getUNAVCOData()
-    // It uses Delaunator to calculate the mesh and colors each triangle based on calculated strain
-    // The strain calculation can be found in "../../strain.ts"
-    private buildMesh(data: StationData[]) {
-        const { map } = this.props;
+    for (let i = 0; i < strainOutputs.length; i++) {
+      const percent = (adjustedStrainValues[i] - strainMin) / (strainMax - strainMin);
+      adjustedStrainValues[i] = percent * (1) + 0;
+      adjustedStrainValues[i] = Number.isNaN(adjustedStrainValues[i]) ? strainMin : adjustedStrainValues[i];
 
-        // Proximity based point removal
-        // GPS points that are very close to each other will produce extremely high strain values
-        // By removing these points, it becomes easier to plot the data using an infinite scale
-        // Other methods of solving this problem would be by plotting the data in a bucketed gradient
-        // e.g. 0 - 5: Blue, 5 - 50: Green, 50 - 250: Yellow, 250+: Red
-        const removablePoints: Set<string> = new Set<string>();
-        for (let i = 0; i < data.length; i++) {
-            for (let k = 0; k < data.length; k++) {
-                if (i !== k && !removablePoints.has(data[i].id) && !removablePoints.has(data[k].id)) {
-                    const dist = Math.sqrt(Math.pow(data[i].latitude - data[k].latitude, 2) +
-                                           Math.pow(data[i].longitude - data[k].longitude, 2));
-                    if (dist < 0.1) {
-                        removablePoints.add(data[i].id);
-                    }
-                }
-            }
-        }
-
-        // Output station id for all points removed from the mesh
-        // let removedPoints: string = "";
-        // removablePoints.forEach(element => {
-        //     removedPoints += element + ", ";
-        // });
-        // console.log(removedPoints);
-
-        const filteredData: StationData[] = data.filter((obj: StationData) => !removablePoints.has(obj.id));
-
-        const points: number[][] = [];
-        const coords: number[] = [];
-        for (let i = 0; i < filteredData.length; i++) {
-            const lat = filteredData[i].latitude;
-            const lng = filteredData[i].longitude;
-
-            coords.push(lat);
-            coords.push(lng);
-            points.push([lat, lng, i]);
-
-        }
-
-        // Delaunator takes in a 1D array of coordinates organized [x1, y1, x2, y2, ...]
-        // It outputs a 2D array containing sets of vertices
-        // Each vertex is returned as an index to an array of coordinates
-        const mesh = new Delaunator(coords);
-        const strainOutputs: StrainOutput[] = [];
-        const adjustedStrainValues: number[] = [];
-        let strainMin: number = 0;
-        let strainMax: number = 0;
-
-        for (let i = 0; i < mesh.triangles.length; i += 3) {
-            const strainOutput: StrainOutput = strainCalc({data: [ filteredData[points[mesh.triangles[i]][2]],
-                filteredData[points[mesh.triangles[i + 1]][2]],
-                filteredData[points[mesh.triangles[i + 2]][2]],
-            ]});
-
-            const strain = strainOutput.secondInvariant;
-            // const strain = Math.log10(strainOutput.maxShearStrain);
-            // strain = Math.sign(strain) * Math.log10(Math.abs(strain));
-            strainOutputs.push(strainOutput);
-            adjustedStrainValues.push(strain);
-            if (i === 0) {
-                strainMin = strain;
-                strainMax = strain;
-            } else {
-                strainMax = strain > strainMax ? strain : strainMax;
-                strainMin = strain < strainMin ? strain : strainMin;
-            }
-        }
-
-        console.log(strainMax + " " + strainMin);
-
-        for (let i = 0; i < strainOutputs.length; i++) {
-            const percent = (adjustedStrainValues[i] - strainMin) / (strainMax - strainMin);
-            adjustedStrainValues[i] = percent * (1) + 0;
-            adjustedStrainValues[i] = Number.isNaN(adjustedStrainValues[i]) ? strainMin : adjustedStrainValues[i];
-
-        }
-
-        for (let i = 0; i < mesh.triangles.length; i += 3) {
-            if (map) {
-                const p1 = Leaflet.latLng(
-                    points[mesh.triangles[i]][0],
-                    points[mesh.triangles[i]][1]
-                );
-                const p2 = Leaflet.latLng(
-                    points[mesh.triangles[i + 1]][0],
-                    points[mesh.triangles[i + 1]][1]
-                );
-                const p3 = Leaflet.latLng(
-                    points[mesh.triangles[i + 2]][0],
-                    points[mesh.triangles[i + 2]][1]
-                );
-
-                const polygon: Leaflet.Polygon = Leaflet.polygon(
-                    [p1, p2, p3],
-                    {
-                        stroke: true,
-                        color: "#FFF",
-                        weight: 1,
-                        fillOpacity: 1,
-                        fillColor: this.gradient.rgbAt(adjustedStrainValues[(i - i % 3) / 3]).toRgbString()
-                    }
-                    ).addTo(map);
-            }
-        }
     }
+
+    const triangles = [];
+    for (let i = 0; i < mesh.triangles.length; i += 3) {
+      const p1 = Leaflet.latLng(
+        points[mesh.triangles[i]][0],
+        points[mesh.triangles[i]][1]
+      );
+      const p2 = Leaflet.latLng(
+        points[mesh.triangles[i + 1]][0],
+        points[mesh.triangles[i + 1]][1]
+      );
+      const p3 = Leaflet.latLng(
+        points[mesh.triangles[i + 2]][0],
+        points[mesh.triangles[i + 2]][1]
+      );
+
+      triangles.push(<Polygon
+        positions={[p1, p2, p3]} key={`triangle-${i}`}
+        stroke={true}
+        color="#FFF"
+        weight={1}
+        fillOpacity={0.8}
+        fillColor={this.gradient.rgbAt(adjustedStrainValues[(i - i % 3) / 3]).toRgbString()}
+      />);
+    }
+    return (
+      <LayerGroup>
+        {triangles}
+      </LayerGroup>
+    );
+  }
 
 }

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -17,6 +17,8 @@ const deformationSite1 = [0.75, 0.2];
 const deformationSite2 = [0.6, 0.85];
 const deformationSite3 = [0.2, 0.6];
 
+export type ColorMethod = "logarithmic" | "equalInterval";
+
 export const SeismicSimulationStore = types
   .model("seismicSimulation", {
     scenario: "Seismic CA",
@@ -38,7 +40,8 @@ export const SeismicSimulationStore = types
     strainMapMinLng: -180,
     strainMapMaxLat: 90,
     strainMapMaxLng: 180,
-    paintStrainMap: false,
+    strainMapColorMethod: types.optional(types.string, "logarithmic"),
+    renderStrainMap: false,
   })
   .volatile(self => ({
     delaunayTriangles: [] as number[][][],
@@ -141,9 +144,10 @@ export const SeismicSimulationStore = types
 
         self.delaunayTriangles.push([p1, p2, p3]);
       }
-
-      // FIXME
-      self.paintStrainMap = true;
+    },
+    setRenderStrainMap(method: ColorMethod) {
+      self.strainMapColorMethod = method;
+      self.renderStrainMap = true;
     },
     reset() {
       self.visibleGPSStationIds.clear();
@@ -154,7 +158,7 @@ export const SeismicSimulationStore = types
       self.strainMapMinLng = -180;
       self.strainMapMaxLat = 90;
       self.strainMapMaxLng = 180;
-      self.paintStrainMap = false;
+      self.renderStrainMap = false;
     }
   }))
   .actions((self) => ({

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -1,6 +1,7 @@
 import { types } from "mobx-state-tree";
 import { parseOfflineUNAVCOData } from "../utilities/unavco-data";
 import { StationData } from "../strain";
+import { Filter, Range } from "./data-sets";
 
 const minLat = 32;
 const maxLat = 42;
@@ -30,8 +31,13 @@ export const SeismicSimulationStore = types
     deformDirPlate1: 0,
     deformSpeedPlate2: 0,
     deformDirPlate2: 0,
-    deformMaxSpeed: 30
+    deformMaxSpeed: 30,
 
+    strainMapMinLat: -90,
+    strainMapMinLng: -180,
+    strainMapMaxLat: 90,
+    strainMapMaxLng: 180,
+    paintStrainMap: false,
   })
   .actions((self) => ({
     showGPSStations(stations: StationData[] | string) {
@@ -54,11 +60,32 @@ export const SeismicSimulationStore = types
     setShowVelocityArrows(show: boolean) {
       self.showVelocityArrows = show;
     },
+    setStrainMapBounds(bounds: Filter) {
+      if (bounds.latitude && (bounds.latitude as Range).min) {
+        self.strainMapMinLat = (bounds.latitude as Range).min as number;
+      }
+      if (bounds.longitude && (bounds.longitude as Range).min) {
+        self.strainMapMinLng = (bounds.longitude as Range).min as number;
+      }
+      if (bounds.latitude && (bounds.latitude as Range).max) {
+        self.strainMapMaxLat = (bounds.latitude as Range).max as number;
+      }
+      if (bounds.longitude && (bounds.longitude as Range).max) {
+        self.strainMapMaxLng = (bounds.longitude as Range).max as number;
+      }
+      // FIXME
+      self.paintStrainMap = true;
+    },
     reset() {
       self.visibleGPSStationIds.clear();
       self.selectedGPSStationId = undefined;
       self.showVelocityArrows = false;
       self.deformationModelStep = 0;
+      self.strainMapMinLat = -90;
+      self.strainMapMinLng = -180;
+      self.strainMapMaxLat = 90;
+      self.strainMapMaxLng = 180;
+      self.paintStrainMap = false;
     }
   }))
   .actions((self) => ({

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -123,9 +123,6 @@ export const SeismicSimulationStore = types
       // It outputs a 2D array containing sets of vertices
       // Each vertex is returned as an index to an array of coordinates
       const mesh = new Delaunator(coords);
-      const strainOutputs: StrainOutput[] = [];
-      let strainMin: number = 0;
-      let strainMax: number = 0;
 
       for (let i = 0; i < mesh.triangles.length; i += 3) {
         const strainOutput: StrainOutput = strainCalc({data: [ filteredData[mesh.triangles[i]],
@@ -134,24 +131,7 @@ export const SeismicSimulationStore = types
         ]});
 
         const strain = strainOutput.secondInvariant;
-        // const strain = Math.log10(strainOutput.maxShearStrain);
-        // strain = Math.sign(strain) * Math.log10(Math.abs(strain));
-        strainOutputs.push(strainOutput);
         self.delaunayTriangleStrains.push(strain);
-        if (i === 0) {
-          strainMin = strain;
-          strainMax = strain;
-        } else {
-          strainMax = strain > strainMax ? strain : strainMax;
-          strainMin = strain < strainMin ? strain : strainMin;
-        }
-      }
-
-      for (let i = 0; i < strainOutputs.length; i++) {
-        const percent = ( self.delaunayTriangleStrains[i] - strainMin) / (strainMax - strainMin);
-        self.delaunayTriangleStrains[i] = percent * (1) + 0;
-        self.delaunayTriangleStrains[i] = Number.isNaN( self.delaunayTriangleStrains[i]) ?
-          strainMin :  self.delaunayTriangleStrains[i];
       }
 
       for (let i = 0; i < mesh.triangles.length; i += 3) {

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -1,7 +1,8 @@
 import { types } from "mobx-state-tree";
 import { parseOfflineUNAVCOData } from "../utilities/unavco-data";
-import { StationData } from "../strain";
+import strainCalc, { StationData, StrainOutput } from "../strain";
 import { Filter, Range } from "./data-sets";
+import Delaunator from "delaunator";
 
 const minLat = 32;
 const maxLat = 42;
@@ -39,6 +40,10 @@ export const SeismicSimulationStore = types
     strainMapMaxLng: 180,
     paintStrainMap: false,
   })
+  .volatile(self => ({
+    delaunayTriangles: [] as number[][][],
+    delaunayTriangleStrains: [] as number[],
+  }))
   .actions((self) => ({
     showGPSStations(stations: StationData[] | string) {
       self.visibleGPSStationIds.clear();
@@ -61,6 +66,9 @@ export const SeismicSimulationStore = types
       self.showVelocityArrows = show;
     },
     setStrainMapBounds(bounds: Filter) {
+      self.delaunayTriangles = [];
+      self.delaunayTriangleStrains = [];
+
       if (bounds.latitude && (bounds.latitude as Range).min) {
         self.strainMapMinLat = (bounds.latitude as Range).min as number;
       }
@@ -73,6 +81,87 @@ export const SeismicSimulationStore = types
       if (bounds.longitude && (bounds.longitude as Range).max) {
         self.strainMapMaxLng = (bounds.longitude as Range).max as number;
       }
+
+      // const { minLat, maxLat, minLng, maxLng } = this.props;
+
+      const stationDataInBounds = stationData.filter(s =>
+        s.latitude >= self.strainMapMinLat && s.latitude <= self.strainMapMaxLat &&
+        s.longitude >= self.strainMapMinLng && s.longitude <= self.strainMapMaxLng);
+
+      // Proximity based point removal
+      // GPS points that are very close to each other will produce extremely high strain values
+      // By removing these points, it becomes easier to plot the data using an infinite scale
+      // Other methods of solving this problem would be by plotting the data in a bucketed gradient
+      // e.g. 0 - 5: Blue, 5 - 50: Green, 50 - 250: Yellow, 250+: Red
+      const removablePoints: Set<string> = new Set<string>();
+      for (let i = 0; i < stationDataInBounds.length; i++) {
+        for (let k = i + 1; k < stationDataInBounds.length; k++) {
+          const dist = Math.sqrt(Math.pow(stationDataInBounds[i].latitude - stationDataInBounds[k].latitude, 2) +
+                      Math.pow(stationDataInBounds[i].longitude - stationDataInBounds[k].longitude, 2));
+          if (dist < 0.1) {
+            removablePoints.add(stationDataInBounds[i].id);
+            break;
+          }
+        }
+      }
+
+      const filteredData: StationData[] = stationDataInBounds.filter(s => !removablePoints.has(s.id));
+
+      const points: number[][] = [];
+      const coords: number[] = [];
+      for (const station of filteredData) {
+        const lat = station.latitude;
+        const lng = station.longitude;
+
+        coords.push(lat);
+        coords.push(lng);
+        points.push([lat, lng]);
+
+      }
+
+      // Delaunator takes in a 1D array of coordinates organized [x1, y1, x2, y2, ...]
+      // It outputs a 2D array containing sets of vertices
+      // Each vertex is returned as an index to an array of coordinates
+      const mesh = new Delaunator(coords);
+      const strainOutputs: StrainOutput[] = [];
+      let strainMin: number = 0;
+      let strainMax: number = 0;
+
+      for (let i = 0; i < mesh.triangles.length; i += 3) {
+        const strainOutput: StrainOutput = strainCalc({data: [ filteredData[mesh.triangles[i]],
+          filteredData[mesh.triangles[i + 1]],
+          filteredData[mesh.triangles[i + 2]],
+        ]});
+
+        const strain = strainOutput.secondInvariant;
+        // const strain = Math.log10(strainOutput.maxShearStrain);
+        // strain = Math.sign(strain) * Math.log10(Math.abs(strain));
+        strainOutputs.push(strainOutput);
+        self.delaunayTriangleStrains.push(strain);
+        if (i === 0) {
+          strainMin = strain;
+          strainMax = strain;
+        } else {
+          strainMax = strain > strainMax ? strain : strainMax;
+          strainMin = strain < strainMin ? strain : strainMin;
+        }
+      }
+
+      for (let i = 0; i < strainOutputs.length; i++) {
+        const percent = ( self.delaunayTriangleStrains[i] - strainMin) / (strainMax - strainMin);
+        self.delaunayTriangleStrains[i] = percent * (1) + 0;
+        self.delaunayTriangleStrains[i] = Number.isNaN( self.delaunayTriangleStrains[i]) ?
+          strainMin :  self.delaunayTriangleStrains[i];
+      }
+
+      for (let i = 0; i < mesh.triangles.length; i += 3) {
+        const p1 = [points[mesh.triangles[i]][0], points[mesh.triangles[i]][1]];
+        const p2 = [points[mesh.triangles[i + 1]][0], points[mesh.triangles[i + 1]][1]];
+        const p3 = [points[mesh.triangles[i + 2]][0], points[mesh.triangles[i + 2]][1]];
+
+        self.delaunayTriangles.push([p1, p2, p3]);
+      }
+
       // FIXME
       self.paintStrainMap = true;
     },

--- a/src/strain.ts
+++ b/src/strain.ts
@@ -264,7 +264,10 @@ function calculateStrainOutputData(inputData: StrainInput, calculatedData: Stati
                                             Math.pow(m6[1][1], 2));
     const areaStrain = correctedValues[0] + correctedValues[1];
 
-    const strainSecondInvariant = correctedValues[0] * correctedValues[1];
+    // This returns values such as -3e-20 and 8e-21
+    let strainSecondInvariant = correctedValues[0] * correctedValues[1];
+    // Ranges from 0.00005 to 127000
+    strainSecondInvariant = Math.abs(strainSecondInvariant) * Math.pow(10, 20);
 
     const output: StrainOutput = {
         triangleCenter: {
@@ -284,7 +287,7 @@ function calculateStrainOutputData(inputData: StrainInput, calculatedData: Stati
         minHorizontalExtension: correctedValues[1],
         maxShearStrain: maximumIninitesimalShearStrain * Math.pow(10, 9),
         areaStrain: areaStrain * Math.pow(10, 9),
-        secondInvariant: strainSecondInvariant * Math.pow(10, 9)
+        secondInvariant: strainSecondInvariant
     };
 
     return output;


### PR DESCRIPTION
This adds the strain rate map layer and allows it to be controlled by blocks.

This extracts the calculations that were previously done on mount by the layer and makes them an explicit action on the store. The view then renders that state as a standard leaflet pane, instead of directly adding polygons to the map.

The scaling of the two coloring modes is still under discussion by the team, but any changes will be easy to add in later.

<img width="1295" alt="Screen Shot 2020-10-15 at 9 31 46 AM" src="https://user-images.githubusercontent.com/35721/96163116-78b08280-0ee7-11eb-8d1d-697291c013a8.png">

<img width="1272" alt="Screen Shot 2020-10-15 at 9 50 41 AM" src="https://user-images.githubusercontent.com/35721/96163105-73ebce80-0ee7-11eb-9c10-bdd622e12b33.png">
