### PR TITLE
Finish deformation model math

### DIFF
--- a/src/components/deformation/deformation-model.tsx
+++ b/src/components/deformation/deformation-model.tsx
@@ -70,7 +70,7 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
 
   public componentDidMount() {
     this.drawModel();
-    this.disposer = onAction(this.stores.seismicSimulation, this.drawModel);
+    this.disposer = onAction(this.stores.seismicSimulation, this.drawModel, true);
   }
 
   public componentDidUpdate() {

--- a/src/components/deformation/deformation-model.tsx
+++ b/src/components/deformation/deformation-model.tsx
@@ -160,6 +160,8 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
       const textPositionAdjust = stationPoints[i].x < this.modelWidth / 2 ? -10 : 10;
       ctx.fillText(`Station ${i}`, stationPoints[i].x + textPositionAdjust, stationPoints[i].y);
     }
+    ctx.fillText(`Year ${year.toLocaleString()}`,
+      canvasMargin.left + this.modelWidth, canvasMargin.top + modelMargin.top + this.modelWidth + 20);
     ctx.stroke();
 
     // Draw lines between stations to form a triangle

--- a/src/components/deformation/deformation-model.tsx
+++ b/src/components/deformation/deformation-model.tsx
@@ -34,10 +34,10 @@ const lineSpacing = 20;
 const lockingDepth = 1;
 // for converting pixels to world distance
 // we want the area shown to be approx this size in each direction
-const distanceScale = 20;
+const distanceScale = 50;
 
 // angle between the plates vertically (into the Earth)
-const plateDipAngle = deg2rad(90);
+const dip = deg2rad(90);
 
 @inject("stores")
 @observer
@@ -51,7 +51,7 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     return smallestDimension - (minModelMargin * 2);
   }
   private get stepSize() {
-    const steps = 30;
+    const steps = 100;
     return this.modelWidth / steps;
   }
 
@@ -123,8 +123,12 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     ctx.lineWidth = 1;
     ctx.strokeStyle = textColor;
 
+    const { deformationModelStep: year } = this.stores.seismicSimulation;
+    const vSpeed = this.getRelativeVerticalSpeed();     // mm/yr
+    const hSpeed = this.getRelativeHorizontalSpeed();
+
     // set up the GPS site positions
-    const stationPoints = this.generateGPSStationPoints();
+    const stationPoints = this.generateGPSStationPoints(vSpeed, hSpeed, year);
     const startPoint = stationPoints[0];
 
     // text labels
@@ -152,22 +156,27 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     // useful to disable this while debugging!
     ctx.clip();
 
-    // Start deformation lines
-    const lines: Point[][] = [];
-    // start below model and go beyond in case lines curve into model
+    // Deformation lines
+    const horizontalLines: Point[][] = [];
+    const verticalLines: Point[][] = [];
+
+    // horizontal lines start below model and go beyond in case lines curve into model
     const yBounds = [modelMargin.top - 10, modelMargin.top + this.modelWidth + 20];
+    // vertical lines remain vertical and can be clipped to frame
     const xBounds = [modelMargin.left - 10, modelMargin.left + this.modelWidth + 20];
-    // horizontal point arrays
+
+    // form "horizontal" lines, one for each step vertically
+    // (this is slightly inefficient, because they all have the same shape, but the calc is fast)
     for (let y = yBounds[0]; y < yBounds[1]; y += lineSpacing) {
-      lines.push(this.generateYDisplacementLine(y, modelMargin.left));
+      horizontalLines.push(this.generateHorizontalLine(y, modelMargin.left, vSpeed, year));
     }
-    // vertical lines
+    // form vertical lines, one for each step horizontally
     for (let x = xBounds[0]; x < xBounds[1]; x += lineSpacing) {
-      lines.push(this.generateXDisplacementLine(x, modelMargin.top));
+      verticalLines.push(this.generateVerticalLine(x, modelMargin.top, hSpeed, year));
     }
     ctx.strokeStyle = lineColor;
     const drawBzCurve = this.bzCurve(ctx);
-    lines.forEach(drawBzCurve);
+    horizontalLines.forEach(drawBzCurve);
 
     // site markers - draw slightly overlaid on the clipped triangle, so need to restore (unclip) canvas
     ctx.restore();
@@ -251,73 +260,64 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     return relativeSpeed;
   }
 
