### PR TITLE
Update tab colors

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -455,7 +455,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
             { showData &&
               <TabPanel
                 width={`${tabWidth}px`}
-                tabcolor={this.getRightTabColor(RightSectionTypes.DATA)}
+                tabcolor={this.getRightTabColor(RightSectionTypes.DATA, unitName)}
                 rightpanel={"true"}
                 data-test={this.getRightTabName(RightSectionTypes.DATA) + "-panel"}
               >
@@ -480,7 +480,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
             }
             <RightTabBack
               width={tabWidth}
-              backgroundcolor={this.getRightTabColor(currentRightTabType)}
+              backgroundcolor={this.getRightTabColor(currentRightTabType, unitName)}
             />
             <BottomBar>
               <TabsContainer>
@@ -526,7 +526,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                       selected={rightTabIndex === kRightTabInfo.data.index}
                       leftofselected={rightTabIndex === (kRightTabInfo.data.index + 1) ? "true" : undefined}
                       rightofselected={rightTabIndex === (kRightTabInfo.data.index - 1) ? "true" : undefined}
-                      backgroundcolor={this.getRightTabColor(RightSectionTypes.DATA)}
+                      backgroundcolor={this.getRightTabColor(RightSectionTypes.DATA, unitName)}
                       backgroundhovercolor={this.getRightTabHoverColor(RightSectionTypes.DATA)}
                       data-test={this.getRightTabName(RightSectionTypes.DATA) + "-tab"}
                     >
@@ -580,11 +580,19 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     return (type ? kTabInfo[type].name : "");
   }
 
-  private getRightTabColor = (type: RightSectionTypes) => {
-    return (type ? kRightTabInfo[type].backgroundColor : "white");
+  private getRightTabColor = (type: RightSectionTypes, unit?: UnitNameType) => {
+    if (!type) return "white";
+    if (unit && kRightTabInfo[type].unitBackgroundColor && kRightTabInfo[type].unitBackgroundColor![unit]) {
+      return kRightTabInfo[type].unitBackgroundColor![unit];
+    }
+    return kRightTabInfo[type].backgroundColor;
   }
-  private getRightTabHoverColor = (type: RightSectionTypes) => {
-    return (type ? kRightTabInfo[type].hoverBackgroundColor : "white");
+  private getRightTabHoverColor = (type: RightSectionTypes, unit?: UnitNameType) => {
+    if (!type) return "white";
+    if (unit && kRightTabInfo[type].unitHoverBackgroundColor && kRightTabInfo[type].unitHoverBackgroundColor![unit]) {
+      return kRightTabInfo[type].unitHoverBackgroundColor![unit];
+    }
+    return kRightTabInfo[type].hoverBackgroundColor;
   }
   private getRightTabName = (type: RightSectionTypes, unit?: UnitNameType) => {
     if (!type) return "";

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -55,6 +55,8 @@ type RightTabInfo = {
     index: number;
     backgroundColor: string;
     hoverBackgroundColor: string;
+    unitBackgroundColor?: { [unit in UnitNameType ]: string };
+    unitHoverBackgroundColor?: { [unit in UnitNameType ]: string };
   }
 };
 const kRightTabInfo: RightTabInfo = {
@@ -85,12 +87,20 @@ const kRightTabInfo: RightTabInfo = {
     index: -1,
     backgroundColor: "#e6f2e4",
     hoverBackgroundColor: "#dae6d7",
+    unitBackgroundColor: {
+      Tephra: "#e6f2e4",
+      Seismic: "#cee6c9"
+    },
+    unitHoverBackgroundColor: {
+      Tephra: "#dae6d7",
+      Seismic: "#c3dabd"
+    },
   },
   deformation: {
     name: "Deformation",
     index: -1,
-    backgroundColor: "#cee6c9",
-    hoverBackgroundColor: "#c3dabd"
+    backgroundColor: "#e6f2e4",
+    hoverBackgroundColor: "#dae6d7",
   }
 };
 


### PR DESCRIPTION
Update the bottom right tab colors in the seismic unit to match the UI spec (note that this means the data tab can now have different colors depending on the unit - hence this being more than a single line change).

Test here:
http://geocode-app.concord.org/branch/tab-colors/index.html

Updated colors:
![image](https://user-images.githubusercontent.com/5126913/110565914-1bbaa080-8104-11eb-9ddc-9588099e3069.png)
