### PR TITLE
Fix GPS direction filter

### DIFF
--- a/src/blockly-blocks/seismic/block-seismic-gps-stations.js
+++ b/src/blockly-blocks/seismic/block-seismic-gps-stations.js
@@ -165,7 +165,7 @@ Blockly.JavaScript['seismic_filter_data'] = function (block) {
   let filterObj = JSON.stringify(filter);
   filterObj = filterObj.replace(/"([^"]+)":/g, '$1:')
 
-  var code = `filter({dataset: ${dataset}, filter: ${filterObj}})`
+  var code = `filter({dataset: ${dataset}, filter: ${filterObj}, useDirectionTo: ${true}})`
   // TODO: Change ORDER_NONE to the correct strength.
   return [code, Blockly.JavaScript.ORDER_NONE]
 }

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -212,7 +212,7 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
       };
     });
 
-    addFunc("filter", (params: {dataset: Dataset, filter: Filter}) => {
+    addFunc("filter", (params: {dataset: Dataset, filter: Filter, useDirectionTo?: boolean}) => {
       if (!params.dataset) {
         blocklyController.throwError("You must include a dataset to filter.");
         return;
@@ -228,7 +228,8 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
             }
             return;
           } else if (key === "direction") {
-            // Wind data is stored using direction to, but we use direction from. Need to convert.
+            if (!params.useDirectionTo) {
+              // Wind data is stored using direction to, but we use direction from. Need to convert.
               const rotate = (dir: number) => dir < 180 ? dir + 180 : dir - 180;
               if (typeof params.filter.direction === "number") {
                 params.filter.direction = rotate(params.filter.direction);
@@ -236,6 +237,7 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
                 params.filter.direction.min = rotate(params.filter.direction.min as number);
                 params.filter.direction.max = rotate(params.filter.direction.max as number);
               }
+            }
           }
         }
       }


### PR DESCRIPTION
This PR fixes a but that broke the GPS station direction filter.  The change between direction to and direction from only applies to the wind data.  Pass the filter function an extra parameter to determine if the to/from adjustment should be applied.

Note, it feels a little clunky to have an extra field in params for this, but trying to add it inside params.filter got sticky fast.  I made it optional and decided to leave the current implementation as the base case.  This means the to/from adjustment happens by default and those who don't want it, can turn it off.

Can test here:
http://geocode-app.concord.org/branch/fix-gps-direction-filter/index.html