### PR TITLE
Fix GPS position over time data bug

### DIFF
--- a/src/stores/data-sets.ts
+++ b/src/stores/data-sets.ts
@@ -93,7 +93,8 @@ export const Datasets = {
   },
 
   getGPSPositionTimeData(name: string, timeRange?: TimeRange) {
-    let dataSet = (PositionTimeDataSets as any)[name] as Dataset;
+    const storeDataSet = (PositionTimeDataSets as any)[name] as Dataset;
+    let dataSet = [...storeDataSet];
     if (timeRange) {
       if (timeRange.from) {
         dataSet = dataSet.filter(d => (d.Date as Date) >= timeRange.from!);

--- a/src/stores/data-sets.ts
+++ b/src/stores/data-sets.ts
@@ -1,7 +1,6 @@
 // @ts-ignore
 import * as RawWindDataSet from "../assets/data/winds_Cerro_Negro.csv";
 import RawPositionTimeData, { filterStationByPositionData } from "../assets/data/seismic/position-time-data";
-import { cloneDeep } from "lodash";
 
 interface DatasetCase {[key: string]: number | Date; }
 export type Dataset = DatasetCase[];
@@ -94,24 +93,24 @@ export const Datasets = {
   },
 
   getGPSPositionTimeData(name: string, timeRange?: TimeRange) {
-    const storeDataSet = (PositionTimeDataSets as any)[name] as Dataset;
-    let dataSet = cloneDeep(storeDataSet);
+    const dataSet = (PositionTimeDataSets as any)[name] as Dataset;
+    let filteredDataSet = [...dataSet];
     if (timeRange) {
       if (timeRange.from) {
-        dataSet = dataSet.filter(d => (d.Date as Date) >= timeRange.from!);
+        filteredDataSet = filteredDataSet.filter(d => (d.Date as Date) >= timeRange.from!);
       }
       if (timeRange.to) {
-        dataSet = dataSet.filter(d => (d.Date as Date) <= timeRange.to!);
+        filteredDataSet = filteredDataSet.filter(d => (d.Date as Date) <= timeRange.to!);
       }
       if (timeRange.duration) {
         if (timeRange.to) {
-          dataSet = dataSet.splice(dataSet.length - timeRange.duration, timeRange.duration);
+          filteredDataSet = filteredDataSet.splice(dataSet.length - timeRange.duration, timeRange.duration);
         } else {
-          dataSet = dataSet.splice(0, timeRange.duration);
+          filteredDataSet = filteredDataSet.splice(0, timeRange.duration);
         }
       }
     }
-    return dataSet;
+    return filteredDataSet;
   },
 
 };

--- a/src/stores/data-sets.ts
+++ b/src/stores/data-sets.ts
@@ -1,6 +1,7 @@
 // @ts-ignore
 import * as RawWindDataSet from "../assets/data/winds_Cerro_Negro.csv";
 import RawPositionTimeData, { filterStationByPositionData } from "../assets/data/seismic/position-time-data";
+import { cloneDeep } from "lodash";
 
 interface DatasetCase {[key: string]: number | Date; }
 export type Dataset = DatasetCase[];
@@ -94,7 +95,7 @@ export const Datasets = {
 
   getGPSPositionTimeData(name: string, timeRange?: TimeRange) {
     const storeDataSet = (PositionTimeDataSets as any)[name] as Dataset;
-    let dataSet = [...storeDataSet];
+    let dataSet = cloneDeep(storeDataSet);
     if (timeRange) {
       if (timeRange.from) {
         dataSet = dataSet.filter(d => (d.Date as Date) >= timeRange.from!);


### PR DESCRIPTION
This PR fixes a bug that caused the GPS position over time graph data to change each time we ran the program.  This was caused by a ref to the actual dataset that caused the underlying data to change when we filtered out the ranged data for display in the graph.  A deeper copy of the data fixes the bug.  This took me a while to find, however.  At the time, I was reworking the graph point color ranges so I assumed this was a simple display bug that I had introduced with that work.  I finally went to production and discovered that the bug had, in fact, been present for some time.

Test here:
http://geocode-app.concord.org/branch/gps-block-data-bug/index.html

Previous behavior (the bug):
![gps-location-over-time](https://user-images.githubusercontent.com/5126913/111502675-4e1b5d80-8703-11eb-8ce1-fef692d56c3b.gif)

New behavior (the fix):
![gps-location-over-time-fix](https://user-images.githubusercontent.com/5126913/111502707-54a9d500-8703-11eb-974b-1e38056562cf.gif)
