### PR TITLE
Update map legends to match UI spec

### DIFF
--- a/src/components/buttons/icon-button.tsx
+++ b/src/components/buttons/icon-button.tsx
@@ -29,6 +29,7 @@ const IconButtonContainer = styled.div`
     background-color: ${(p: IconButtonContainerProps) => p.activeColor};
   }
   font-size: ${(p: IconButtonContainerProps) => p.fontSize || "16px"};
+  cursor: pointer;
 `;
 
 const IconButtonText = styled.div`

--- a/src/components/map/map-gps-legend.tsx
+++ b/src/components/map/map-gps-legend.tsx
@@ -14,9 +14,10 @@ const LegendContainer = styled.div`
 `;
 
 const LegendTitleText = styled.div`
-  margin: 5px 11px 2px 11px;
+  margin: 5px 11px 2px 0;
   color: #434343;
   font-size: 14px;
+  font-weight: normal;
   width: 105px;
   height: 20px;
   box-sizing: border-box;
@@ -27,21 +28,31 @@ export const GPSContainer = styled.div`
   display: flex;
   justify-content: flex-start;
   align-items: flex-start;
-  width: 97px;
+  width: 108px;
   margin-top: 8px;
 `;
 
 export const GPSLabel = styled.div`
   color: #434343;
   font-size: 12px;
+  font-weight: normal;
   flex: 1;
+  margin-left: 7px;
+  text-indent: -7px;
+`;
+
+export const GPSCircleContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 26px;
 `;
 
 export interface GPSCircleProps {
-    radius: number;
-    fill: string;
-    strokeWeight: number;
-    strokeColor: string;
+  radius: number;
+  fill: string;
+  strokeWeight: number;
+  strokeColor: string;
 }
 export const GPSCircle = styled.div`
   border-radius: 50%;
@@ -56,58 +67,63 @@ export const GPSCircle = styled.div`
 `;
 
 interface IProps {
-    onClick: any;
+  onClick: any;
 }
 
 interface IState {}
 
 export default class GPSLegendComponent extends PureComponent<IProps, IState> {
-    public static defaultProps = {
-        onClick: undefined,
-    };
+  public static defaultProps = {
+    onClick: undefined,
+  };
 
-    public render() {
-        const { onClick } = this.props;
-
-        return(
-            <LegendContainer>
-                <LegendTitleText>GPS Stations</LegendTitleText>
-                <AbsoluteIcon
-                    width={12}
-                    height={12}
-                    fill={"#b7dcad"}
-                    onClick={onClick}
-                >
-                    <CloseIcon />
-                </AbsoluteIcon>
-                <GPSContainer>
-                    <GPSCircle
-                        radius={7}
-                        fill={"#98E643"}
-                        strokeColor={"#9c9c9c"}
-                        strokeWeight={2}
-                    />
-                    <GPSLabel>GPS station without past position data</GPSLabel>
-                </GPSContainer>
-                <GPSContainer>
-                    <GPSCircle
-                        radius={7}
-                        fill={"#37cfff"}
-                        strokeColor={"#9c9c9c"}
-                        strokeWeight={2}
-                    />
-                    <GPSLabel>GPS station with past position data</GPSLabel>
-                </GPSContainer>
-                <GPSContainer>
-                    <GPSCircle
-                        radius={9}
-                        fill={"#DDEDFF"}
-                        strokeColor={"#434343"}
-                        strokeWeight={3}
-                    />
-                    <GPSLabel>Selected GPS station</GPSLabel>
-                </GPSContainer>
-            </LegendContainer>
-        );
-    }
+  public render() {
+    const { onClick } = this.props;
+    return (
+      <LegendContainer>
+        <LegendTitleText>GPS Stations</LegendTitleText>
+        <AbsoluteIcon
+          width={28}
+          height={28}
+          fill={"#b7dcad"}
+          onClick={onClick}
+        >
+          <CloseIcon width={12} height={12} />
+        </AbsoluteIcon>
+        <GPSContainer>
+        <GPSCircleContainer>
+          <GPSCircle
+            radius={7}
+            fill={"#98E643"}
+            strokeColor={"#9c9c9c"}
+            strokeWeight={2}
+          />
+        </GPSCircleContainer>
+        <GPSLabel>- GPS station <span style={{fontWeight: "bold"}}>without</span> past position data</GPSLabel>
+        </GPSContainer>
+        <GPSContainer>
+          <GPSCircleContainer>
+          <GPSCircle
+            radius={7}
+            fill={"#37cfff"}
+            strokeColor={"#9c9c9c"}
+            strokeWeight={2}
+          />
+          </GPSCircleContainer>
+          <GPSLabel>- GPS station <span style={{fontWeight: "bold"}}>with</span> past position data</GPSLabel>
+        </GPSContainer>
+        <GPSContainer>
+          <GPSCircleContainer>
+            <GPSCircle
+              radius={9}
+              fill={"#DDEDFF"}
+              strokeColor={"#434343"}
+              strokeWeight={3}
+            />
+          </GPSCircleContainer>
+          <GPSLabel>- Selected GPS station</GPSLabel>
+        </GPSContainer>
+      </LegendContainer>
+    );
+  }
 }

