### PR TITLE
Show strain rate labels

### DIFF
--- a/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
@@ -9,6 +9,7 @@
     <block type="seismic_render_strain_triangles"></block>
     <block type="seismic_logarithmic"></block>
     <block type="seismic_equal_interval"></block>
+    <block type="seismic_render_strain_labels"></block>
   </category>
 
   <category name="Deformation Model" colour="15">

--- a/src/blockly-blocks/seismic/block-seismic-strain-rate.js
+++ b/src/blockly-blocks/seismic/block-seismic-strain-rate.js
@@ -124,3 +124,20 @@ Blockly.JavaScript['seismic_render_strain_triangles'] = function (block) {
   var code = value_color_method ? `renderStrainRate${value_color_method};` : "renderStrainRate();";
   return code;
 }
+
+Blockly.Blocks['seismic_render_strain_labels'] = {
+  init: function () {
+    this.appendDummyInput()
+      .appendField('Show strain rate value')
+    this.setInputsInline(false)
+    this.setPreviousStatement(true, null)
+    this.setNextStatement(true, null)
+    this.setColour(230)
+    this.setTooltip('Show strain rate value')
+    this.setHelpUrl('')
+  }
+}
+Blockly.JavaScript['seismic_render_strain_labels'] = function (block) {
+  var code = "renderStrainRateLabels();";
+  return code;
+}

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -356,6 +356,10 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
       seismicSimulation.setRenderStrainMap(method);
     });
 
+    addFunc("renderStrainRateLabels", () => {
+      seismicSimulation.renderStrainRateLabels();
+    });
+
     addFunc("runDeformationModel", () => {
       seismicSimulation.startDeformationModel();
     });

--- a/src/components/icons.ts
+++ b/src/components/icons.ts
@@ -66,4 +66,15 @@ export function latLngIcon(label: string, anchorCorner: string = "top-left"): Di
   return new DivIcon({ className: "div-icon", html });
 }
 
+export function strainLabelIcon(strain: number): DivIcon {
+    let strainText = `${Math.round(Math.abs(strain) * 100) / 100}`;
+    if (strainText.length < 4) {
+        strainText = `${Array(5 - strainText.length).join("&nbsp;")}${strainText}`;
+    }
+    const html = `<div class='strain-icon'>
+        ${strainText}
+    </div>`;
+    return new DivIcon({ className: "div-icon", html });
+}
+
 export { iconVolcano, iconMarker };

--- a/src/components/map/map-triangulated-strain-layer.tsx
+++ b/src/components/map/map-triangulated-strain-layer.tsx
@@ -83,24 +83,25 @@ export class MapTriangulatedStrainLayer extends BaseComponent<IProps, IState> {
         fillColor={fillColor}
       />);
 
