### PR TITLE
177256960 add set point tool

### DIFF
--- a/cypress/support/elements/Map.js
+++ b/cypress/support/elements/Map.js
@@ -11,9 +11,12 @@ class Map {
     getRulerButton(){
         return cy.get('[data-test=Ruler-button]');
     }
-    getLatlngButton(){
-      return cy.get('[data-test=Latlng-button]');
+    getLatlngRegionButton(){
+      return cy.get('[data-test=Latlng-region-button]');
     }
+    getLatlngPointButton(){
+        return cy.get('[data-test=Latlng-point-button]');
+      }
     getKeyButton(){
         return cy.get('[data-test=Key-button]');
     }

--- a/src/components/map/layers/latlng-point-draw-layer.tsx
+++ b/src/components/map/layers/latlng-point-draw-layer.tsx
@@ -53,6 +53,7 @@ export class LatLngPointDrawLayer extends BaseComponent<IProps, IState> {
     if (map !== null) {
       map.dragging.enable();
       map.off(MOUSE_DOWN, this.drawPoint);
+      map.off(MOUSE_UP, this.endDraw);
       L.DomUtil.removeClass(map.getContainer(), "crosshair-cursor");
     }
   }

--- a/src/components/map/layers/latlng-point-draw-layer.tsx
+++ b/src/components/map/layers/latlng-point-draw-layer.tsx
@@ -142,7 +142,7 @@ export class LatLngPointDrawLayer extends BaseComponent<IProps, IState> {
     };
 
     const pIcon = latLngIcon(
-      `<b>Corner 1</b><br/>Latitude: ${pLat.toFixed(2)} <b>W</b><br/>Longitude: ${pLng.toFixed(2)} <b>N</b>`,
+      `Latitude: ${pLat.toFixed(2)} <b>W</b><br/>Longitude: ${pLng.toFixed(2)} <b>N</b>`,
       getCorner(point), !pointSet);
 
     return (

--- a/src/components/map/layers/latlng-point-draw-layer.tsx
+++ b/src/components/map/layers/latlng-point-draw-layer.tsx
@@ -1,0 +1,154 @@
+import { inject, observer } from "mobx-react";
+import Leaflet from "leaflet";
+import * as L from "leaflet";
+import * as React from "react";
+import { BaseComponent } from "../../base";
+import { latLngIcon } from "../../icons";
+import { LayerGroup, Marker, Polyline } from "react-leaflet";
+
+const MOUSE_DOWN = "mousedown touchstart";
+const MOUSE_MOVE = "mousemove touchmove";
+const MOUSE_UP = "mouseup touchend";
+
+interface IProps {
+  map: Leaflet.Map | null;
+  pLat: number;
+  pLng: number;
+}
+
+interface IState {
+  pointSet: boolean;
+}
+
+@inject("stores")
+@observer
+export class LatLngPointDrawLayer extends BaseComponent<IProps, IState> {
+
+  constructor(props: IProps) {
+    super(props);
+    const initialState: IState = {
+      pointSet: false
+    };
+
+    this.drawPoint = this.drawPoint.bind(this);
+    this.endDraw = this.endDraw.bind(this);
+    this.setPoint = this.setPoint.bind(this);
+    this.dragPointStart = this.dragPointStart.bind(this);
+    this.dragPointEnd = this.dragPointEnd.bind(this);
+    this.state = initialState;
+  }
+
+  public componentDidMount() {
+    const { map } = this.props;
+    if (map !== null) {
+      map.dragging.disable();
+      map.on(MOUSE_DOWN, this.drawPoint);
+      map.on(MOUSE_UP, this.endDraw);
+      L.DomUtil.addClass(map.getContainer(), "crosshair-cursor");
+    }
+  }
+
+  public componentWillUnmount() {
+    const { map } = this.props;
+    if (map !== null) {
+      map.dragging.enable();
+      map.off(MOUSE_DOWN, this.drawPoint);
+      L.DomUtil.removeClass(map.getContainer(), "crosshair-cursor");
+    }
+  }
+  public drawPoint(event: Leaflet.LeafletMouseEvent) {
+    const { map } = this.props;
+    const { latLngPointLat } = this.stores.tephraSimulation;
+    if (map !== null) {
+      if (latLngPointLat === 0) {
+        map.dragging.disable();
+        this.setPoint(event);
+      }
+    }
+  }
+  public endDraw() {
+    const { map } = this.props;
+    const { pointSet } = this.state;
+    if (map !== null) {
+      // has the user entered two points?
+      if (!pointSet) {
+        // user has clicked / tapped to place point
+        map.dragging.enable();
+        map.off(MOUSE_MOVE, this.setPoint);
+        map.off(MOUSE_DOWN, this.drawPoint);
+        this.setState({ pointSet: true });
+        L.DomUtil.removeClass(map.getContainer(), "crosshair-cursor");
+      } else {
+        // user dragged the point
+        map.dragging.enable();
+        map.off(MOUSE_MOVE, this.setPoint);
+      }
+    }
+  }
+
+  public setPoint(event: Leaflet.LeafletEvent | null) {
+    const { map } = this.props;
+    if (map !== null && event) {
+      map.dragging.disable();
+      let latLng = (event as Leaflet.LeafletMouseEvent).latlng;
+      if (!latLng) latLng = event.target.getLatLng(); // for when we are dragging
+      this.stores.tephraSimulation.setLatLngPoint(latLng.lat, latLng.lng);
+    }
+  }
+
+  public dragPointStart(event: Leaflet.LeafletEvent | null) {
+    const { map } = this.props;
+    if (map !== null && event) {
+      map.dragging.disable();
+      map.on(MOUSE_MOVE, this.setPoint);
+    }
+  }
+
+  public dragPointEnd(event: Leaflet.LeafletEvent | null) {
+    const { map } = this.props;
+    if (map !== null && event) {
+      map.dragging.enable();
+      this.setPoint(event);
+    }
+  }
+
+  public render() {
+    const { map } = this.props;
+    const { pointSet } = this.state;
+    if (!map) return null;
+
+    const { pLat, pLng } = this.props;
+    const point = L.latLng(pLat, pLng);
+
+    const mapBounds = map.getBounds();
+    const labelWidth = 116;
+    const labelHeight = 56;
+
+    const getCorner = (cornerPoint: L.LatLng) => {
+      let cornerString;
+
+      const containerPoint = map.latLngToContainerPoint(cornerPoint);
+      const mapSouthContainerPoint = map.latLngToContainerPoint(L.latLng(mapBounds.getSouth(), cornerPoint.lng));
+      const mapEastContainerPoint =  map.latLngToContainerPoint(L.latLng(cornerPoint.lat, mapBounds.getEast()));
+      const willOverlapNorth = containerPoint.y < labelHeight;
+      const willOverlapSouth = containerPoint.y > mapSouthContainerPoint.y - labelHeight;
+      const willOverlapWest = containerPoint.x < labelWidth;
+      const willOverlapEast = containerPoint.x > mapEastContainerPoint.x - labelWidth;
+
+      !willOverlapNorth || willOverlapSouth ? cornerString = "bottom-" : cornerString = "top-";
+      !willOverlapEast || willOverlapWest ? cornerString += "left" : cornerString += "right";
+      return cornerString;
+    };
+
+    const pIcon = latLngIcon(
+      `<b>Corner 1</b><br/>Latitude: ${pLat.toFixed(2)} <b>W</b><br/>Longitude: ${pLng.toFixed(2)} <b>N</b>`,
+      getCorner(point), !pointSet);
+
+    return (
+      <LayerGroup map={map}>
+        {point && <Marker key={"latlngp1"} marker_index={1} position={point} icon={pIcon}
+          draggable={true} onDragStart={this.dragPointStart} onDragEnd={this.dragPointEnd} />}
+      </LayerGroup>
+    );
+  }
+}

--- a/src/components/map/layers/latlng-region-draw-layer.tsx
+++ b/src/components/map/layers/latlng-region-draw-layer.tsx
@@ -24,7 +24,7 @@ interface IState {
 
 @inject("stores")
 @observer
-export class LatLngDrawLayer extends BaseComponent<IProps, IState> {
+export class LatLngRegionDrawLayer extends BaseComponent<IProps, IState> {
 
   constructor(props: IProps) {
     super(props);
@@ -61,9 +61,9 @@ export class LatLngDrawLayer extends BaseComponent<IProps, IState> {
   }
   public drawPoints(event: Leaflet.LeafletMouseEvent) {
     const { map } = this.props;
-    const { latLngPoint1Lat } = this.stores.tephraSimulation;
+    const { latLngRegionPoint1Lat } = this.stores.tephraSimulation;
     if (map !== null) {
-      if (latLngPoint1Lat === 0) {
+      if (latLngRegionPoint1Lat === 0) {
         map.dragging.disable();
         this.setPoint1(event);
         this.setPoint2(event);

--- a/src/components/map/layers/latlng-region-draw-layer.tsx
+++ b/src/components/map/layers/latlng-region-draw-layer.tsx
@@ -56,6 +56,7 @@ export class LatLngRegionDrawLayer extends BaseComponent<IProps, IState> {
     if (map !== null) {
       map.dragging.enable();
       map.off(MOUSE_DOWN, this.drawPoints);
+      map.off(MOUSE_UP, this.endDraw);
       L.DomUtil.removeClass(map.getContainer(), "crosshair-cursor");
     }
   }

--- a/src/components/map/map-component.tsx
+++ b/src/components/map/map-component.tsx
@@ -23,7 +23,7 @@ import CompassComponent from "./map-compass";
 import { LegendComponent, LegendType } from "./map-legend";
 import { SamplesCollectionModelType, SamplesLocationModelType } from "../../stores/samples-collections-store";
 import { RiskLevels } from "../montecarlo/monte-carlo";
-import { LatLngDrawLayer } from "./layers/latlng-draw-layer";
+import { LatLngRegionDrawLayer } from "./layers/latlng-region-draw-layer";
 import { MapGPSStationsLayer } from "./map-gps-stations-layer";
 import { ColorMethod } from "../../stores/seismic-simulation-store";
 
@@ -75,7 +75,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
   private map = React.createRef<LeafletMap>();
   private crossRef = React.createRef<CrossSectionDrawLayer>();
   private tephraRef = React.createRef<MapTephraThicknessLayer>();
-  private latlngRef = React.createRef<LatLngDrawLayer>();
+  private latlngRegionRef = React.createRef<LatLngRegionDrawLayer>();
   private hoverCoords = React.createRef<L.LatLng>();
 
   constructor(props: IProps) {
@@ -180,7 +180,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
     const {
       isSelectingCrossSection,
       isSelectingRuler,
-      isSelectingLatlng,
+      isSelectingSetRegion,
     } = this.stores.tephraSimulation;
 
     const cityItems = cities.map( (city: CityType) => {
@@ -223,7 +223,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
     const center: L.LatLngTuple = [centerLat, centerLng];
 
     const { crossPoint1Lat, crossPoint1Lng, crossPoint2Lat, crossPoint2Lng,
-            latLngPoint1Lat, latLngPoint1Lng, latLngPoint2Lat, latLngPoint2Lng } =
+            latLngRegionPoint1Lat, latLngRegionPoint1Lng, latLngRegionPoint2Lat, latLngRegionPoint2Lng } =
       this.stores.tephraSimulation;
     const volcanoPos = L.latLng(centerLat, centerLng);
     const corner1 = L.latLng(topLeftLat, topLeftLng);
@@ -301,14 +301,14 @@ export class MapComponent extends BaseComponent<IProps, IState>{
                 {pinItems}
                 {/* {riskItems} */}
                 {sampleLocations}
-                {isSelectingLatlng && <LatLngDrawLayer
-                  key="lat-lng-layer"
-                  ref={this.latlngRef}
+                {isSelectingSetRegion && <LatLngRegionDrawLayer
+                  key="lat-lng-region-layer"
+                  ref={this.latlngRegionRef}
                   map={this.state.mapLeafletRef}
-                  p1Lat={latLngPoint1Lat}
-                  p2Lat={latLngPoint2Lat}
-                  p1Lng={latLngPoint1Lng}
-                  p2Lng={latLngPoint2Lng}
+                  p1Lat={latLngRegionPoint1Lat}
+                  p2Lat={latLngRegionPoint2Lat}
+                  p1Lng={latLngRegionPoint1Lng}
+                  p2Lng={latLngRegionPoint2Lng}
                 /> }
                 {isSelectingCrossSection && <CrossSectionDrawLayer
                   ref={this.crossRef}
@@ -337,14 +337,14 @@ export class MapComponent extends BaseComponent<IProps, IState>{
                 mapScale={this.getMapScale()}
                 getPointFromLatLng={this.getScreenPointFromLatLng}
               />,
-              (isSelectingLatlng && <LatLngDrawLayer
-                key="lat-lng-layer"
-                ref={this.latlngRef}
+              (isSelectingSetRegion && <LatLngRegionDrawLayer
+                key="lat-lng-region-layer"
+                ref={this.latlngRegionRef}
                 map={this.state.mapLeafletRef}
-                p1Lat={latLngPoint1Lat}
-                p2Lat={latLngPoint2Lat}
-                p1Lng={latLngPoint1Lng}
-                p2Lng={latLngPoint2Lng}
+                p1Lat={latLngRegionPoint1Lat}
+                p2Lat={latLngRegionPoint2Lat}
+                p1Lng={latLngRegionPoint1Lng}
+                p2Lng={latLngRegionPoint2Lng}
               />)
             ]
           }
@@ -352,9 +352,9 @@ export class MapComponent extends BaseComponent<IProps, IState>{
         <OverlayControls
           showRuler={isSelectingRuler}
           onRulerClick={this.stores.tephraSimulation.rulerClick}
-          onLatLngClick={this.stores.tephraSimulation.latlngClick}
+          onSetRegionClick={this.stores.tephraSimulation.setRegionClick}
           isSelectingCrossSection={isSelectingCrossSection}
-          isSelectingLatLng={isSelectingLatlng}
+          isSelectingSetRegion={isSelectingSetRegion}
           showCrossSection={hasErupted && showCrossSection && panelType === RightSectionTypes.CROSS_SECTION}
           onCrossSectionClick={this.stores.tephraSimulation.crossSectionClick}
           onReCenterClick={this.onRecenterClick}
@@ -404,7 +404,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
   }
   private onMapClick = (e: any) => {
     const { tephraSimulation } = this.stores;
-    if (tephraSimulation.isSelectingLatlng) {
+    if (tephraSimulation.isSelectingSetRegion) {
       tephraSimulation.setPoint1Pos(e.latlng.lat, e.latlng.lng);
     } else return;
   }

--- a/src/components/map/map-component.tsx
+++ b/src/components/map/map-component.tsx
@@ -24,6 +24,7 @@ import { LegendComponent, LegendType } from "./map-legend";
 import { SamplesCollectionModelType, SamplesLocationModelType } from "../../stores/samples-collections-store";
 import { RiskLevels } from "../montecarlo/monte-carlo";
 import { LatLngRegionDrawLayer } from "./layers/latlng-region-draw-layer";
+import { LatLngPointDrawLayer } from "./layers/latlng-point-draw-layer";
 import { MapGPSStationsLayer } from "./map-gps-stations-layer";
 import { ColorMethod } from "../../stores/seismic-simulation-store";
 
@@ -75,6 +76,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
   private map = React.createRef<LeafletMap>();
   private crossRef = React.createRef<CrossSectionDrawLayer>();
   private tephraRef = React.createRef<MapTephraThicknessLayer>();
+  private latlngPointRef = React.createRef<LatLngPointDrawLayer>();
   private latlngRegionRef = React.createRef<LatLngRegionDrawLayer>();
   private hoverCoords = React.createRef<L.LatLng>();
 
@@ -180,6 +182,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
     const {
       isSelectingCrossSection,
       isSelectingRuler,
+      isSelectingSetPoint,
       isSelectingSetRegion,
     } = this.stores.tephraSimulation;
 
@@ -222,7 +225,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
 
     const center: L.LatLngTuple = [centerLat, centerLng];
 
-    const { crossPoint1Lat, crossPoint1Lng, crossPoint2Lat, crossPoint2Lng,
+    const { crossPoint1Lat, crossPoint1Lng, crossPoint2Lat, crossPoint2Lng, latLngPointLat, latLngPointLng,
             latLngRegionPoint1Lat, latLngRegionPoint1Lng, latLngRegionPoint2Lat, latLngRegionPoint2Lng } =
       this.stores.tephraSimulation;
     const volcanoPos = L.latLng(centerLat, centerLng);
@@ -301,6 +304,13 @@ export class MapComponent extends BaseComponent<IProps, IState>{
                 {pinItems}
                 {/* {riskItems} */}
                 {sampleLocations}
+                {isSelectingSetPoint && <LatLngPointDrawLayer
+                  key="lat-lng-point-layer"
+                  ref={this.latlngPointRef}
+                  map={this.state.mapLeafletRef}
+                  pLat={latLngPointLat}
+                  pLng={latLngPointLng}
+                /> }
                 {isSelectingSetRegion && <LatLngRegionDrawLayer
                   key="lat-lng-region-layer"
                   ref={this.latlngRegionRef}
@@ -337,6 +347,13 @@ export class MapComponent extends BaseComponent<IProps, IState>{
                 mapScale={this.getMapScale()}
                 getPointFromLatLng={this.getScreenPointFromLatLng}
               />,
+              (isSelectingSetPoint && <LatLngPointDrawLayer
+                key="lat-lng-point-layer"
+                ref={this.latlngPointRef}
+                map={this.state.mapLeafletRef}
+                pLat={latLngPointLat}
+                pLng={latLngPointLng}
+              />),
               (isSelectingSetRegion && <LatLngRegionDrawLayer
                 key="lat-lng-region-layer"
                 ref={this.latlngRegionRef}
@@ -352,8 +369,10 @@ export class MapComponent extends BaseComponent<IProps, IState>{
         <OverlayControls
           showRuler={isSelectingRuler}
           onRulerClick={this.stores.tephraSimulation.rulerClick}
+          onSetPointClick={this.stores.tephraSimulation.setPointClick}
           onSetRegionClick={this.stores.tephraSimulation.setRegionClick}
           isSelectingCrossSection={isSelectingCrossSection}
+          isSelectingSetPoint={isSelectingSetPoint}
           isSelectingSetRegion={isSelectingSetRegion}
           showCrossSection={hasErupted && showCrossSection && panelType === RightSectionTypes.CROSS_SECTION}
           onCrossSectionClick={this.stores.tephraSimulation.crossSectionClick}

--- a/src/components/overlay-controls.tsx
+++ b/src/components/overlay-controls.tsx
@@ -9,9 +9,9 @@ import { BaseComponent } from "./base";
 interface IProps {
     showRuler: boolean;
     onRulerClick: () => void;
-    onLatLngClick: () => void;
+    onSetRegionClick: () => void;
     isSelectingCrossSection: boolean;
-    isSelectingLatLng: boolean;
+    isSelectingSetRegion: boolean;
     showCrossSection: boolean;
     onCrossSectionClick: () => void;
     onReCenterClick: () => void;
@@ -30,16 +30,16 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
 
         const { showRuler,
             onRulerClick,
-            onLatLngClick,
+            onSetRegionClick,
             isSelectingCrossSection,
-            isSelectingLatLng,
+            isSelectingSetRegion,
             showCrossSection,
             onCrossSectionClick,
             onReCenterClick} = this.props;
         const { hasErupted } = this.stores.tephraSimulation;
 
         const rulerColor = showRuler ? kRightTabInfo[RightSectionTypes.CONDITIONS].hoverBackgroundColor : "white";
-        const selectingLatLngColor = isSelectingLatLng
+        const selectingLatLngColor = isSelectingSetRegion
                                ? kRightTabInfo[RightSectionTypes.CROSS_SECTION].hoverBackgroundColor
                                : "white";
         const selectingColor = isSelectingCrossSection
@@ -73,9 +73,9 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
                         dataTest={"Ruler-button"}
                     />}
                     {isSeismicUnit && <IconButton
-                        onClick={onLatLngClick}
+                        onClick={onSetRegionClick}
                         disabled={false}
-                        label={"Lat-Long"}
+                        label={"Set Region"}
                         backgroundColor={selectingLatLngColor}
                         hoverColor={kRightTabInfo[RightSectionTypes.CONDITIONS].hoverBackgroundColor}
                         activeColor={kRightTabInfo[RightSectionTypes.CONDITIONS].backgroundColor}

--- a/src/components/overlay-controls.tsx
+++ b/src/components/overlay-controls.tsx
@@ -9,8 +9,10 @@ import { BaseComponent } from "./base";
 interface IProps {
     showRuler: boolean;
     onRulerClick: () => void;
+    onSetPointClick: () => void;
     onSetRegionClick: () => void;
     isSelectingCrossSection: boolean;
+    isSelectingSetPoint: boolean;
     isSelectingSetRegion: boolean;
     showCrossSection: boolean;
     onCrossSectionClick: () => void;
@@ -30,8 +32,10 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
 
         const { showRuler,
             onRulerClick,
+            onSetPointClick,
             onSetRegionClick,
             isSelectingCrossSection,
+            isSelectingSetPoint,
             isSelectingSetRegion,
             showCrossSection,
             onCrossSectionClick,
@@ -39,7 +43,10 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
         const { hasErupted } = this.stores.tephraSimulation;
 
         const rulerColor = showRuler ? kRightTabInfo[RightSectionTypes.CONDITIONS].hoverBackgroundColor : "white";
-        const selectingLatLngColor = isSelectingSetRegion
+        const selectingLatLngPtColor = isSelectingSetPoint
+                               ? kRightTabInfo[RightSectionTypes.CROSS_SECTION].hoverBackgroundColor
+                               : "white";
+        const selectingLatLngRegionColor = isSelectingSetRegion
                                ? kRightTabInfo[RightSectionTypes.CROSS_SECTION].hoverBackgroundColor
                                : "white";
         const selectingColor = isSelectingCrossSection
@@ -73,16 +80,28 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
                         dataTest={"Ruler-button"}
                     />}
                     {isSeismicUnit && <IconButton
-                        onClick={onSetRegionClick}
+                        onClick={onSetPointClick}
                         disabled={false}
-                        label={"Set Region"}
-                        backgroundColor={selectingLatLngColor}
+                        label={"Set Point"}
+                        backgroundColor={selectingLatLngPtColor}
                         hoverColor={kRightTabInfo[RightSectionTypes.CONDITIONS].hoverBackgroundColor}
                         activeColor={kRightTabInfo[RightSectionTypes.CONDITIONS].backgroundColor}
                         fill={"black"}
                         width={26}
                         height={26}
-                        dataTest={"Latlng-button"}
+                        dataTest={"Latlng-point-button"}
+                    />}
+                    {isSeismicUnit && <IconButton
+                        onClick={onSetRegionClick}
+                        disabled={false}
+                        label={"Set Region"}
+                        backgroundColor={selectingLatLngRegionColor}
+                        hoverColor={kRightTabInfo[RightSectionTypes.CONDITIONS].hoverBackgroundColor}
+                        activeColor={kRightTabInfo[RightSectionTypes.CONDITIONS].backgroundColor}
+                        fill={"black"}
+                        width={26}
+                        height={26}
+                        dataTest={"Latlng-region-button"}
                     />}
                 </div>
                 <div className="controls bottom right">

--- a/src/components/overlay-controls.tsx
+++ b/src/components/overlay-controls.tsx
@@ -26,6 +26,7 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
         const { name: unitName } = this.stores.unit;
 
         const isTephraUnit = unitName === "Tephra";
+        const isSeismicUnit = unitName === "Seismic";
 
         const { showRuler,
             onRulerClick,
@@ -71,7 +72,7 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
                         height={26}
                         dataTest={"Ruler-button"}
                     />}
-                    <IconButton
+                    {isSeismicUnit && <IconButton
                         onClick={onLatLngClick}
                         disabled={false}
                         label={"Lat-Long"}
@@ -82,7 +83,7 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
                         width={26}
                         height={26}
                         dataTest={"Latlng-button"}
-                    />
+                    />}
                 </div>
                 <div className="controls bottom right">
                     {(showCrossSection && hasErupted) && <IconButton

--- a/src/stores/tephra-simulation-store.test.ts
+++ b/src/stores/tephra-simulation-store.test.ts
@@ -66,17 +66,17 @@ describe("simulation-store", () => {
       simulation.rulerClick();
       expect(simulation.isSelectingRuler).toBe(true);
       expect(simulation.isSelectingCrossSection).toBe(false);
-      expect(simulation.isSelectingLatlng).toBe(false);
+      expect(simulation.isSelectingSetRegion).toBe(false);
 
       simulation.crossSectionClick();
       expect(simulation.isSelectingRuler).toBe(false);
       expect(simulation.isSelectingCrossSection).toBe(true);
-      expect(simulation.isSelectingLatlng).toBe(false);
+      expect(simulation.isSelectingSetRegion).toBe(false);
 
-      simulation.latlngClick();
+      simulation.setRegionClick();
       expect(simulation.isSelectingRuler).toBe(false);
       expect(simulation.isSelectingCrossSection).toBe(false);
-      expect(simulation.isSelectingLatlng).toBe(true);
+      expect(simulation.isSelectingSetRegion).toBe(true);
     });
   });
 });

--- a/src/stores/tephra-simulation-store.test.ts
+++ b/src/stores/tephra-simulation-store.test.ts
@@ -66,16 +66,25 @@ describe("simulation-store", () => {
       simulation.rulerClick();
       expect(simulation.isSelectingRuler).toBe(true);
       expect(simulation.isSelectingCrossSection).toBe(false);
+      expect(simulation.isSelectingSetPoint).toBe(false);
       expect(simulation.isSelectingSetRegion).toBe(false);
 
       simulation.crossSectionClick();
       expect(simulation.isSelectingRuler).toBe(false);
       expect(simulation.isSelectingCrossSection).toBe(true);
+      expect(simulation.isSelectingSetPoint).toBe(false);
       expect(simulation.isSelectingSetRegion).toBe(false);
+
+      simulation.setPointClick();
+      expect(simulation.isSelectingRuler).toBe(false);
+      expect(simulation.isSelectingCrossSection).toBe(false);
+      expect(simulation.isSelectingSetRegion).toBe(false);
+      expect(simulation.isSelectingSetPoint).toBe(true);
 
       simulation.setRegionClick();
       expect(simulation.isSelectingRuler).toBe(false);
       expect(simulation.isSelectingCrossSection).toBe(false);
+      expect(simulation.isSelectingSetPoint).toBe(false);
       expect(simulation.isSelectingSetRegion).toBe(true);
     });
   });

--- a/src/stores/tephra-simulation-store.ts
+++ b/src/stores/tephra-simulation-store.ts
@@ -116,11 +116,14 @@ export const TephraSimulationStore = types
     hasErupted: false,
     isSelectingRuler: false,
     isSelectingCrossSection: false,
+    isSelectingSetPoint: false,
     isSelectingSetRegion: false,
     latLngRegionPoint1Lat: 0,
     latLngRegionPoint1Lng: 0,
     latLngRegionPoint2Lat: 0,
     latLngRegionPoint2Lng: 0,
+    latLngPointLat: 0,
+    latLngPointLng: 0,
     // authoring props
     requireEruption: true,
     requirePainting: true,
@@ -159,9 +162,22 @@ export const TephraSimulationStore = types
       self.isSelectingRuler = !self.isSelectingRuler;
       self.isSelectingCrossSection = false;
       self.isSelectingSetRegion = false;
+      self.isSelectingSetPoint = false;
+    },
+    setPointClick() {
+      self.isSelectingSetPoint = !self.isSelectingSetPoint;
+      self.isSelectingSetRegion = false;
+      self.isSelectingRuler = false;
+      self.isSelectingCrossSection = false;
+      if (!self.isSelectingSetPoint) {
+        // clear original point
+        self.latLngPointLat = 0;
+        self.latLngPointLng = 0;
+      }
     },
     setRegionClick() {
       self.isSelectingSetRegion = !self.isSelectingSetRegion;
+      self.isSelectingSetPoint = false;
       self.isSelectingRuler = false;
       self.isSelectingCrossSection = false;
       if (!self.isSelectingSetRegion) {
@@ -176,6 +192,7 @@ export const TephraSimulationStore = types
       self.isSelectingCrossSection = !self.isSelectingCrossSection;
       self.isSelectingRuler = false;
       self.isSelectingSetRegion = false;
+      self.isSelectingSetPoint = false;
     },
     setIsSelectingRuler(val: boolean) {
       self.isSelectingRuler = val;
@@ -189,6 +206,10 @@ export const TephraSimulationStore = types
       self.viewportZoom = zoom;
       self.viewportCenterLat = viewportCenterLat;
       self.viewportCenterLng = viewportCenterLng;
+    },
+    setLatLngPoint(lat: number, lng: number) {
+      self.latLngPointLat = lat;
+      self.latLngPointLng = lng;
     },
     setLatLngP1(lat: number, lng: number) {
       self.latLngRegionPoint1Lat = lat;

--- a/src/stores/tephra-simulation-store.ts
+++ b/src/stores/tephra-simulation-store.ts
@@ -116,11 +116,11 @@ export const TephraSimulationStore = types
     hasErupted: false,
     isSelectingRuler: false,
     isSelectingCrossSection: false,
-    isSelectingLatlng: false,
-    latLngPoint1Lat: 0,
-    latLngPoint1Lng: 0,
-    latLngPoint2Lat: 0,
-    latLngPoint2Lng: 0,
+    isSelectingSetRegion: false,
+    latLngRegionPoint1Lat: 0,
+    latLngRegionPoint1Lng: 0,
+    latLngRegionPoint2Lat: 0,
+    latLngRegionPoint2Lng: 0,
     // authoring props
     requireEruption: true,
     requirePainting: true,
@@ -158,24 +158,24 @@ export const TephraSimulationStore = types
     rulerClick() {
       self.isSelectingRuler = !self.isSelectingRuler;
       self.isSelectingCrossSection = false;
-      self.isSelectingLatlng = false;
+      self.isSelectingSetRegion = false;
     },
-    latlngClick() {
-      self.isSelectingLatlng = !self.isSelectingLatlng;
+    setRegionClick() {
+      self.isSelectingSetRegion = !self.isSelectingSetRegion;
       self.isSelectingRuler = false;
       self.isSelectingCrossSection = false;
-      if (!self.isSelectingLatlng) {
+      if (!self.isSelectingSetRegion) {
         // clear original points
-        self.latLngPoint1Lat = 0;
-        self.latLngPoint1Lng = 0;
-        self.latLngPoint2Lat = 0;
-        self.latLngPoint2Lng = 0;
+        self.latLngRegionPoint1Lat = 0;
+        self.latLngRegionPoint1Lng = 0;
+        self.latLngRegionPoint2Lat = 0;
+        self.latLngRegionPoint2Lng = 0;
       }
     },
     crossSectionClick() {
       self.isSelectingCrossSection = !self.isSelectingCrossSection;
       self.isSelectingRuler = false;
-      self.isSelectingLatlng = false;
+      self.isSelectingSetRegion = false;
     },
     setIsSelectingRuler(val: boolean) {
       self.isSelectingRuler = val;
@@ -191,12 +191,12 @@ export const TephraSimulationStore = types
       self.viewportCenterLng = viewportCenterLng;
     },
     setLatLngP1(lat: number, lng: number) {
-      self.latLngPoint1Lat = lat;
-      self.latLngPoint1Lng = lng;
+      self.latLngRegionPoint1Lat = lat;
+      self.latLngRegionPoint1Lng = lng;
     },
     setLatLngP2(lat: number, lng: number) {
-      self.latLngPoint2Lat = lat;
-      self.latLngPoint2Lng = lng;
+      self.latLngRegionPoint2Lat = lat;
+      self.latLngRegionPoint2Lng = lng;
     },
     reset() {
       self.hasErupted = false;

--- a/src/stores/tephra-simulation-store.ts
+++ b/src/stores/tephra-simulation-store.ts
@@ -174,6 +174,11 @@ export const TephraSimulationStore = types
         self.latLngPointLat = 0;
         self.latLngPointLng = 0;
       }
+      // clear points from set region
+      self.latLngRegionPoint1Lat = 0;
+      self.latLngRegionPoint1Lng = 0;
+      self.latLngRegionPoint2Lat = 0;
+      self.latLngRegionPoint2Lng = 0;
     },
     setRegionClick() {
       self.isSelectingSetRegion = !self.isSelectingSetRegion;
@@ -187,6 +192,9 @@ export const TephraSimulationStore = types
         self.latLngRegionPoint2Lat = 0;
         self.latLngRegionPoint2Lng = 0;
       }
+      // clear point from set point
+      self.latLngPointLat = 0;
+      self.latLngPointLng = 0;
     },
     crossSectionClick() {
       self.isSelectingCrossSection = !self.isSelectingCrossSection;


### PR DESCRIPTION
This PR adds a set point tool to the seismic model.  Changes includes:
- rename lat-long tool to Set Region
- add Set Point button
- when in set point mode a single lat/long point can be added and moved around the map
- Set Point and Set Region only appear in Seismic unit
- points or region are cleared when the mode is exited

Can test here:
http://geocode-app.concord.org/branch/set-point/index.html

![set-point](https://user-images.githubusercontent.com/5126913/110706663-12394300-81ad-11eb-94cd-6762a1202260.gif)
