### PR TITLE
Fix seismic sizing on Firefox

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -63,6 +63,7 @@ const Row = styled.div`
 
 const CenteredRow = styled(Row)`
   justify-content: center;
+  height: 135px;
 `;
 
 const BottomBar = styled.div`


### PR DESCRIPTION
This PR fixes a sizing bug in Firefox.  The panel below the seismic map was being shown with an incorrect height which caused it to take up half the screen.  Give it a static height to eliminate the bug.

Bug here:
![image](https://user-images.githubusercontent.com/5126913/110029136-f20b0f00-7ce8-11eb-8827-e169fa16409e.png)