-  private generateYDisplacementLine(yOrigin: number, xOffset: number) {
-    const { deformationSimulationProgress: progress } = this.stores.seismicSimulation;
-
+  private generateHorizontalLine(yOrigin: number, xOffset: number, relativeVerticalSpeed: number, year: number) {
     const center = this.modelWidth / 2;
     const points: Point[] = [];
 
-    // generate horizontal lines
+    // generate vertical displacements along a horizontal line
     for (let x = 0; x < this.modelWidth; x += this.stepSize) {
       // xDist is always distance from the center fault line
       const xDist = this.canvasToWorld(center - x);
 
       // distance is measured from the center fault
-      const verticalSheer =
-        this.calculateVerticalSheer(xDist, this.getRelativeVerticalSpeed(), plateDipAngle) * progress;
-      const horizontalSheer =
-        this.calculateHorizontalSheer(xDist, this.getRelativeHorizontalSpeed(), plateDipAngle) * progress;
+      const verticalDisplacement =
+        this.calculateVerticalDisplacement(xDist, relativeVerticalSpeed, year);
 
-      const newY = yOrigin + this.worldToCanvas(verticalSheer);
+      const newY = yOrigin + this.worldToCanvas(verticalDisplacement);
       const newX = x + xOffset; // + this.worldToCanvas(horizontalSheer);
       points.push({ x: newX, y: newY });
     }
     return points;
   }
 
-  private generateXDisplacementLine(xOrigin: number, yOffset: number) {
-    const { deformationSimulationProgress: progress } =
-      this.stores.seismicSimulation;
-
+  // vertical lines are always precisely straight, so just require two points
+  private generateVerticalLine(xOrigin: number, yOffset: number, relativeHorizontalSpeed: number, year: number) {
     const center = (this.modelWidth / 2) + modelMargin.left;
+
+    // xDist is always distance from the fault line.
+    const xDist = this.canvasToWorld(center - xOrigin);
+    const horizontalDisplacement =
+        this.calculateHorizontalDisplacement(xDist, relativeHorizontalSpeed, year);
+
     const points: Point[] = [];
 
     // generate vertical lines
     for (let y = 0; y < this.modelWidth; y += this.stepSize) {
-      // xDist is always distance from the fault line.
-      const xDist = this.canvasToWorld(center - xOrigin);
 
       // add the x shear over time as the simulation runs
       // our distance is measured from the center fault
-      const horizontalSheer =
-        this.calculateHorizontalSheer(xDist, this.getRelativeHorizontalSpeed(), plateDipAngle) * progress;
-      // add the y shear component
-      const verticalSheer =
-        this.calculateVerticalSheer(xDist, this.getRelativeVerticalSpeed(), plateDipAngle) * progress;
 
       // having a perfectly straight vertical line makes the line disappear
       const lineFudge = y / 1000;
       const newX = xOrigin + lineFudge; // + this.worldToCanvas(horizontalSheer);
-      const newY = y + yOffset + this.worldToCanvas(verticalSheer);
+      const newY = y + yOffset + this.worldToCanvas(horizontalDisplacement);
 
       points.push({ x: newX, y: newY });
     }
     return points;
   }
 
-  private generateGPSStationPoints() {
-    const { deformationSimulationProgress: progress, deformationSites } =
-      this.stores.seismicSimulation;
-
+  private generateGPSStationPoints(relativeVerticalSpeed: number, relativeHorizontalSpeed: number, year: number) {
+    const { deformationSites } = this.stores.seismicSimulation;
     // stations will move with the land
     const stationPoints: Point[] = [];
     for (const site of deformationSites) {
       // get speed by determining which side of fault
       // station x and y are stored in the array as 0-1 percentage across the canvas
-      const siteDisplacementX = this.calculateHorizontalSheer(
-        this.percentToWorld(0.5 - site[0]), this.getRelativeHorizontalSpeed(), plateDipAngle) * progress;
-      const siteDisplacementY = this.calculateVerticalSheer(
-        this.percentToWorld(0.5 - site[0]), this.getRelativeVerticalSpeed(), plateDipAngle) * progress;
+      const siteDisplacementX = this.calculateHorizontalDisplacement(
+        this.percentToWorld(0.5 - site[0]), relativeHorizontalSpeed, year);
+      const siteDisplacementY = this.calculateVerticalDisplacement(
+        this.percentToWorld(0.5 - site[0]), relativeVerticalSpeed, year);
 
       const x = this.modelWidth * site[0] + modelMargin.left; // + this.worldToCanvas(siteDisplacementX);
       const y = this.modelWidth * site[1] + modelMargin.top + this.worldToCanvas(siteDisplacementY);
@@ -327,21 +327,24 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
   }
 
   // Calculations taken from PowerPoint linked here: https://www.pivotaltracker.com/story/show/174401018
-  private calculateVerticalSheer(px: number, speed: number, dip: number) {
-    const sheer = speed / Math.PI *
-      (Math.cos(dip) * Math.atan(px / lockingDepth) - dip + Math.PI / 2) -
-      px * (lockingDepth * Math.cos(dip) + px * (Math.sin(dip)))
-      / ((px ** 2) + (lockingDepth ** 2));
-    return (px < 0 ? -sheer : sheer);
+  private calculateVerticalDisplacement(px: number, vSpeed: number, year: number) {
+    const verticalSlipRatemmYr = vSpeed / Math.PI *
+      (Math.cos(dip) * (Math.atan(px / lockingDepth) - dip + Math.PI / 2) -
+      (px * (lockingDepth * Math.cos(dip) + px * Math.sin(dip)))
+      / (px * px + lockingDepth * lockingDepth));                   // mm/yr
+    const verticalSlipRateKmYr = verticalSlipRatemmYr / 1000000;
+    const verticalDisplacement = verticalSlipRateKmYr * year;       // km
+    return (px > 0 ? -verticalDisplacement : verticalDisplacement);
   }
 
   // this will need more work
-  private calculateHorizontalSheer(px: number, speed: number, dip: number) {
-    const sheer = speed / Math.PI *
-    (Math.sin(dip) * Math.atan(px / lockingDepth) - dip + Math.PI / 2) +
-    lockingDepth * (lockingDepth * Math.cos(dip) + px * Math.sin(dip))
-    / ((px ** 2) + (lockingDepth ** 2));
-    return sheer;
+  private calculateHorizontalDisplacement(px: number, speed: number, year: number) {
+    // const displacementRate = speed / Math.PI *
+    // (Math.sin(dip) * Math.atan(px / lockingDepth) - dip + Math.PI / 2) +
+    // lockingDepth * (lockingDepth * Math.cos(dip) + px * Math.sin(dip))
+    // / ((px ** 2) + (lockingDepth ** 2));
+    // return sheer;
+    return 0;
   }
 
   private canvasToWorld(canvasPosition: number) {

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -24,17 +24,17 @@ export const SeismicSimulationStore = types
     scenario: "Seismic CA",
     visibleGPSStationIds: types.array(types.string),      // by id
     selectedGPSStationId: types.maybe(types.string),
-
-    deformationModelStep: 0,
-    deformationModelSpeed: 100,      // steps / second
-    deformationModelEndStep: 500,
     showVelocityArrows: false,
 
-    deformSpeedPlate1: 0,
-    deformDirPlate1: 0,
+    deformationModelStep: 0,            // year
+    deformationModelSpeed: 100000,      // years / second
+    deformationModelEndStep: 500000,
+
+    deformSpeedPlate1: 0,     // mm/yr
+    deformDirPlate1: 0,       // º from N
     deformSpeedPlate2: 0,
     deformDirPlate2: 0,
-    deformMaxSpeed: 30,
+    deformMaxSpeed: 50,
 
     strainMapMinLat: -90,
     strainMapMinLng: -180,
@@ -201,9 +201,6 @@ export const SeismicSimulationStore = types
     },
     get deformationSites() {
       return [deformationSite1, deformationSite2, deformationSite3];
-    },
-    get deformationSimulationProgress() {
-      return self.deformationModelStep / self.deformationModelEndStep;
     }
   }));
 

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -60,7 +60,11 @@ export const SeismicSimulationStore = types
       self.selectedGPSStationId = id;
     },
     setDeformationStep(step: number) {
-      self.deformationModelStep = step;
+      if (step > self.deformationModelEndStep) {
+        self.deformationModelStep = self.deformationModelEndStep;
+      } else {
+        self.deformationModelStep = step;
+      }
     },
     resetDeformationModel() {
       self.deformationModelStep = 0;


### PR DESCRIPTION
This makes some fixes the the vertical movement (the version that's currently deployed always moves the same way no matter the inputs), and adds the horizontal movement to the deformation model.

As far as I can tell, the math is all correct. Rather than trying an algebraic integration to work out the horizontal displacement given the function for rate, I opted to simply calculate it iteratively -- working out the total horizontal displacement at year 1000 is found by summing all the displacements from year 0 to 1000. So as not to re-calculate the whole thing each time, the previous values are cached. I made the decision to keep all the previously-cached values (i.e. during a full run from 0 to 500,000 years, we might calculate once at 120 years, once at 250, once at 700, etc, depending on the randomness of `requestAnimationFrame`), which will slightly speed up any subsequent run at the same speed, for a small memory cost. I think this makes sense, but the savings for subsequent runs might be so minimal that it would make more sense just to keep the very last value.

There are a couple remaining UI odds-and-ends to the model -- labelling the plates, making the background grid clip to the triangle only on Run -- but I think those would make sense in another PR.