### PR TITLE
Update button styling

### DIFF
--- a/src/assets/map-icons/ruler.svg
+++ b/src/assets/map-icons/ruler.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Ruler" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 26 26" style="enable-background:new 0 0 26 26;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#FFFFFF;}
+	.st1{fill:#B263F7;}
+	.st2{fill:#949494;}
+</style>
+<path id="outline" class="st0" d="M7.5,0C3.4,0,0,3.4,0,7.5S3.4,15,7.5,15l0.3,0c0.5,0,1-0.1,1.5-0.2l0.4-0.1l1.6,1.6l0,0
+	C11.1,17,11,17.7,11,18.5c0,4.1,3.4,7.5,7.5,7.5s7.5-3.4,7.5-7.5l0-0.3c-0.1-2.6-1.6-5-3.8-6.3L22,11.9L22,4l-7.9,0L14,3.8
+	C12.7,1.5,10.3,0,7.5,0z"/>
+<g id="icon">
+	<polygon id="outer_3" class="st1" points="20,6 3.9,6 20,22.1 	"/>
+	<polygon id="inner_3" class="st0" points="17,9 17,14.9 11.1,9 	"/>
+	<path id="outer_2" class="st2" d="M18.5,13c3,0,5.5,2.5,5.5,5.5S21.5,24,18.5,24S13,21.5,13,18.5S15.5,13,18.5,13z"/>
+	<path id="inner_2" class="st0" d="M18.5,15c-1.9,0-3.5,1.6-3.5,3.5s1.6,3.5,3.5,3.5s3.5-1.6,3.5-3.5S20.4,15,18.5,15z"/>
+	<path id="outer_1" class="st2" d="M7.5,2c3,0,5.5,2.5,5.5,5.5S10.5,13,7.5,13S2,10.5,2,7.5S4.5,2,7.5,2z"/>
+	<path id="inner_1" class="st0" d="M7.5,4C5.6,4,4,5.6,4,7.5S5.6,11,7.5,11S11,9.4,11,7.5S9.4,4,7.5,4z"/>
+</g>
+</svg>

--- a/src/assets/map-icons/set-point.svg
+++ b/src/assets/map-icons/set-point.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Set_Point" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
+	.st1{fill:#949494;}
+	.st2{fill:#FFFFFF;}
+</style>
+<circle id="outline" class="st0" cx="8" cy="8" r="8"/>
+<g id="icon">
+	<path id="outer" class="st1" d="M8,2c3.3,0,6,2.7,6,6s-2.7,6-6,6s-6-2.7-6-6S4.7,2,8,2z"/>
+	<path id="inner" class="st2" d="M8,4C5.8,4,4,5.8,4,8s1.8,4,4,4s4-1.8,4-4S10.2,4,8,4z"/>
+</g>
+</svg>

--- a/src/assets/map-icons/set-region.svg
+++ b/src/assets/map-icons/set-region.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 25.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Set_Region" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 26 26" style="enable-background:new 0 0 26 26;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
+	.st1{fill:#B263F7;}
+	.st2{fill:#FFFFFF;}
+	.st3{fill:#949494;}
+</style>
+<path id="outline" class="st0" d="M7.5,0c2.9,0,5.4,1.6,6.6,4H22v7.9c2.4,1.3,4,3.8,4,6.6c0,4.1-3.4,7.5-7.5,7.5
+	c-2.9,0-5.4-1.6-6.6-4H4v-7.9c-2.4-1.3-4-3.8-4-6.6C0,3.4,3.4,0,7.5,0z"/>
+<g id="icon">
+	<polygon id="outer_3" class="st1" points="20,6 6,6 6,20 20,20 	"/>
+	<polygon id="inner_3" class="st2" points="17,9 17,17 9,17 9,9 	"/>
+	<path id="outer_2" class="st3" d="M18.5,13c3,0,5.5,2.5,5.5,5.5S21.5,24,18.5,24S13,21.5,13,18.5S15.5,13,18.5,13z"/>
+	<path id="inner_2" class="st2" d="M18.5,15c-1.9,0-3.5,1.6-3.5,3.5s1.6,3.5,3.5,3.5s3.5-1.6,3.5-3.5S20.4,15,18.5,15z"/>
+	<path id="outer_1" class="st3" d="M7.5,2c3,0,5.5,2.5,5.5,5.5S10.5,13,7.5,13S2,10.5,2,7.5S4.5,2,7.5,2z"/>
+	<path id="inner_1" class="st2" d="M7.5,4C5.6,4,4,5.6,4,7.5S5.6,11,7.5,11S11,9.4,11,7.5S9.4,4,7.5,4z"/>
+</g>
+</svg>

--- a/src/components/buttons/icon-button.tsx
+++ b/src/components/buttons/icon-button.tsx
@@ -29,6 +29,7 @@ const IconButtonContainer = styled.div`
     background-color: ${(p: IconButtonContainerProps) => p.activeColor};
   }
   font-size: ${(p: IconButtonContainerProps) => p.fontSize || "16px"};
+  cursor: pointer;
 `;
 
 const IconButtonText = styled.div`

--- a/src/components/overlay-controls.tsx
+++ b/src/components/overlay-controls.tsx
@@ -1,10 +1,18 @@
 import * as React from "react";
+import RulerIcon from "../assets/map-icons/ruler.svg";
+import SetPointIcon from "../assets/map-icons/set-point.svg";
+import SetRegionIcon from "../assets/map-icons/set-region.svg";
 import IconButton from "./buttons/icon-button";
-import { RightSectionTypes, kRightTabInfo } from "./tabs";
 
 import "../css/overlay-controls.css";
 import { observer, inject } from "mobx-react";
 import { BaseComponent } from "./base";
+
+const kButtonColor = "white";
+const kButtonSelectedColor = "#cee6c9";
+const kButtonHoverColor = "#cee6c9";
+const kButtonSelectedHoverColor = "#b7dcad";
+const kButtonActiveColor = "#e6f2e4";
 
 interface IProps {
     showRuler: boolean;
@@ -42,17 +50,6 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
             onReCenterClick} = this.props;
         const { hasErupted } = this.stores.tephraSimulation;
 
-        const rulerColor = showRuler ? kRightTabInfo[RightSectionTypes.CONDITIONS].hoverBackgroundColor : "white";
-        const selectingLatLngPtColor = isSelectingSetPoint
-                               ? kRightTabInfo[RightSectionTypes.CROSS_SECTION].hoverBackgroundColor
-                               : "white";
-        const selectingLatLngRegionColor = isSelectingSetRegion
-                               ? kRightTabInfo[RightSectionTypes.CROSS_SECTION].hoverBackgroundColor
-                               : "white";
-        const selectingColor = isSelectingCrossSection
-                               ? kRightTabInfo[RightSectionTypes.CROSS_SECTION].hoverBackgroundColor
-                               : "white";
-
         return (
             <div className="overlay-controls">
                 <div className="controls bottom left">
@@ -60,44 +57,45 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
                         onClick={onReCenterClick}
                         disabled={false}
                         label={"Re-center"}
-                        hoverColor={kRightTabInfo[RightSectionTypes.CONDITIONS].hoverBackgroundColor}
-                        activeColor={kRightTabInfo[RightSectionTypes.CONDITIONS].backgroundColor}
+                        hoverColor={kButtonHoverColor}
+                        activeColor={kButtonActiveColor}
                         fill={"black"}
-                        width={26}
-                        height={26}
                         dataTest={"Re-center-button"}
                     />
                     {isTephraUnit && <IconButton
+                        children={<RulerIcon />}
                         onClick={onRulerClick}
                         disabled={false}
                         label={"Ruler"}
-                        backgroundColor={rulerColor}
-                        hoverColor={kRightTabInfo[RightSectionTypes.CONDITIONS].hoverBackgroundColor}
-                        activeColor={kRightTabInfo[RightSectionTypes.CONDITIONS].backgroundColor}
+                        backgroundColor={showRuler ? kButtonSelectedColor : kButtonColor}
+                        hoverColor={showRuler ? kButtonSelectedHoverColor : kButtonHoverColor}
+                        activeColor={kButtonActiveColor}
                         fill={"black"}
                         width={26}
                         height={26}
                         dataTest={"Ruler-button"}
                     />}
                     {isSeismicUnit && <IconButton
+                        children={<SetPointIcon />}
                         onClick={onSetPointClick}
                         disabled={false}
                         label={"Set Point"}
-                        backgroundColor={selectingLatLngPtColor}
-                        hoverColor={kRightTabInfo[RightSectionTypes.CONDITIONS].hoverBackgroundColor}
-                        activeColor={kRightTabInfo[RightSectionTypes.CONDITIONS].backgroundColor}
+                        backgroundColor={isSelectingSetPoint ? kButtonSelectedColor : kButtonColor}
+                        hoverColor={isSelectingSetPoint ? kButtonSelectedHoverColor : kButtonHoverColor}
+                        activeColor={kButtonActiveColor}
                         fill={"black"}
-                        width={26}
-                        height={26}
+                        width={16}
+                        height={16}
                         dataTest={"Latlng-point-button"}
                     />}
                     {isSeismicUnit && <IconButton
+                        children={<SetRegionIcon />}
                         onClick={onSetRegionClick}
                         disabled={false}
                         label={"Set Region"}
-                        backgroundColor={selectingLatLngRegionColor}
-                        hoverColor={kRightTabInfo[RightSectionTypes.CONDITIONS].hoverBackgroundColor}
-                        activeColor={kRightTabInfo[RightSectionTypes.CONDITIONS].backgroundColor}
+                        backgroundColor={isSelectingSetRegion ? kButtonSelectedColor : kButtonColor}
+                        hoverColor={isSelectingSetRegion ? kButtonSelectedHoverColor : kButtonHoverColor}
+                        activeColor={kButtonActiveColor}
                         fill={"black"}
                         width={26}
                         height={26}
@@ -110,9 +108,9 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
                         onClick={onCrossSectionClick}
                         disabled={false}
                         label={"Draw a cross section line"}
-                        backgroundColor={selectingColor}
-                        hoverColor={kRightTabInfo[RightSectionTypes.CROSS_SECTION].hoverBackgroundColor}
-                        activeColor={kRightTabInfo[RightSectionTypes.CROSS_SECTION].backgroundColor}
+                        backgroundColor={isSelectingCrossSection ? kButtonSelectedColor : kButtonColor}
+                        hoverColor={isSelectingCrossSection ? kButtonSelectedHoverColor : kButtonHoverColor}
+                        activeColor={kButtonActiveColor}
                         fill={"black"}
                         width={26}
                         height={26}


### PR DESCRIPTION
This PR updates the map button styling to match the UI spec.  Changes include:
- add correct background, hover, and active colors
- add new icons to ruler, set point, set region
- add cursor state when hovering

Can be tested here:
http://geocode-app.concord.org/branch/button-styling/index.html