-      // calculate the incenter of the triangle
-      const perim1 = Math.sqrt(((p1.lat - p2.lat) ** 2) + ((p1.lng - p2.lng) ** 2));
-      const perim2 = Math.sqrt(((p2.lat - p3.lat) ** 2) + ((p2.lng - p3.lng) ** 2));
-      const perim3 = Math.sqrt(((p3.lat - p1.lat) ** 2) + ((p3.lng - p1.lng) ** 2));
-      const perimeter = perim1 + perim2 + perim3;
-      const centLat = ((p1.lat * perim2) + (p2.lat * perim3) + p3.lat * perim1) / perimeter;
-      const centLng = ((p1.lng * perim2) + (p2.lng * perim3) + p3.lng * perim1) / perimeter;
-      const incenter = Leaflet.latLng(centLat, centLng);
-      const minPerimSize = 1.5 - ((zoomLevel - 6) * 0.4);
-      const largeSide = zoomLevel > 7 ? perimeter * 0.48 : perimeter * 0.45;
-      const smallSide = zoomLevel > 7 ? perimeter * 0.1 : perimeter * 0.25;
-      console.log(minPerimSize);
+      if (renderStrainLabels) {
+        // calculate the incenter of the triangle
+        const perim1 = Math.sqrt(((p1.lat - p2.lat) ** 2) + ((p1.lng - p2.lng) ** 2));
+        const perim2 = Math.sqrt(((p2.lat - p3.lat) ** 2) + ((p2.lng - p3.lng) ** 2));
+        const perim3 = Math.sqrt(((p3.lat - p1.lat) ** 2) + ((p3.lng - p1.lng) ** 2));
+        const perimeter = perim1 + perim2 + perim3;
+        const centLat = ((p1.lat * perim2) + (p2.lat * perim3) + p3.lat * perim1) / perimeter;
+        const centLng = ((p1.lng * perim2) + (p2.lng * perim3) + p3.lng * perim1) / perimeter;
+        const incenter = Leaflet.latLng(centLat, centLng);
+        const minPerimSize = 1.5 - ((zoomLevel - 6) * 0.4);
+        const largeSide = zoomLevel > 7 ? perimeter * 0.48 : perimeter * 0.45;
+        const smallSide = zoomLevel > 7 ? perimeter * 0.1 : perimeter * 0.25;
 
-      if (perimeter > minPerimSize
-          && perim1 < largeSide && perim1 > smallSide && perim2 < largeSide
-          && perim2 > smallSide  && perim3 < largeSide && perim3 > smallSide ) {
-        const text = strainLabelIcon(delaunayTriangleStrains[i]);
-        labels.push(<Marker  key={`strain-label-${i}`}position={incenter} icon={text} />);
+        if (perimeter > minPerimSize
+            && perim1 < largeSide && perim1 > smallSide && perim2 < largeSide
+            && perim2 > smallSide  && perim3 < largeSide && perim3 > smallSide ) {
+          const text = strainLabelIcon(delaunayTriangleStrains[i]);
+          labels.push(<Marker  key={`strain-label-${i}`}position={incenter} icon={text} />);
+        }
       }
     }
     return (

--- a/src/css/custom-leaflet-icons.css
+++ b/src/css/custom-leaflet-icons.css
@@ -167,3 +167,7 @@
     bottom: -8px;
     right: -6px;
   }
+
+  .strain-icon {
+    margin-left: -8px;
+  }

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -42,6 +42,7 @@ export const SeismicSimulationStore = types
     strainMapMaxLng: 180,
     strainMapColorMethod: types.optional(types.string, "logarithmic"),
     renderStrainMap: false,
+    renderStrainLabels: false,
   })
   .volatile(self => ({
     delaunayTriangles: [] as number[][][],
@@ -159,6 +160,9 @@ export const SeismicSimulationStore = types
       self.strainMapColorMethod = method;
       self.renderStrainMap = true;
     },
+    renderStrainRateLabels() {
+      self.renderStrainLabels = true;
+    },
     reset() {
       self.visibleGPSStationIds.clear();
       self.selectedGPSStationId = undefined;
@@ -169,6 +173,7 @@ export const SeismicSimulationStore = types
       self.strainMapMaxLat = 90;
       self.strainMapMaxLng = 180;
       self.renderStrainMap = false;
+      self.renderStrainLabels = false;
     }
   }))
   .actions((self) => ({

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -74,6 +74,9 @@ export const SeismicSimulationStore = types
       self.showVelocityArrows = show;
     },
     setStrainMapBounds(bounds: Filter) {
+      self.renderStrainMap = false;
+      self.renderStrainLabels = false;
+
       self.delaunayTriangles = [];
       self.delaunayTriangleStrains = [];
 


### PR DESCRIPTION
This adds labels showing the strain rate within Delaunay triangles. This only adds labels in triangles that are large enough given a specific zoom size to fit them (using some quick-and-dirty math -- we could be more exact by calculating the size of the largest circle we can enclose in the triangle, but this seems to work well enough).

This can be seen at http://geocode-app.concord.org/branch/show-strain-rate-labels/index.html, by adding the "calculate strain rate" and "show strain value" blocks, like in the screenshot.

<img width="1007" alt="Screen Shot 2020-10-20 at 11 31 11 AM" src="https://user-images.githubusercontent.com/35721/96608828-d538e680-12c7-11eb-96a7-8be992b53044.png">
