### PR TITLE
Add migration to convert author/student state to latest

### DIFF
--- a/src/assets/test/test-serialization.json
+++ b/src/assets/test/test-serialization.json
@@ -1,0 +1,84 @@
+{
+  "tests": [
+    {
+      "oldState": {
+        "version": 1,
+        "state": {
+          "simulation": {
+            "requireEruption": true,
+            "requirePainting": true,
+            "scenario": "Cerro Negro",
+            "toolbox": "Everything",
+            "initialCodeTitle": "Basic",
+            "initialXmlCode": "<xml xmlns=\"http://www.w3.org/1999/xhtml\">\n  <block type=\"simulate_wind\" id=\"[q=jJs5eVLi`hbMBNkUv\" x=\"198\" y=\"93\">\n    <value name=\"wspeed\">\n      <block type=\"math_number\" id=\"@u3Zdj+hJTZpwyn.Er]+\">\n        <field name=\"NUM\">4</field>\n      </block>\n    </value>\n    <value name=\"wdirection\">\n      <block type=\"math_number\" id=\"@v[VUG[q]$(wDU)ot1Uf\">\n        <field name=\"NUM\">4</field>\n      </block>\n    </value>\n  </block>\n</xml>",
+            "stagingWindSpeed": 6,
+            "stagingWindDirection": 0,
+            "stagingMass": 10000000000000,
+            "stagingColHeight": 20000
+          },
+          "uiStore": {
+            "showBlocks": true,
+            "showCode": false,
+            "showControls": true,
+            "showWindSpeed": true,
+            "showWindDirection": true,
+            "showEjectedVolume": true,
+            "showColumnHeight": true,
+            "showVEI": true,
+            "showConditions": true,
+            "showCrossSection": false,
+            "showMonteCarlo": true,
+            "showData": true,
+            "showSpeedControls": true,
+            "showBarHistogram": false,
+            "showLog": false,
+            "showDemoCharts": false
+          }
+        }
+      },
+      "expectedConvertedState": {
+        "version": 2,
+        "state": {
+          "unit": {
+            "name": "Tephra"
+          },
+          "blocklyStore": {
+            "toolbox": "Everything",
+            "initialCodeTitle": "Basic",
+            "initialXmlCode": "<xml xmlns=\"http://www.w3.org/1999/xhtml\">\n  <block type=\"simulate_wind\" id=\"[q=jJs5eVLi`hbMBNkUv\" x=\"198\" y=\"93\">\n    <value name=\"wspeed\">\n      <block type=\"math_number\" id=\"@u3Zdj+hJTZpwyn.Er]+\">\n        <field name=\"NUM\">4</field>\n      </block>\n    </value>\n    <value name=\"wdirection\">\n      <block type=\"math_number\" id=\"@v[VUG[q]$(wDU)ot1Uf\">\n        <field name=\"NUM\">4</field>\n      </block>\n    </value>\n  </block>\n</xml>"
+          },
+          "tephraSimulation": {
+            "requireEruption": true,
+            "requirePainting": true,
+            "scenario": "Cerro Negro",
+            "stagingWindSpeed": 6,
+            "stagingWindDirection": 0,
+            "stagingMass": 10000000000000,
+            "stagingColHeight": 20000
+          },
+          "seismicSimulation": {},
+          "uiStore": {
+            "showBlocks": true,
+            "showCode": false,
+            "showControls": true,
+            "showWindSpeed": true,
+            "showWindDirection": true,
+            "showEjectedVolume": true,
+            "showColumnHeight": true,
+            "showVEI": true,
+            "showConditions": true,
+            "showCrossSection": false,
+            "showMonteCarlo": true,
+            "showData": true,
+            "showDeformation": true,
+            "showSpeedControls": true,
+            "showBarHistogram": false,
+            "showLog": false,
+            "showDemoCharts": false,
+            "showRiskDiamonds": false
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -23,7 +23,7 @@ import screenfull from "screenfull";
 import ResizeObserver from "react-resize-observer";
 import AuthoringMenu from "./authoring-menu";
 import { getAuthorableSettings, updateStores, serializeState, getSavableState,
-         deserializeState, SerializedState, IStoreish } from "../stores/stores";
+         deserializeState, UnmigratedSerializedState, IStoreish } from "../stores/stores";
 import { ChartPanel } from "./charts/chart-panel";
 import { BlocklyController } from "../blockly/blockly-controller";
 import { HistogramPanel } from "./montecarlo/histogram-panel";
@@ -649,7 +649,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
   private loadStateFromLocalStorage = () => {
     const savedStateJSON = localStorage.getItem("geocode-state");
     if (savedStateJSON) {
-      const savedState = JSON.parse(savedStateJSON) as SerializedState;
+      const savedState = JSON.parse(savedStateJSON) as UnmigratedSerializedState;
       updateStores(deserializeState(savedState));
     }
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,8 @@ import * as iframePhone from "iframe-phone";
 
 import { AppComponent } from "./components/app";
 import { onSnapshot } from "mobx-state-tree";
-import { stores, serializeState, getSavableState, deserializeState, updateStores, SerializedState, IStoreish } from "./stores/stores";
+import { stores, serializeState, getSavableState, deserializeState, updateStores,
+        IStoreish, UnmigratedSerializedState } from "./stores/stores";
 
 ReactDOM.render(
   <Provider stores={stores}>
@@ -60,9 +61,9 @@ phone.addListener("initInteractive", (data: {
 
   parseJSON(data, ["authoredState", "interactiveState", "linkedState"]);
 
-  const authorState: SerializedState = data && data.authoredState || {};
+  const authorState: UnmigratedSerializedState = data && data.authoredState || {};
   // student data may be in either the current interactive's saved state, or a previous model's linked state
-  const studentState: SerializedState = data && (data.interactiveState || data.linkedState) || {};
+  const studentState: UnmigratedSerializedState = data && (data.interactiveState || data.linkedState) || {};
 
   if (data.mode === "authoring") {
     mode = "author";

--- a/src/utilities/migrate-state.test.ts
+++ b/src/utilities/migrate-state.test.ts
@@ -1,0 +1,11 @@
+import * as testMigrations from "./../assets/test/test-serialization.json";
+import { migrate } from "./migrate-state";
+
+describe("stores", () => {
+  it("we can migrate old state to the most recent state", () => {
+    for (const test of testMigrations.tests) {
+      const migratedState = migrate(test.oldState);
+      expect(migratedState).toEqual(test.expectedConvertedState);
+    }
+  });
+});

--- a/src/utilities/migrate-state.ts
+++ b/src/utilities/migrate-state.ts
@@ -7,26 +7,19 @@ type Migration = (oldState: UnmigratedSerializedState) => SerializedState;
 
 const migrate01to02: Migration = (oldState) => {
   if (oldState.version === 1 && !oldState.state.unit) {
-    // serailization with version = 1 and a unit specified is identical to version 2
+    // serialization with version = 1 and a unit specified is identical to version 2
     const {simulation, uiStore} = oldState.state;
+    const {toolbox, initialCodeTitle, initialXmlCode, ...tephraSimulation} = simulation;
     return {
       version: 2,
       state: {
         unit: { name: "Tephra" },
         blocklyStore: {
-          toolbox: simulation.toolbox,
-          initialCodeTitle: simulation. initialCodeTitle,
-          initialXmlCode: simulation.initialXmlCode
+          toolbox,
+          initialCodeTitle,
+          initialXmlCode
         },
-        tephraSimulation: {
-          requireEruption: simulation.requireEruption,
-          requirePainting: simulation.requirePainting,
-          scenario: simulation.scenario,
-          stagingWindSpeed: simulation.stagingWindSpeed,
-          stagingWindDirection: simulation.stagingWindDirection,
-          stagingMass: simulation.stagingMass,
-          stagingColHeight: simulation.stagingColHeight
-        },
+        tephraSimulation,
         seismicSimulation: {},
         uiStore: {
           ...uiStore,

--- a/src/utilities/migrate-state.ts
+++ b/src/utilities/migrate-state.ts
@@ -1,0 +1,53 @@
+import { UnmigratedSerializedState, SerializedState } from "../stores/stores";
+
+export const CURRENT_SERIALIZATION_VERSION = 2;
+
+type PartialMigration = (oldState: UnmigratedSerializedState) => UnmigratedSerializedState;
+type Migration = (oldState: UnmigratedSerializedState) => SerializedState;
+
+const migrate01to02: Migration = (oldState) => {
+  if (oldState.version === 1 && !oldState.state.unit) {
+    // serailization with version = 1 and a unit specified is identical to version 2
+    const {simulation, uiStore} = oldState.state;
+    return {
+      version: 2,
+      state: {
+        unit: { name: "Tephra" },
+        blocklyStore: {
+          toolbox: simulation.toolbox,
+          initialCodeTitle: simulation. initialCodeTitle,
+          initialXmlCode: simulation.initialXmlCode
+        },
+        tephraSimulation: {
+          requireEruption: simulation.requireEruption,
+          requirePainting: simulation.requirePainting,
+          scenario: simulation.scenario,
+          stagingWindSpeed: simulation.stagingWindSpeed,
+          stagingWindDirection: simulation.stagingWindDirection,
+          stagingMass: simulation.stagingMass,
+          stagingColHeight: simulation.stagingColHeight
+        },
+        seismicSimulation: {},
+        uiStore: {
+          ...uiStore,
+          showDeformation: true,
+          showRiskDiamonds: false
+        }
+      }
+    };
+  }
+  return oldState as SerializedState;
+};
+
+// final migration function must be of type Migration to ensure we output SerializedState
+const migrations: Array<Migration|PartialMigration> = [
+  migrate01to02
+];
+
+export const migrate: Migration = (oldState: UnmigratedSerializedState) => {
+  let newState = oldState;
+  for (const migration of migrations) {
+    newState = migration(newState);
+  }
+  return newState as SerializedState;
+};


### PR DESCRIPTION
When we created the Seismic work, I updated the shape of the student data, as we were modifying the MST stores. Because of this, old authoring or student data saved before this would not load in the new app. For this reason, the code soft-forked, with `production` being reserved for Tephra and `master` unable to merge directly into production.

This creates a framework for a series of migrations that can convert any old state to the latest version. At the moment, this only converts from the pre-seismic-unit states (which is what's saved, as of this commit, on production) to the post-seismic-unit state.

This belatedly bumps the serialization version number to 2. Because post-seismic-unit work may have been saved under version number 1, the migration duck-types to check if it needs migration.

The result of this work is that we will be able to

1. Release master as-is to production, instead of needing to cherry-pick tephra-specific features to production
2. Use production urls for the seismic work
3. Make further changes to the data structure as necessary, by increasing the version number and adding a new migration

I have QA'd this by saving authoring and student data on production and ensuring that it shows up when the branch is changed, and Chris Lore is doing the same.