--- a/src/components/map/map-key-button.tsx
+++ b/src/components/map/map-key-button.tsx
@@ -25,6 +25,7 @@ const KeyButtonContainer = styled.div`
   &:active {
     background-color: #e6f2e4;
   }
+  cursor: pointer;
 `;
 
 const KeyButtonText = styled.div`

--- a/src/components/map/map-legend.tsx
+++ b/src/components/map/map-legend.tsx
@@ -75,18 +75,16 @@ export class LegendComponent extends BaseComponent<IProps, IState> {
                     <GPSLegendComponent onClick={onClick} />;
     return (
       <LegendContainer data-test="key-container">
-        {
-          legend
-        }
+        { legend }
         {
           <IconButton
             onClick={this.onLegendModeClick}
             disabled={false}
             label={`Show ${secondaryPanel[currentLegendType]}`}
-            borderColor={"#ADD1A2"}
-            hoverColor={"#ADD1A2"}
-            activeColor={"#B7DCAD"}
-            fontSize={"13px"}
+            borderColor={"#cee6c9"}
+            hoverColor={"#cee6c9"}
+            activeColor={"#e6f2e4"}
+            fontSize={"14px"}
             fill={"black"}
             width={26}
             height={26}

--- a/src/components/map/map-risk-legend.tsx
+++ b/src/components/map/map-risk-legend.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 import { PureComponent } from "react";
 import styled from "styled-components";
-import { Icon } from "../icon";
 import CloseIcon from "../../assets/map-icons/close.svg";
 import { isNumber } from "util";
 import { RiskLevels } from "../montecarlo/monte-carlo";
+import { AbsoluteIcon } from "./map-tephra-legend";
 
 const LegendContainer = styled.div`
   display: flex;
@@ -19,32 +19,23 @@ const LegendTitleText = styled.div`
   margin: 5px 11px 2px 11px;
   color: #434343;
   font-size: 14px;
+  font-weight: normal;
   width: 105px;
   height: 20px;
   box-sizing: border-box;
   text-align: center;
 `;
+
 const LegendTitleSubText = styled.div`
-  margin: 2px 11px 2px 11px;
+  margin: 2px 11px 5px 11px;
   color: #434343;
   font-size: 11px;
+  font-weight: normal;
   width: 120px;
   height: 30px;
   box-sizing: border-box;
   text-align: center;
   font-style: italic;
-`;
-
-const AbsoluteIcon = styled(Icon)`
-  position: absolute;
-  top: 2px;
-  right: 6px;
-  &:hover {
-    fill: #75cd75;
-  }
-  &:active {
-    fill: #e6f2e4;
-  }
 `;
 
 const RiskContainer = styled.div`
@@ -53,7 +44,7 @@ const RiskContainer = styled.div`
   align-items: center;
   width: 140px;
   height: 34px;
