### PR TITLE
Protect against performing spread on non-array

### DIFF
--- a/src/stores/data-sets.ts
+++ b/src/stores/data-sets.ts
@@ -94,7 +94,7 @@ export const Datasets = {
 
   getGPSPositionTimeData(name: string, timeRange?: TimeRange) {
     const dataSet = (PositionTimeDataSets as any)[name] as Dataset;
-    let filteredDataSet = [...dataSet];
+    let filteredDataSet = Array.isArray(dataSet) ? [...dataSet] : dataSet;
     if (timeRange) {
       if (timeRange.from) {
         filteredDataSet = filteredDataSet.filter(d => (d.Date as Date) >= timeRange.from!);


### PR DESCRIPTION
In some cases `getGPSPositionTimeData` results in a non-array value in `dataSet`.  In this case, the spread operation throws an error.  This was happening when we clicked on a GPS location on the map.  This PR adds protection around spreading non array values.

Can be tested here:
http://geocode-app.concord.org/branch/fix-array-spread/index.html