### PR TITLE
Save state on play

### DIFF
--- a/src/assets/test/test-serialization.json
+++ b/src/assets/test/test-serialization.json
@@ -37,7 +37,7 @@
         }
       },
       "expectedConvertedState": {
-        "version": 2,
+        "version": 3,
         "state": {
           "unit": {
             "name": "Tephra"
@@ -45,7 +45,8 @@
           "blocklyStore": {
             "toolbox": "Everything",
             "initialCodeTitle": "Basic",
-            "initialXmlCode": "<xml xmlns=\"http://www.w3.org/1999/xhtml\">\n  <block type=\"simulate_wind\" id=\"[q=jJs5eVLi`hbMBNkUv\" x=\"198\" y=\"93\">\n    <value name=\"wspeed\">\n      <block type=\"math_number\" id=\"@u3Zdj+hJTZpwyn.Er]+\">\n        <field name=\"NUM\">4</field>\n      </block>\n    </value>\n    <value name=\"wdirection\">\n      <block type=\"math_number\" id=\"@v[VUG[q]$(wDU)ot1Uf\">\n        <field name=\"NUM\">4</field>\n      </block>\n    </value>\n  </block>\n</xml>"
+            "initialXmlCode": "<xml xmlns=\"http://www.w3.org/1999/xhtml\">\n  <block type=\"simulate_wind\" id=\"[q=jJs5eVLi`hbMBNkUv\" x=\"198\" y=\"93\">\n    <value name=\"wspeed\">\n      <block type=\"math_number\" id=\"@u3Zdj+hJTZpwyn.Er]+\">\n        <field name=\"NUM\">4</field>\n      </block>\n    </value>\n    <value name=\"wdirection\">\n      <block type=\"math_number\" id=\"@v[VUG[q]$(wDU)ot1Uf\">\n        <field name=\"NUM\">4</field>\n      </block>\n    </value>\n  </block>\n</xml>",
+            "hasRunOnce": false
           },
           "tephraSimulation": {
             "requireEruption": true,

--- a/src/blockly/blockly-controller.ts
+++ b/src/blockly/blockly-controller.ts
@@ -47,6 +47,7 @@ export class BlocklyController {
     }
     this.stores.chartsStore.reset();
     this.stores.samplesCollectionsStore.reset();
+    this.stores.blocklyStore.runClicked();
   }
 
   public reset = () => {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -22,7 +22,7 @@ import WidgetPanel from "./widgets/widget-panel";
 import screenfull from "screenfull";
 import ResizeObserver from "react-resize-observer";
 import AuthoringMenu from "./authoring-menu";
-import { getAuthorableSettings, updateStores, serializeState, getSavableState,
+import { getAuthorableSettings, updateStores, serializeState, getSavableStateAuthor,
          deserializeState, UnmigratedSerializedState, IStoreish } from "../stores/stores";
 import { ChartPanel } from "./charts/chart-panel";
 import { BlocklyController } from "../blockly/blockly-controller";
@@ -621,7 +621,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
 
   private updateAuthoring = (authorMenuState: IStoreish) => {
     // first get the state from the entire app, including slider values etc
-    const localState = serializeState(getSavableState()).state;
+    const localState = serializeState(getSavableStateAuthor()).state;
 
     // delete the initialXml code that was serialized, or we will never update the blocks when
     // the author changes the initial code
@@ -643,7 +643,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
   }
 
   private saveStateToLocalStorage = () => {
-    localStorage.setItem("geocode-state", JSON.stringify(serializeState(getSavableState())));
+    localStorage.setItem("geocode-state", JSON.stringify(serializeState(getSavableStateAuthor())));
   }
 
   private loadStateFromLocalStorage = () => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -85,6 +85,12 @@ phone.addListener("initInteractive", (data: {
   }
   updateStores(initialState);
 
+  if (mode === "student") {
+    // set the initial state to whatever the mobx stores actually create after loading the initial data.
+    // this way saveUserData will accurately know if a new state is dirty.
+    initialState = serializeState(getSavableStateStudent()).state;
+  }
+
   onSnapshot(stores.unit, saveUserData);                   // MobX function called on every store change
   onSnapshot(stores.tephraSimulation, saveUserData);
   onSnapshot(stores.blocklyStore, saveUserData);

--- a/src/stores/blockly-store.ts
+++ b/src/stores/blockly-store.ts
@@ -25,6 +25,9 @@ export const BlocklyStore = types
           // see https://github.com/microsoft/TypeScript/issues/31663
           (self[key] as any) = data[key] as any;
         });
+        // after we have loaded, set the current cml code to the initial. This will ensure that our
+        // first saveable state is the same as our initial state.
+        self.xmlCode = self.initialXmlCode;
       },
       runClicked: () => {
         // this does nothing but set this flag, so that we save user data on first run

--- a/src/stores/blockly-store.ts
+++ b/src/stores/blockly-store.ts
@@ -25,7 +25,7 @@ export const BlocklyStore = types
           // see https://github.com/microsoft/TypeScript/issues/31663
           (self[key] as any) = data[key] as any;
         });
-        // after we have loaded, set the current cml code to the initial. This will ensure that our
+        // after we have loaded, set the current xml code to the initial. This will ensure that our
         // first saveable state is the same as our initial state.
         self.xmlCode = self.initialXmlCode;
       },

--- a/src/stores/blockly-store.ts
+++ b/src/stores/blockly-store.ts
@@ -7,6 +7,7 @@ export const BlocklyStore = types
     initialXmlCode: "",         // initial blockly xml code
     toolbox: "Everything",
     initialCodeTitle: "Basic",
+    hasRunOnce: false,
   })
   .actions((self) => ({
     setBlocklyCode(code: string, workspace: any) {
@@ -24,6 +25,10 @@ export const BlocklyStore = types
           // see https://github.com/microsoft/TypeScript/issues/31663
           (self[key] as any) = data[key] as any;
         });
+      },
+      runClicked: () => {
+        // this does nothing but set this flag, so that we save user data on first run
+        if (!self.hasRunOnce) self.hasRunOnce = true;
       },
     };
   });

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -73,6 +73,10 @@ const blocklyAuthorStateProps = (blocklyAuthorSettingsProps as string[]).concat(
   "xmlCode",
   "initialXmlCode",
 ));
