### PR TITLE
Small fixes for rotated wind direction

### DIFF
--- a/src/blockly-blocks/wind-data/block-wind-data.js
+++ b/src/blockly-blocks/wind-data/block-wind-data.js
@@ -94,11 +94,6 @@ Blockly.JavaScript['filter_data'] = function (block) {
   allKeys.forEach((key) => {
     if (filter[key] === "") {
       delete filter[key];
-    } else if (!isNaN(parseFloat(filter[key]))) {
-      // Wind data is stored using direction to, but we use direction from. Need to convert.
-      filter[key] = key === "direction"
-        ? parseFloat(filter[key]) < 180 ? parseFloat(filter[key]) + 180 : parseFloat(filter[key]) - 180
-        : parseFloat(filter[key]);
     }
   });
   let filterObj = JSON.stringify(filter);

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -226,6 +226,9 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
               const rotate = (dir: number) => dir < 180 ? dir + 180 : dir - 180;
               if (typeof params.filter.direction === "number") {
                 params.filter.direction = rotate(params.filter.direction);
+              } else {
+                params.filter.direction.min = rotate(params.filter.direction.min as number);
+                params.filter.direction.max = rotate(params.filter.direction.max as number);
               }
           }
         }

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -200,9 +200,10 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
       }
       // Wind data is stored using direction to, but we use direction from. Need to convert.
       const sampleData = (Datasets.getRandomSampleWithReplacement(dataset, 1)[0] as any) as WindDataCase;
-      sampleData.direction = sampleData.direction < 180 ? sampleData.direction + 180 : sampleData.direction - 180;
+      const sampleDataClone = {...sampleData};
+      sampleDataClone.direction = sampleData.direction < 180 ? sampleData.direction + 180 : sampleData.direction - 180;
       return {
-        data: sampleData
+        data: sampleDataClone
       };
     });
 

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -221,6 +221,12 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
               blocklyController.throwError(`There is an error on the filter key "${key}"`);
             }
             return;
+          } else if (key === "direction") {
+            // Wind data is stored using direction to, but we use direction from. Need to convert.
+              const rotate = (dir: number) => dir < 180 ? dir + 180 : dir - 180;
+              if (typeof params.filter.direction === "number") {
+                params.filter.direction = rotate(params.filter.direction);
+              }
           }
         }
       }


### PR DESCRIPTION
This fixes two small left-over issues that I found after the work over the summer to rotate the wind 180º. I don't know if anyone else has noticed them yet, but I kept running into them when trying to fix the Monte Carlo bug (and for a while I was chasing a red herring thinking that the issue was related to rotating the wind).

This fixes:
* Though filtering a specific number for wind (e.g. direction=90º) correctly gives us wind FROM 90º, putting a Range block in the direction slot gave us wind TO.
* If we used either of the "Erupt with a random wind sample from" blocks, the block would modify the actual underlying data point, meaning it would disappear from the filter the second time we tried to find it (even after a reset).