### PR TITLE
Add uniform axis scaling for position over time graph

### DIFF
--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -333,7 +333,8 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
         duration: timeRange.duration ? timeRange.duration : undefined,
       };
       const dataset = Datasets.getGPSPositionTimeData(station, validTimeRange);
-      chartsStore.addArbitraryChart(dataset, "East (mm)", "North (mm)", `${params.station} Position over Time`, true);
+      chartsStore.addArbitraryChart(dataset, "East (mm)", "North (mm)", `${params.station} Position over Time`, true,
+                                    true);
     });
 
     addFunc("computeStrainRate", (filter: Filter) => {

--- a/src/components/charts/canvas-d3-scatter-chart.tsx
+++ b/src/components/charts/canvas-d3-scatter-chart.tsx
@@ -58,6 +58,7 @@ export class CanvasD3ScatterChart extends React.Component<IProps> {
     const xRange = Number(chart.extent(0)[1]) - Number(chart.extent(0)[0]);
     const yRange = Number(chart.extent(1)[1]) - Number(chart.extent(1)[0]);
     const chartWidth = width - margin.left - margin.right + (canvasPadding * 2);
+    // adjust height if the x and y axes need to be scaled uniformly, base off of width
     const chartHeight = uniformXYScale
       ? yRange / xRange * chartWidth
       : height - margin.top - margin.bottom + (canvasPadding * 2);

--- a/src/components/charts/svg-d3-scatter-chart.tsx
+++ b/src/components/charts/svg-d3-scatter-chart.tsx
@@ -11,23 +11,36 @@ interface IProps {
 }
 
 export const SvgD3ScatterChart = (props: IProps) => {
-  const { height, width, chart } = props;
-  const { data, xAxisLabel, yAxisLabel, fadeIn, uniformXYScale } = chart;
+
+  const calculateChartDimensions = (_xRange: number, _yRange: number) => {
+    const _chart = props.chart;
+    const _width = props.width;
+    const _height = props.height;
+    const { uniformXYScale } = _chart;
+    const chartUsedWidth = _width - margin.left - margin.right;
+    // adjust height if the x and y axes need to be scaled uniformly, base off of width
+    const chartUsedHeight = uniformXYScale
+      ? _yRange / _xRange * chartUsedWidth
+      : _height - margin.top - margin.bottom;
+    const usedHeight = uniformXYScale ? chartUsedHeight + margin.top + margin.bottom : _height;
+    return { width: _width, height: usedHeight, chartWidth: chartUsedWidth, chartHeight: chartUsedHeight};
+  };
+
+  const { chart } = props;
+  const { data, xAxisLabel, yAxisLabel, fadeIn } = chart;
   const xRange = Number(chart.extent(0)[1]) - Number(chart.extent(0)[0]);
   const yRange = Number(chart.extent(1)[1]) - Number(chart.extent(1)[0]);
   const xTicks = Math.floor(xRange / 100);
   const yTicks = Math.floor(yRange / 100);
   const margin = {top: 15, right: 20, bottom: 43, left: 50};
-  const chartWidth = width - margin.left - margin.right;
-  // adjust height if the x and y axes need to be scaled uniformly, base off of width
-  const chartHeight = uniformXYScale ? yRange / xRange * chartWidth : height - margin.top - margin.bottom;
-  const usedHeight = uniformXYScale ? chartHeight + margin.top + margin.bottom : height;
+  const chartDimensions = calculateChartDimensions(xRange, yRange);
+  const { width, height, chartWidth, chartHeight } = chartDimensions;
 
   const div = new ReactFauxDOM.Element("div");
 
   const svg = d3.select(div).append("svg")
     .attr("width", width)
-    .attr("height", usedHeight)
+    .attr("height", height)
     .append("g")
     .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
@@ -56,7 +69,7 @@ export const SvgD3ScatterChart = (props: IProps) => {
   if (xAxisLabel) {
     svg.append("text")
       .attr("x", `${chartWidth / 2}`)
-      .attr("y", `${usedHeight - 20}`)
+      .attr("y", `${height - 20}`)
       .style("text-anchor", "middle")
       .style("font-size", "0.9em")
       .style("fill", "#555")
@@ -64,7 +77,7 @@ export const SvgD3ScatterChart = (props: IProps) => {
   }
   if (yAxisLabel) {
     svg.append("text")
-      .attr("x", `-${usedHeight / 2}`)
+      .attr("x", `-${height / 2}`)
       .attr("dy", "-30px")
       .attr("transform", "rotate(-90)")
       .style("font-size", "0.9em")

--- a/src/components/charts/svg-d3-scatter-chart.tsx
+++ b/src/components/charts/svg-d3-scatter-chart.tsx
@@ -11,18 +11,23 @@ interface IProps {
 }
 
 export const SvgD3ScatterChart = (props: IProps) => {
-  const { width, height, chart } = props;
-  const { data, xAxisLabel, yAxisLabel, fadeIn } = chart;
-
+  const { height, width, chart } = props;
+  const { data, xAxisLabel, yAxisLabel, fadeIn, uniformXYScale } = chart;
+  const xRange = Number(chart.extent(0)[1]) - Number(chart.extent(0)[0]);
+  const yRange = Number(chart.extent(1)[1]) - Number(chart.extent(1)[0]);
+  const xTicks = Math.floor(xRange / 100);
+  const yTicks = Math.floor(yRange / 100);
   const margin = {top: 15, right: 20, bottom: 43, left: 50};
   const chartWidth = width - margin.left - margin.right;
-  const chartHeight = height - margin.top - margin.bottom;
+  // adjust height if the x and y axes need to be scaled uniformly, base off of width
+  const chartHeight = uniformXYScale ? yRange / xRange * chartWidth : height - margin.top - margin.bottom;
+  const usedHeight = uniformXYScale ? chartHeight + margin.top + margin.bottom : height;
 
   const div = new ReactFauxDOM.Element("div");
 
   const svg = d3.select(div).append("svg")
     .attr("width", width)
-    .attr("height", height)
+    .attr("height", usedHeight)
     .append("g")
     .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
@@ -36,14 +41,14 @@ export const SvgD3ScatterChart = (props: IProps) => {
   // add axes
   const axisBottom = chart.isDate(0) ?
       d3.axisBottom(xScale).tickFormat(chart.toDateString()) :
-      d3.axisBottom(xScale);
+      d3.axisBottom(xScale).ticks(xTicks);
   svg.append("g")
     .attr("transform", "translate(0," + chartHeight + ")")
     .call(axisBottom);
 
   const axisLeft = chart.isDate(1) ?
     d3.axisLeft(yScale).tickFormat(chart.toDateString()) :
-    d3.axisLeft(yScale);
+    d3.axisLeft(yScale).ticks(yTicks);
   svg.append("g")
     .call(axisLeft);
 
@@ -51,7 +56,7 @@ export const SvgD3ScatterChart = (props: IProps) => {
   if (xAxisLabel) {
     svg.append("text")
       .attr("x", `${chartWidth / 2}`)
-      .attr("y", `${height - 20}`)
+      .attr("y", `${usedHeight - 20}`)
       .style("text-anchor", "middle")
       .style("font-size", "0.9em")
       .style("fill", "#555")
@@ -59,7 +64,7 @@ export const SvgD3ScatterChart = (props: IProps) => {
   }
   if (yAxisLabel) {
     svg.append("text")
-      .attr("x", `-${height / 2}`)
+      .attr("x", `-${usedHeight / 2}`)
       .attr("dy", "-30px")
       .attr("transform", "rotate(-90)")
       .style("font-size", "0.9em")

--- a/src/stores/charts-store.ts
+++ b/src/stores/charts-store.ts
@@ -24,6 +24,7 @@ const Chart = types.model("Chart", {
   dateLabelFormat: types.maybe(types.string),
   threshold: types.maybe(types.number),
   fadeIn: types.optional(types.boolean, false),
+  uniformXYScale: types.optional(types.boolean, false),
 })
 .views((self) => {
   const isDate = (column: 0|1) => {
@@ -70,7 +71,8 @@ const ChartsStore = types.model("Charts", {
 })
 .actions((self) => ({
   addChart(chartProps: {type: ChartTypeType, chartStyle?: ChartStyleType, data: ChartData, customExtents?: number[][],
-          title?: string, xAxisLabel?: string, yAxisLabel?: string, dateLabelFormat?: string, fadeIn?: boolean}) {
+          title?: string, xAxisLabel?: string, yAxisLabel?: string, dateLabelFormat?: string, fadeIn?: boolean,
+          uniformXYScale?: boolean}) {
     const chart = Chart.create(chartProps);
     self.charts.push(chart);
     return chart;     // returns in case anyone wants to use the new chart
@@ -117,7 +119,8 @@ const ChartsStore = types.model("Charts", {
   /**
    * Creates a custom chart based on known properties of wind data.
    */
-  addArbitraryChart(dataset: Dataset, xAxis: string, yAxis: string, _title?: string, _fadeIn?: boolean) {
+  addArbitraryChart(dataset: Dataset, xAxis: string, yAxis: string, _title?: string, _fadeIn?: boolean,
+                    _uniformXYScale?: boolean) {
     let data;
 
     const timeParser = WindData.timeParsers[xAxis];
@@ -141,7 +144,9 @@ const ChartsStore = types.model("Charts", {
     const xAxisLabel = WindData.axisLabel[xAxis] ?  WindData.axisLabel[xAxis] : capFirst(xAxis);
     const yAxisLabel = WindData.axisLabel[yAxis] ?  WindData.axisLabel[yAxis] : capFirst(yAxis);
     const fadeIn = _fadeIn || false;
-    self.addChart({type, data, customExtents, title, xAxisLabel, yAxisLabel, chartStyle, dateLabelFormat, fadeIn});
+    const uniformXYScale = _uniformXYScale || false;
+    self.addChart({type, data, customExtents, title, xAxisLabel, yAxisLabel, chartStyle, dateLabelFormat, fadeIn,
+                   uniformXYScale});
   },
 
   /**

--- a/src/stores/data-sets.ts
+++ b/src/stores/data-sets.ts
@@ -126,7 +126,7 @@ export const WindData: DataSetInfo = {
     "elevation": [1450, 1600],
     "speed": [0, 23],
     "East (mm)": [-800, 300],
-    "North (mm)": [0, 650],
+    "North (mm)": [0, 700],
   },
   timeParsers: {
     date: {


### PR DESCRIPTION
This PR adds a `uniformXYScale` flag to the chart store so that the x and y tickmarks on the GPS location over time graph can be scaled uniformly.  

NOTE: it's a little awkward that we pass in a `height` to the `SvgD3ScatterChart` component and then I override it if `uniformXYScale` is true.  However, it seemed a lot more cluttered to do the calculation elsewhere and try to pass in the actual final height.  I'm open to thoughts on this.  

Testable here:
http://geocode-app.concord.org/branch/uniform-axes/index.html

![image](https://user-images.githubusercontent.com/5126913/109705957-382b6b80-7b4d-11eb-9edf-26caddf049c8.png)
