### PR TITLE
Add left/right tab state to UI store, save/restore to and from LARA

### DIFF
--- a/src/assets/test/test-serialization.json
+++ b/src/assets/test/test-serialization.json
@@ -32,7 +32,9 @@
             "showSpeedControls": true,
             "showBarHistogram": false,
             "showLog": false,
-            "showDemoCharts": false
+            "showDemoCharts": false,
+            "leftTabIndex": 0,
+            "rightTabIndex": 0
           }
         }
       },
@@ -76,7 +78,9 @@
             "showBarHistogram": false,
             "showLog": false,
             "showDemoCharts": false,
-            "showRiskDiamonds": false
+            "showRiskDiamonds": false,
+            "leftTabIndex": 0,
+            "rightTabIndex": 0
           }
         }
       }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -35,8 +35,6 @@ import { UnitNameType } from "../stores/unit-store";
 interface IProps extends IBaseProps {}
 
 interface IState {
-  tabIndex: number;
-  rightTabIndex: number;
   expandOptionsDialog: boolean;
   dimensions: {
     width: number;
@@ -144,12 +142,10 @@ export class AppComponent extends BaseComponent<IProps, IState> {
   public constructor(props: IProps) {
     super(props);
 
-    this.handleTabSelect = this.handleTabSelect.bind(this);
+    this.handleLeftTabSelect = this.handleLeftTabSelect.bind(this);
     this.handleRightTabSelect = this.handleRightTabSelect.bind(this);
 
     const initialState: IState = {
-      tabIndex: 0,
-      rightTabIndex: 0,
       expandOptionsDialog: false,
       dimensions: {
         width: window.innerWidth,
@@ -194,6 +190,8 @@ export class AppComponent extends BaseComponent<IProps, IState> {
         showSpeedControls,
         speed,
         hideBlocklyToolbox,
+        leftTabIndex,
+        rightTabIndex
       }
     } = this.stores;
     const {
@@ -210,8 +208,6 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     } = this.blocklyController;
 
     const {
-      tabIndex,
-      rightTabIndex,
       expandOptionsDialog
     } = this.state;
 
@@ -262,7 +258,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     if (showData)         { enabledRightTabTypes.push(RightSectionTypes.DATA); }
     if (showDeformation)  { enabledRightTabTypes.push(RightSectionTypes.DEFORMATION); }
 
-    const currentTabType = enabledTabTypes[tabIndex || 0];
+    const currentTabType = enabledTabTypes[leftTabIndex || 0];
     const currentRightTabType = enabledRightTabTypes[rightTabIndex || 0];
 
     const setSpeed = (_speed: number) => uiStore.setSpeed(_speed);
@@ -273,7 +269,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
           onResize={this.resize}
         />
         <Row>
-          <Tabs selectedIndex={tabIndex} onSelect={this.handleTabSelect}>
+          <Tabs selectedIndex={leftTabIndex} onSelect={this.handleLeftTabSelect}>
             <TabBack
               width={tabWidth}
               backgroundcolor={this.getTabColor(currentTabType)}
@@ -281,9 +277,9 @@ export class AppComponent extends BaseComponent<IProps, IState> {
             <TabList>
               { showBlocks &&
                 <Tab
-                  selected={tabIndex === kTabInfo.blocks.index}
-                  leftofselected={tabIndex === (kTabInfo.blocks.index + 1) ? "true" : undefined}
-                  rightofselected={tabIndex === (kTabInfo.blocks.index - 1) ? "true" : undefined}
+                  selected={leftTabIndex === kTabInfo.blocks.index}
+                  leftofselected={leftTabIndex === (kTabInfo.blocks.index + 1) ? "true" : undefined}
+                  rightofselected={leftTabIndex === (kTabInfo.blocks.index - 1) ? "true" : undefined}
                   backgroundcolor={this.getTabColor(SectionTypes.BLOCKS)}
                   backgroundhovercolor={this.getTabHoverColor(SectionTypes.BLOCKS)}
                   data-test={this.getTabName(SectionTypes.BLOCKS) + "-tab"}
@@ -293,9 +289,9 @@ export class AppComponent extends BaseComponent<IProps, IState> {
               }
               { showCode &&
                 <Tab
-                  selected={tabIndex === kTabInfo.code.index}
-                  leftofselected={tabIndex === (kTabInfo.code.index + 1) ? "true" : undefined}
-                  rightofselected={tabIndex === (kTabInfo.code.index - 1) ? "true" : undefined}
+                  selected={leftTabIndex === kTabInfo.code.index}
+                  leftofselected={leftTabIndex === (kTabInfo.code.index + 1) ? "true" : undefined}
+                  rightofselected={leftTabIndex === (kTabInfo.code.index - 1) ? "true" : undefined}
                   backgroundcolor={this.getTabColor(SectionTypes.CODE)}
                   backgroundhovercolor={this.getTabHoverColor(SectionTypes.CODE)}
                   data-test={this.getTabName(SectionTypes.CODE) + "-tab"}
@@ -305,9 +301,9 @@ export class AppComponent extends BaseComponent<IProps, IState> {
               }
               { showControls &&
                 <Tab
-                  selected={tabIndex === kTabInfo.controls.index}
-                  leftofselected={tabIndex === (kTabInfo.controls.index + 1) ? "true" : undefined}
-                  rightofselected={tabIndex === (kTabInfo.controls.index - 1) ? "true" : undefined}
+                  selected={leftTabIndex === kTabInfo.controls.index}
+                  leftofselected={leftTabIndex === (kTabInfo.controls.index + 1) ? "true" : undefined}
+                  rightofselected={leftTabIndex === (kTabInfo.controls.index - 1) ? "true" : undefined}
                   backgroundcolor={this.getTabColor(SectionTypes.CONTROLS)}
                   backgroundhovercolor={this.getTabHoverColor(SectionTypes.CONTROLS)}
                   data-test={this.getTabName(SectionTypes.CONTROLS) + "-tab"}
@@ -611,12 +607,12 @@ export class AppComponent extends BaseComponent<IProps, IState> {
 
   private toggleShowOptions = () => this.setState({expandOptionsDialog: !this.state.expandOptionsDialog});
 
-  private handleTabSelect(tabIndex: number) {
-    this.setState({tabIndex});
+  private handleLeftTabSelect(tabIndex: number) {
+    this.stores.uiStore.setLeftTabIndex(tabIndex);
   }
 
-  private handleRightTabSelect(rightTabIndex: number) {
-    this.setState({rightTabIndex});
+  private handleRightTabSelect(tabIndex: number) {
+    this.stores.uiStore.setRightTabIndex(tabIndex);
   }
 
   private updateAuthoring = (authorMenuState: IStoreish) => {

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -102,7 +102,9 @@ const uiAuthorSettingsProps = tuple(
   "showBarHistogram",
   "showLog",
   "showDemoCharts",
-  "showRiskDiamonds"
+  "showRiskDiamonds",
+  "leftTabIndex",
+  "rightTabIndex"
 );
 
 export type UIAuthorSettingsProps = typeof uiAuthorSettingsProps[number];

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -30,6 +30,8 @@ const UIStore = types.model("UI", {
   currentHistogramTab: 0,
   // hide toolbar in reports mode
   hideBlocklyToolbox: false,
+  leftTabIndex: 0,
+  rightTabIndex: 0,
 })
 .actions((self) => ({
   setShowOptionsDialog(show: boolean) {
@@ -38,12 +40,18 @@ const UIStore = types.model("UI", {
   setHideBlocklyToolbox(show: boolean) {
     self.hideBlocklyToolbox = show;
   },
+  setLeftTabIndex(index: number) {
+    self.leftTabIndex = index;
+  },
+  setRightTabIndex(index: number) {
+    self.rightTabIndex = index;
+  }
 }))
 .actions((self) => {
   return {
     loadAuthorSettingsData: (data: UIAuthorSettings) => {
       Object.keys(data).forEach((key: UIAuthorSettingsProps) => {
-        self[key] = data[key];
+        (self[key] as any) = data[key] as any;
       });
 
       // if author is showing fast speed, set model to fast initially


### PR DESCRIPTION
This PR moves the left and right tab state management put of the `App` component and into the `uiStore`.  The current tab index is then saved to and restored from LARA.

Running here (not much to see other than the fact that we can test that the tabbing still functions as expected):
https://geocode-app.concord.org/branch/tab-authoring/index.html

Here is an example running in the activity player.  When authored, I saved with the code tab and the data tab as the current tabs. When loaded, the code tab is restored on the left and the data tab is restored on the right:
https://activity-player.concord.org/branch/master/?activity=https%3A%2F%2Fauthoring.staging.concord.org%2Fapi%2Fv1%2Factivities%2F20939.json&page=page_308580&preview 