### PR TITLE
Improve monte carlo display on small view ports

### DIFF
--- a/src/components/montecarlo/histogram-panel.tsx
+++ b/src/components/montecarlo/histogram-panel.tsx
@@ -44,9 +44,9 @@ interface PanelStatProps {
   marginRight?: number;
 }
 const PanelStat = styled.div`
-  margin: 5px;
-  font-size: 14px;
-  margin-right: ${(p: PanelStatProps) => `${p.marginRight ? p.marginRight : 5}px`};
+  margin: 3px;
+  font-size: 13px;
+  margin-right: ${(p: PanelStatProps) => `${p.marginRight ? p.marginRight : 3}px`};
 `;
 const RiskContainer = styled(HorizontalContainer)`
   margin-top: 15px;


### PR DESCRIPTION
This PR makes small CSS improvements to the monte carlo stats so they display properly on small viewports.  

Testable here:
http://geocode-app.concord.org/branch/monte-carlo-display-fix/index.html

Results on 875 x 560 view port (the top image is how the monte carlo panel previously looked, the bottom image is the improved version):
![image](https://user-images.githubusercontent.com/5126913/109704628-aa9b4c00-7b4b-11eb-9822-1c1cca60b4f3.png)
