### PR TITLE
Fix issue caused by migrating null data

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,9 +61,9 @@ phone.addListener("initInteractive", (data: {
 
   parseJSON(data, ["authoredState", "interactiveState", "linkedState"]);
 
-  const authorState: UnmigratedSerializedState = data && data.authoredState || {};
+  const authorState: UnmigratedSerializedState | {} = data && data.authoredState || {};
   // student data may be in either the current interactive's saved state, or a previous model's linked state
-  const studentState: UnmigratedSerializedState = data && (data.interactiveState || data.linkedState) || {};
+  const studentState: UnmigratedSerializedState | {} = data && (data.interactiveState || data.linkedState) || {};
 
   if (data.mode === "authoring") {
     mode = "author";

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -145,9 +145,16 @@ export const serializeState = (state: IStoreish): SerializedState => {
   };
 };
 // deserializes saved state, migrating data if necessary
-export const deserializeState = (serializedState: UnmigratedSerializedState): IStoreish => {
-  const migratedState = migrate(serializedState);
-  return migratedState.state;
+export const deserializeState = (serializedState: UnmigratedSerializedState | {}): IStoreish => {
+  if (serializedState && serializedState.hasOwnProperty("version")) {
+    const migratedState = migrate(serializedState as UnmigratedSerializedState);
+    return migratedState.state;
+  } else {
+    return {
+      unit: { name: "Tephra" },
+      blocklyStore: {}, tephraSimulation: {}, seismicSimulation: {}, uiStore: {}
+    };
+  }
 };
 
 export function updateStores(state: IStoreish) {


### PR DESCRIPTION
When an author first creates a model, it passes {} to the migration, which doesn't deal with that correctly. This was causing `updateStores` to throw an exception, preventing the store listeners from ever being added.

This fixes the issue by making the initial type of the data loaded from LARA explicit such that it may be {}, and passes back a valid but empty state if so.

(This essentially returns the handling of the empty state to what it was before the migration work was added. We had tested the migration work against existing models, but hadn't tried creating a new model.)