### PR TITLE
Updates to the lat/long tool UI

### DIFF
--- a/src/components/icons.ts
+++ b/src/components/icons.ts
@@ -58,8 +58,8 @@ export function getCachedSampleLocationIcon(label: string) {
     return iconsCache.get(iconKey);
 }
 
-export function latLngIcon(label: string, anchorCorner: string = "top-left"): DivIcon {
-  const html = `<div class='latlng-icon-content ${anchorCorner}'>
+export function latLngIcon(label: string, anchorCorner: string = "top-left", crosshair: boolean = false): DivIcon {
+  const html = `<div class='latlng-icon-content ${anchorCorner} ${crosshair ? "crosshair-cursor" : ""}'>
     <div class='content'>${label}</div>
     <div class='handle'></div>
   </div>`;

--- a/src/components/map/layers/latlng-draw-layer.tsx
+++ b/src/components/map/layers/latlng-draw-layer.tsx
@@ -145,6 +145,7 @@ export class LatLngDrawLayer extends BaseComponent<IProps, IState> {
 
   public render() {
     const { map } = this.props;
+    const { pointsSet } = this.state;
     if (!map) return null;
 
     const { p1Lat, p1Lng, p2Lat, p2Lng } = this.props;
@@ -183,10 +184,10 @@ export class LatLngDrawLayer extends BaseComponent<IProps, IState> {
 
     const p1Icon = latLngIcon(
       `<b>Corner 1</b><br/>Latitude: ${p1Lat.toFixed(2)} <b>W</b><br/>Longitude: ${p1Lng.toFixed(2)} <b>N</b>`,
-      getCorner(point1, point2));
+      getCorner(point1, point2), !pointsSet);
     const p2Icon = latLngIcon(
       `<b>Corner 2</b><br/>Latitude: ${p2Lat.toFixed(2)} <b>W</b><br/>Longitude: ${p2Lng.toFixed(2)} <b>N</b>`,
-      getCorner(point2, point1, false));
+      getCorner(point2, point1, false), !pointsSet);
 
     return (
       <LayerGroup map={map}>

--- a/src/components/map/layers/latlng-draw-layer.tsx
+++ b/src/components/map/layers/latlng-draw-layer.tsx
@@ -47,6 +47,7 @@ export class LatLngDrawLayer extends BaseComponent<IProps, IState> {
       map.dragging.disable();
       map.on(MOUSE_DOWN, this.drawPoints);
       map.on(MOUSE_UP, this.endDraw);
+      L.DomUtil.addClass(map.getContainer(), "crosshair-cursor");
     }
   }
 
@@ -55,6 +56,7 @@ export class LatLngDrawLayer extends BaseComponent<IProps, IState> {
     if (map !== null) {
       map.dragging.enable();
       map.off(MOUSE_DOWN, this.drawPoints);
+      L.DomUtil.removeClass(map.getContainer(), "crosshair-cursor");
     }
   }
   public drawPoints(event: Leaflet.LeafletMouseEvent) {
@@ -67,13 +69,6 @@ export class LatLngDrawLayer extends BaseComponent<IProps, IState> {
         this.setPoint2(event);
         map.on(MOUSE_MOVE, this.setPoint2);
       }
-      else {
-        this.setPoint2(event);
-        map.dragging.enable();
-        map.off(MOUSE_MOVE, this.setPoint2);
-        map.off(MOUSE_DOWN, this.drawPoints);
-        this.setState({ pointsSet: true });
-      }
     }
   }
   public endDraw() {
@@ -82,10 +77,15 @@ export class LatLngDrawLayer extends BaseComponent<IProps, IState> {
     if (map !== null) {
       // has the user entered two points?
       if (!pointsSet) {
-        // user has clicked / tapped once to select first point
+        // user has clicked / tapped to complete initial rectangle
+        map.dragging.enable();
         map.off(MOUSE_MOVE, this.setPoint1);
+        map.off(MOUSE_MOVE, this.setPoint2);
+        map.off(MOUSE_DOWN, this.drawPoints);
+        this.setState({ pointsSet: true });
+        L.DomUtil.removeClass(map.getContainer(), "crosshair-cursor");
       } else {
-        // user click/dragged the points, assume we're finished
+        // user dragged the points
         map.dragging.enable();
         map.off(MOUSE_MOVE, this.setPoint1);
         map.off(MOUSE_MOVE, this.setPoint2);
@@ -190,10 +190,6 @@ export class LatLngDrawLayer extends BaseComponent<IProps, IState> {
 
     return (
       <LayerGroup map={map}>
-        {point1 && <Marker key={"latlngp1"} marker_index={1} position={point1} icon={p1Icon}
-          draggable={true} onDragStart={this.dragPointStart} onDragEnd={this.dragPointEnd} />}
-        {point2 && <Marker key={"latlngp2"} marker_index={2} position={point2} icon={p2Icon}
-          draggable={true} onDragStart={this.dragPointStart} onDragEnd={this.dragPointEnd} />}
         {point1 && point2 &&
           <Polyline
             key={"lat-lng-line"}
@@ -202,6 +198,10 @@ export class LatLngDrawLayer extends BaseComponent<IProps, IState> {
             color="#b263f7"
             opacity={1}
           />}
+        {point1 && <Marker key={"latlngp1"} marker_index={1} position={point1} icon={p1Icon}
+          draggable={true} onDragStart={this.dragPointStart} onDragEnd={this.dragPointEnd} />}
+        {point2 && <Marker key={"latlngp2"} marker_index={2} position={point2} icon={p2Icon}
+          draggable={true} onDragStart={this.dragPointStart} onDragEnd={this.dragPointEnd} />}
       </LayerGroup>
     );
   }

--- a/src/css/custom-leaflet-icons.css
+++ b/src/css/custom-leaflet-icons.css
@@ -92,8 +92,8 @@
   background: #fff;
   width: max-content !important;
   height: max-content !important;
-  margin-top: 2px !important;
-  margin-left: 5px !important;
+  margin-top: 6px !important;
+  margin-left: 6px !important;
   padding: 2px !important;
   border-radius: 0px;
   box-shadow: 0 0 7px rgba(0,0,0,0.55);
@@ -109,12 +109,15 @@
   background-color: white;
 }
 .latlng-icon-content .handle{
-  width: 6px;
-  height: 6px;
+  width: 8px;
+  height: 8px;
   position: absolute;
   background-color: white;
   border: 2px solid #999;
-  border-radius: 4px;
+  border-radius: 50%;
+}
+.latlng-icon-content .handle:hover{
+  border: 2px solid black;
 }
 
 .top-left {
@@ -131,7 +134,7 @@
 }
 
 .bottom-left {
-  transform: translate(0%, -100%);;
+  transform: translate(0%, -100%);
 }
 
 .bottom-right {
@@ -158,22 +161,22 @@
 }
 
 .top-left .handle{
-  top: -2px;
-  left: -4px;
+  top: -6px;
+  left: -6px;
 }
 
 .top-right .handle{
-  top: -2px;
-  right: -4px;
+  top: -6px;
+  right: -6px;
 }
 
 .bottom-left .handle{
-  bottom: -8px;
+  bottom: -6px;
   left: -6px;
 }
 
 .bottom-right .handle{
-  bottom: -8px;
+  bottom: -6px;
   right: -6px;
 }
 

--- a/src/css/map-component.css
+++ b/src/css/map-component.css
@@ -1,26 +1,29 @@
 .map-component {
-    position: relative;
-    height: 100%;
+  position: relative;
+  height: 100%;
+}
 
+.map {
+  height: 100%;
+  z-index: 0;
+}
 
-  }
-  .map {
-    height: 100%;
-    z-index: 0;
-  }
+.leaflet-marker-icon {
+  cursor: pointer;
+}
 
-  .leaflet-marker-icon {
-    cursor: pointer;
-  }
+.arrow-scale {
+  z-index: 2000;
+  position: absolute;
+  top: 140px;
+  left: 5px;
+  margin-right: auto;
+  border-top: 2px solid rgb(51, 136, 255);
+  font-size: 0.9em;
+  text-align: center;
+  color: #333
+}
 
-  .arrow-scale {
-    z-index: 2000;
-    position: absolute;
-    top: 140px;
-    left: 5px;
-    margin-right: auto;
-    border-top: 2px solid rgb(51, 136, 255);
-    font-size: 0.9em;
-    text-align: center;
-    color: #333
-  }
+.leaflet-container.crosshair-cursor {
+  cursor: crosshair;
+}

--- a/src/css/map-component.css
+++ b/src/css/map-component.css
@@ -12,6 +12,10 @@
   cursor: pointer;
 }
 
+.crosshair-cursor {
+  cursor: crosshair;
+}
+
 .arrow-scale {
   z-index: 2000;
   position: absolute;


### PR DESCRIPTION
This PR adds small UI/UX updates to the lat long tool based on the UI spec updates.  Changes include:
- Clicking the Lat-Long button changes the default cursor to a crosshair cursor
- Rectangle is added by clicking and holding, dragging, and then releasing.  No longer requires two clicks.
- Once rectangle is added, cursor returns to map default
- Drag handle has hover state  and is slightly larger.  Can be used to drag rectangle corners to move points.
- Minor positioning fixes to drag handles and corner info box

Can be tested here:
http://geocode-app.concord.org/branch/lat-lomg-ux/index.html

![image](https://user-images.githubusercontent.com/5126913/110511835-82ff3300-80b9-11eb-8ca1-7006a2add311.png)