-  margin-top: 5px;
+  margin-bottom: 5px;
 `;
 
 interface RiskDiamondProps {
@@ -84,6 +75,8 @@ export const RiskDiamondText = styled.div`
 const RiskLabel = styled.div`
   color: #434343;
   font-size: 12px;
+  font-weight: normal;
+  margin-left: -3px;
 `;
 
 interface IProps {
@@ -104,12 +97,12 @@ export default class RiskLegendComponent extends PureComponent<IProps, IState> {
         <LegendTitleText>Risk Level</LegendTitleText>
         <LegendTitleSubText>Determined by percents exceeding threshold</LegendTitleSubText>
         <AbsoluteIcon
-          width={12}
-          height={12}
+          width={28}
+          height={28}
           fill={"#b7dcad"}
           onClick={onClick}
         >
-          <CloseIcon />
+          <CloseIcon width={12} height={12} />
         </AbsoluteIcon>
         {RiskLevels.map((riskLevel, index) => {
             return (
@@ -120,8 +113,8 @@ export default class RiskLegendComponent extends PureComponent<IProps, IState> {
                   </RiskDiamondText>
                 </RiskDiamond>
                 { isNumber(riskLevel.max) && isNumber(riskLevel.min)
-                  ? <RiskLabel>{`${riskLevel.type} (${riskLevel.min}-${riskLevel.max}%)`}</RiskLabel>
-                  : <RiskLabel>{riskLevel.type}</RiskLabel>
+                  ? <RiskLabel>{`- ${riskLevel.type} (${riskLevel.min}-${riskLevel.max}%)`}</RiskLabel>
+                  : <RiskLabel>{`- ${riskLevel.type}`}</RiskLabel>
                 }
               </RiskContainer>
             );
@@ -129,5 +122,4 @@ export default class RiskLegendComponent extends PureComponent<IProps, IState> {
       </LegendContainer>
     );
   }
-
 }

--- a/src/components/map/map-strain-legend.tsx
+++ b/src/components/map/map-strain-legend.tsx
@@ -1,8 +1,8 @@
 import * as React from "react";
 import { PureComponent } from "react";
+import styled from "styled-components";
 import CloseIcon from "../../assets/map-icons/close.svg";
-import { LegendContainer, LegendTitleText, AbsoluteIcon,
-  TephraContainer, TephraBox, TephraLabel } from "./map-tephra-legend";
+import { LegendContainer, AbsoluteIcon, TephraContainer, TephraBox, TephraLabel } from "./map-tephra-legend";
 import { ColorMethod } from "../../stores/seismic-simulation-store";
 
 // actual data ranges from 0 to 127000, but with only 4 values above 160
@@ -13,6 +13,17 @@ const MIN_LOG_STRAIN = Math.log10(0.00001);
 const MAX_LOG_STRAIN = Math.log10(1000);
 
 const buckets = 7;
+
+export const LegendTitleText = styled.div`
+  margin: 5px 11px 2px 5px;
+  color: #434343;
+  font-size: 14px;
+  font-weight: normal;
+  width: 80px;
+  height: 34px;
+  box-sizing: border-box;
+  text-align: center;
+`;
 
 export interface StrainRange {
   color: string;
@@ -93,27 +104,25 @@ export default class StrainLegendComponent extends PureComponent<IProps, IState>
       <LegendContainer>
         <LegendTitleText>Strain rate{isLog ? " (log)" : ""}</LegendTitleText>
         <AbsoluteIcon
-          width={12}
-          height={12}
+          width={28}
+          height={28}
           fill={"#b7dcad"}
           onClick={onClick}
         >
-          <CloseIcon />
+          <CloseIcon width={12} height={12} />
         </AbsoluteIcon>
         {ranges.map((range, index) => {
             return (
               <TephraContainer key={index} data-test="tephra-key">
                 <TephraBox backgroundColor={range.color}/>
                 { range.max
-                  ? <TephraLabel>{` ${round(range.min)}—${round(range.max)}`}</TephraLabel>
-                  : <TephraLabel>{` >${round(range.min)}`}</TephraLabel>
+                  ? <TephraLabel>{`- ${round(range.min)}—${round(range.max)}`}</TephraLabel>
+                  : <TephraLabel>{`- >${round(range.min)}`}</TephraLabel>
                 }
               </TephraContainer>
             );
         })}
-
       </LegendContainer>
     );
   }
-
 }

--- a/src/components/map/map-tephra-legend.tsx
+++ b/src/components/map/map-tephra-legend.tsx
@@ -60,6 +60,7 @@ export const LegendTitleText = styled.div`
   margin: 5px 11px 2px 11px;
   color: #434343;
   font-size: 14px;
+  font-weight: normal;
   width: 95px;
   height: 34px;
   box-sizing: border-box;
@@ -68,20 +69,24 @@ export const LegendTitleText = styled.div`
 
 export const AbsoluteIcon = styled(Icon)`
   position: absolute;
-  top: 2px;
-  right: 6px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  top: 0;
+  right: 0;
   &:hover {
     fill: #75cd75;
   }
   &:active {
     fill: #e6f2e4;
   }
+  cursor: pointer;
 `;
 
 export const TephraContainer = styled.div`
   display: flex;
   justify-content: flex-start;
-  align-items: flex-start;
+  align-items: center;
   width: 97px;
   margin-top: 5px;
 `;
@@ -101,6 +106,8 @@ export const TephraBox = styled.div`
 export const TephraLabel = styled.div`
   color: #434343;
   font-size: 12px;
+  font-weight: normal;
+  margin-left: 3px;
 `;
 
 interface IProps {
@@ -120,12 +127,12 @@ export default class TephraLegendComponent extends PureComponent<IProps, IState>
       <LegendContainer>
         <LegendTitleText>Tephra Thickness (mm)</LegendTitleText>
         <AbsoluteIcon
-          width={12}
-          height={12}
+          width={28}
+          height={28}
           fill={"#b7dcad"}
           onClick={onClick}
         >
-          <CloseIcon />
+          <CloseIcon width={12} height={12} />
         </AbsoluteIcon>
         {TephraRanges.map((tephraRange, index) => {
             return (
@@ -138,9 +145,7 @@ export default class TephraLegendComponent extends PureComponent<IProps, IState>
               </TephraContainer>
             );
         })}
-
       </LegendContainer>
     );
   }
-
 }


### PR DESCRIPTION
This PR makes UI improvements to the map legends to match the UI spec.   Changes include:
- use proper font weight, style, size
- displayed text matches spec
- improve margins, alignment, and spacing
- improve x close hitbox
- add hover cursor on buttons
- update button colors
- fix tab size so modules have consistent tab spacing

Can test here:
http://geocode-app.concord.org/branch/legend-styling/index.html