### PR TITLE
Fix mirrored tephra calculations

### DIFF
--- a/cypress/integration/branch/authoring.test.js
+++ b/cypress/integration/branch/authoring.test.js
@@ -58,13 +58,13 @@ context ('Authoring Options',()=>{
             leftPanel.getControlsTab().click();
             controlsTab.getEruptButton().click();
             //verify tephra is visible at a location south of volcano - brittle if the viewport size changes
-            map.getTephra().last().attribute('d').should('contain',"M237 242L249 254L249 336L243 342L243 354L237 361L237 367L234 370L228 370L222 376L201 354L201 336L195 329L195 254L210 239L234 239z")
+            map.getTephra().last().attribute('d').should('contain', "M237 242L249 254L249 267L255 273L249 279L249 336L243 342L243 354L237 361L237 367L234 370L228 370L222 376L201 354L201 329L195 323L201 317L201 311L195 304L195 254L210 239L234 239z")
 
             //change conditions to see tephra change without having to erupt again
             var slider="wind-direction", windDirection = 190;
             controlsTab.setSliderValue(slider,windDirection);
             //verify is in new location north of volcano
-            map.getTephra().last().attribute('d').should('contain', "M249 98L260 110L260 204L255 211L255 217L240 232L216 232L201 217L201 179L207 173L207 167L213 160L213 135L219 129L219 123L225 116L225 110L234 101L240 101L246 94z")
+            map.getTephra().last().attribute('d').should('contain', "M249 98L260 110L260 198L255 204L255 217L240 232L216 232L201 217L201 179L207 173L207 167L213 160L213 135L219 129L219 123L225 116L225 110L234 101L240 101L246 94z")
 
             //reset state for nexxt test
             controlsTab.resetModel();
@@ -79,13 +79,13 @@ context ('Authoring Options',()=>{
             leftPanel.getControlsTab().click();
             controlsTab.getEruptButton().click();
             //verify tephra is visible at a location south of volcano
-            map.getTephra().last().attribute('d').should('contain', "M249 98L260 110L260 204L255 211L255 217L240 232L216 232L201 217L201 179L207 173L207 167L213 160L213 135L219 129L219 123L225 116L225 110L234 101L240 101L246 94z")
+            map.getTephra().last().attribute('d').should('contain', "M249 98L260 110L260 198L255 204L255 217L240 232L216 232L201 217L201 179L207 173L207 167L213 160L213 135L219 129L219 123L225 116L225 110L234 101L240 101L246 94z")
 
             //change conditions to see tephra change without having to erupt again
             var slider="wind-direction", windDirection = 190;
             controlsTab.setSliderValue(slider,windDirection);
             //verify location has not changed north of volcano
-            map.getTephra().last().attribute('d').should('contain', "M249 98L260 110L260 204L255 211L255 217L240 232L216 232L201 217L201 179L207 173L207 167L213 160L213 135L219 129L219 123L225 116L225 110L234 101L240 101L246 94z")
+            map.getTephra().last().attribute('d').should('contain', "M249 98L260 110L260 198L255 204L255 217L240 232L216 232L201 217L201 179L207 173L207 167L213 160L213 135L219 129L219 123L225 116L225 110L234 101L240 101L246 94z")
 
             controlsTab.resetModel();//clean up
          })

--- a/src/components/map/map-tephra-thickness-layer.tsx
+++ b/src/components/map/map-tephra-thickness-layer.tsx
@@ -65,17 +65,17 @@ export class MapTephraThicknessLayer extends BaseComponent<IProps, IState> {
         const latSegments = samplesPerScreenPerAxis;
         const longSegments = samplesPerScreenPerAxis;
 
+        const startingLat = viewportBounds.getNorthEast().lat < viewportBounds.getSouthWest().lat ?
+                viewportBounds.getNorthEast().lat :
+                viewportBounds.getSouthWest().lat;
+        const startingLong = viewportBounds.getNorthEast().lng < viewportBounds.getSouthWest().lng ?
+                viewportBounds.getNorthEast().lng :
+                viewportBounds.getSouthWest().lng;
+
         const data: number[] = [];
 
         for (let currentLat = 0; currentLat < latSegments; currentLat++) {
             for (let currentLong = 0; currentLong < longSegments; currentLong++) {
-                const startingLat = viewportBounds.getNorthEast().lat < viewportBounds.getSouthWest().lat ?
-                                    viewportBounds.getNorthEast().lat :
-                                    viewportBounds.getSouthWest().lat;
-                const startingLong = viewportBounds.getNorthEast().lng < viewportBounds.getSouthWest().lng ?
-                                    viewportBounds.getNorthEast().lng :
-                                    viewportBounds.getSouthWest().lng;
-
                 const lat = startingLat + currentLat * latSize;
                 const long = startingLong + currentLong * longSize;
 
@@ -105,8 +105,8 @@ export class MapTephraThicknessLayer extends BaseComponent<IProps, IState> {
             multipolygon.coordinates.forEach(polygon => {
                 polygon.forEach(poly => {
                     poly.forEach(coord => {
-                        coord[0] = (coord[0] * longSize) + viewportBounds.getSouthWest().lng;
-                        coord[1] = (coord[1] * latSize) + viewportBounds.getSouthWest().lat;
+                        coord[0] = (coord[0] * longSize) + startingLong;
+                        coord[1] = (coord[1] * latSize) + startingLat;
                     });
                 });
             });

--- a/src/tephra2.test.ts
+++ b/src/tephra2.test.ts
@@ -127,7 +127,7 @@ describe("tephra3 calculations", () => {
           0,            // cone x, y
           0,
           -5,            // wind speed
-          0,            // wind direction
+          90,            // wind direction
           20000,        // column height
           1e11,         // eruption mass
           10000,        // disk radius

--- a/src/tephra2.ts
+++ b/src/tephra2.ts
@@ -196,7 +196,7 @@ const tephraLoadFromDiskCell = (
 
 /**
  * Returns the tephra thickness (cm) at an x, y location, given an eruption centered on
- * xVent, yVent, with the other properties.
+ * xVent, yVent, with the other properties. Assumes a wind heading East.
  */
 const tephraCalc3 = (
   x: number,
@@ -244,7 +244,7 @@ const tephraCalc3 = (
  * This function takes grid coordinates, scales for the grid size, and rotates to adjust for the wind
  * direction.
  * It then calls `tephraCalc3`, which takes real distance in meters for the location, and assumes a
- * wind due South.
+ * wind heading East.
  * `tephraCalc3` then models the tephra as initially erupting as a large disk of various particle sizes,
  * and iteratively calls `tephraLoadFromDiskCell` for each cell in the eruption grid, for each phi class
  * (particle size).
@@ -286,8 +286,7 @@ const gridTephraCalc3 = (
   const modelY = gridY * dScale;
   const ventX = ventGridX * dScale;
   const ventY = ventGridY * dScale;
-  const windDirectionTowardsNorth = windDirectionFromNorth + 180;
-  const rotated = rotateGridPoint({x: modelX, y: modelY}, (360 - windDirectionTowardsNorth), {x: ventX, y: ventY});
+  const rotated = rotateGridPoint({x: modelX, y: modelY}, windDirectionFromNorth + 90, {x: ventX, y: ventY});
 
   return tephraCalc3(
     rotated.x, rotated.y,

--- a/src/utilities/coordinateSpaceConversion.ts
+++ b/src/utilities/coordinateSpaceConversion.ts
@@ -32,12 +32,12 @@ export const LocalToLatLng = (point: Ipoint, volcanoPos: L.LatLng): L.LatLng => 
 export const LatLngToLocal = (point: L.LatLng, volcanoPos: L.LatLng): Ipoint => {
     const longDist = getDistanceFromLatLonInKm(volcanoPos, L.latLng(volcanoPos.lat, point.lng));
     const latDist = getDistanceFromLatLonInKm(volcanoPos, L.latLng(point.lat, volcanoPos.lng));
-    return {x: point.lat < volcanoPos.lat ?
-                                 -1 * latDist :
-                                 latDist,
-            y: point.lng < volcanoPos.lng ?
-                                 -1 * longDist :
-                                 longDist};
+    return {x: point.lng < volcanoPos.lng ?
+                -1 * longDist :
+                longDist,
+            y: point.lat < volcanoPos.lat ?
+                -1 * latDist :
+                latDist};
 };
 
 // Haversine formula used for finding the distance between two latLng points


### PR DESCRIPTION
This fixes a tricky problem that Jie noticed, that running the Monte Carlo simulation seemed to give quite different results from running a model "by hand" and counting each time a location was covered in Tephra.

<img width="1434" alt="Screen Shot 2020-12-29 at 2 17 05 PM" src="https://user-images.githubusercontent.com/35721/103308535-a8e4c900-49e0-11eb-945c-df5fab46c1ad.png">

After some research, I found that the problem seemed quite bizarre. Calculating the tephra thickness at a point due South of the volcano, when the wind was blowing South, would show no tephra, even though the map, which was using the exact same calculation, would show tephra to the South. But what was even weirder was that the calculation that the map was making *also* didn't show any tephra to the South, instead it showed Tephra to the West, even though the wind was blowing South and the map contours clearly showed Tephra to the South.

I finally figured out that what happened was

1. An small error was added when the new contour version of the Tephra layer was added in #34, flipping lat and long 
2. Noticing that the results seemed "mirrored" (reflected on the x=y axis) a change was added to mirror the underlying tephra calculations (4ff835f15), such that the double-reflection made the tephra layer look correct, even though it was calculating things in the wrong direction

I'm surprised that we never noticed that the Monte Carlo simulations were giving quite wrong answers, though I think perhaps we did and always put it down to random chance. Using an extremely-tightly bounded filter, like direction=4 (which only has a single sample) made this clearer (though it helps to use the `fix-wind-direction-for-range-filter` branch so you don't get the modifying-sample bug).