+// additional props directly from current model that student will save
+const blocklyStudentStateProps = (blocklyAuthorStateProps as string[]).concat(tuple(
+  "hasRunOnce",
+));
 
 export type BlocklyStoreAuthorSettingsProps = typeof blocklyAuthorSettingsProps[number];
 
@@ -126,9 +130,12 @@ function getStoreSubstate(blocklyStoreProps: string[], tephraSimulationProps: st
 // gets the current stores state in a version appropriate for the authoring menu
 export const getAuthorableSettings =
   getStoreSubstate(blocklyAuthorSettingsProps, tephraSimulationAuthorSettingsProps, uiAuthorSettingsProps);
-// gets the current store state to be saved by an author or student
-export const getSavableState =
+// gets the current store state to be saved by an author
+export const getSavableStateAuthor =
   getStoreSubstate(blocklyAuthorStateProps, tephraSimulationAuthorStateProps, uiAuthorSettingsProps);
+  // gets the current store state to be saved by an student (the above, plus anything like run state or tab state)
+export const getSavableStateStudent =
+getStoreSubstate(blocklyStudentStateProps, tephraSimulationAuthorStateProps, uiAuthorSettingsProps);
 
 // makes state appropriate for saving to e.g. LARA. Changes keys or values as needed. Adds a version number
 export const serializeState = (state: IStoreish): SerializedState => {

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -133,7 +133,7 @@ export const getAuthorableSettings =
 // gets the current store state to be saved by an author
 export const getSavableStateAuthor =
   getStoreSubstate(blocklyAuthorStateProps, tephraSimulationAuthorStateProps, uiAuthorSettingsProps);
-  // gets the current store state to be saved by an student (the above, plus anything like run state or tab state)
+  // gets the current store state to be saved by a student (the above, plus anything like run state or tab state)
 export const getSavableStateStudent =
 getStoreSubstate(blocklyStudentStateProps, tephraSimulationAuthorStateProps, uiAuthorSettingsProps);
 

--- a/src/utilities/migrate-state.ts
+++ b/src/utilities/migrate-state.ts
@@ -1,11 +1,15 @@
 import { UnmigratedSerializedState, SerializedState } from "../stores/stores";
 
-export const CURRENT_SERIALIZATION_VERSION = 2;
+export const CURRENT_SERIALIZATION_VERSION = 3;
 
 type PartialMigration = (oldState: UnmigratedSerializedState) => UnmigratedSerializedState;
 type Migration = (oldState: UnmigratedSerializedState) => SerializedState;
 
-const migrate01to02: Migration = (oldState) => {
+/**
+ * Version 2 adds the seismic unit, which involves new unit, blocklyStore, and seismicSimulation fields.
+ * blocklyStore extracts the common blockly parts out of tephraSimulation.
+ */
+const migrate01to02: PartialMigration = (oldState) => {
   if (oldState.version === 1 && !oldState.state.unit) {
     // serialization with version = 1 and a unit specified is identical to version 2
     const {simulation, uiStore} = oldState.state;
@@ -17,7 +21,7 @@ const migrate01to02: Migration = (oldState) => {
         blocklyStore: {
           toolbox,
           initialCodeTitle,
-          initialXmlCode
+          initialXmlCode,
         },
         tephraSimulation,
         seismicSimulation: {},
@@ -32,9 +36,33 @@ const migrate01to02: Migration = (oldState) => {
   return oldState as SerializedState;
 };
 
+/**
+ * Version 3 adds `hasRunOnce` to the blocklyStore.
+ */
+const migrate02to03: Migration = (oldState) => {
+  if (oldState.version < 3) {
+    const {unit, blocklyStore, tephraSimulation, seismicSimulation, uiStore} = oldState.state;
+    return {
+      version: 3,
+      state: {
+        unit,
+        blocklyStore: {
+          ...blocklyStore,
+          hasRunOnce: false
+        },
+        tephraSimulation,
+        seismicSimulation,
+        uiStore,
+      }
+    };
+  }
+  return oldState as SerializedState;
+};
+
 // final migration function must be of type Migration to ensure we output SerializedState
 const migrations: Array<Migration|PartialMigration> = [
-  migrate01to02
+  migrate01to02,
+  migrate02to03,
 ];
 
 export const migrate: Migration = (oldState: UnmigratedSerializedState) => {


### PR DESCRIPTION
This

1. Ensures that learner state does not save when the model first loads
2. But does save when a learner clicks Play for the first time

This updates the user data model to add a useless boolean `hasRunOnce`. We ensure that this can't get set by an author but only by a student.

Then there is a little additional trickiness to ensure that the `initialState`, which we use to compare against to see whether the user had dirtied state, really is the state that gets loaded before the student performs any actions. Previously, because of the way Blockly loaded its code, we would get a ghost action that looked like it dirtied state.