### PR TITLE
Update GPS station graph to use offset into data to choose colors

### DIFF
--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -335,8 +335,8 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
         duration: timeRange.duration ? timeRange.duration : undefined,
       };
       const dataset = Datasets.getGPSPositionTimeData(station, validTimeRange);
-      chartsStore.addArbitraryChart(dataset, "East (mm)", "North (mm)", `${params.station} Position over Time`, true,
-                                    true, true);
+      chartsStore.addArbitraryChart(dataset.data, "East (mm)", "North (mm)", `${params.station} Position over Time`,
+                                    true, true, true, dataset.dataOffset);
     });
 
     addFunc("computeStrainRate", (filter: Filter) => {

--- a/src/components/charts/canvas-d3-scatter-chart.tsx
+++ b/src/components/charts/canvas-d3-scatter-chart.tsx
@@ -70,7 +70,7 @@ export class CanvasD3ScatterChart extends React.Component<IProps> {
     if (!this.canvasRef.current || !this.svgRef.current) return;
 
     const { chart } = this.props;
-    const { data, xAxisLabel, yAxisLabel, fadeIn, gridlines } = chart;
+    const { data, xAxisLabel, yAxisLabel, fadeIn, gridlines, dataOffset } = chart;
     const chartDimensions = this.calculateChartDimensions();
     const { width, height, chartWidth, chartHeight } = chartDimensions;
 
@@ -179,7 +179,7 @@ export class CanvasD3ScatterChart extends React.Component<IProps> {
       if (!fadeIn) {
         ctx.fillStyle = "#448878";
       } else {
-        ctx.fillStyle = color(i);
+        ctx.fillStyle = color(dataOffset + i);
       }
 
       const px = xScale(d[0]) + canvasPadding;

--- a/src/components/charts/svg-d3-scatter-chart.tsx
+++ b/src/components/charts/svg-d3-scatter-chart.tsx
@@ -45,7 +45,7 @@ export const SvgD3ScatterChart = (props: IProps) => {
   };
 
   const { chart } = props;
-  const { data, xAxisLabel, yAxisLabel, fadeIn, gridlines } = chart;
+  const { data, xAxisLabel, yAxisLabel, fadeIn, gridlines, dataOffset } = chart;
   const xRange = Number(chart.extent(0)[1]) - Number(chart.extent(0)[0]);
   const yRange = Number(chart.extent(1)[1]) - Number(chart.extent(1)[0]);
   const xTicks = Math.floor(xRange / 100);
@@ -137,7 +137,7 @@ export const SvgD3ScatterChart = (props: IProps) => {
   }
 
   const color = fadeIn
-    ? (d: number, i: number) => getFadeColor(i)
+    ? (d: number, i: number) => getFadeColor(dataOffset + i)
     : "#448878";
 
   svg.append("g")

--- a/src/components/gps-station-table.tsx
+++ b/src/components/gps-station-table.tsx
@@ -69,9 +69,9 @@ export class GPSStationTable extends BaseComponent<IProps, IState> {
     let lastRecord = "N/A";
     let datesClass = "na";
     const positionData = Datasets.getGPSPositionTimeData(station.id);
-    if (positionData) {
-      installed = (positionData[0].Date as Date).toLocaleDateString("en-US");
-      lastRecord = (positionData[positionData.length - 1].Date as Date).toLocaleDateString("en-US");
+    if (positionData.data) {
+      installed = (positionData.data[0].Date as Date).toLocaleDateString("en-US");
+      lastRecord = (positionData.data[positionData.data.length - 1].Date as Date).toLocaleDateString("en-US");
       datesClass = "";
     }
 

--- a/src/stores/charts-store.ts
+++ b/src/stores/charts-store.ts
@@ -26,6 +26,7 @@ const Chart = types.model("Chart", {
   fadeIn: types.optional(types.boolean, false),
   uniformXYScale: types.optional(types.boolean, false),
   gridlines: types.optional(types.boolean, false),
+  dataOffset: types.optional(types.number, 0)
 })
 .views((self) => {
   const isDate = (column: 0|1) => {
@@ -73,7 +74,7 @@ const ChartsStore = types.model("Charts", {
 .actions((self) => ({
   addChart(chartProps: {type: ChartTypeType, chartStyle?: ChartStyleType, data: ChartData, customExtents?: number[][],
           title?: string, xAxisLabel?: string, yAxisLabel?: string, dateLabelFormat?: string, fadeIn?: boolean,
-          uniformXYScale?: boolean, gridlines?: boolean}) {
+          uniformXYScale?: boolean, gridlines?: boolean, dataOffset?: number}) {
     const chart = Chart.create(chartProps);
     self.charts.push(chart);
     return chart;     // returns in case anyone wants to use the new chart
@@ -121,7 +122,7 @@ const ChartsStore = types.model("Charts", {
    * Creates a custom chart based on known properties of wind data.
    */
   addArbitraryChart(dataset: Dataset, xAxis: string, yAxis: string, _title?: string, _fadeIn?: boolean,
-                    _uniformXYScale?: boolean, _gridlines?: boolean) {
+                    _uniformXYScale?: boolean, _gridlines?: boolean, _dataOffset?: number) {
     let data;
 
     const timeParser = WindData.timeParsers[xAxis];
@@ -146,9 +147,10 @@ const ChartsStore = types.model("Charts", {
     const yAxisLabel = WindData.axisLabel[yAxis] ?  WindData.axisLabel[yAxis] : capFirst(yAxis);
     const fadeIn = _fadeIn || false;
     const uniformXYScale = _uniformXYScale || false;
+    const dataOffset = _dataOffset;
     const gridlines = _gridlines || false;
     self.addChart({type, data, customExtents, title, xAxisLabel, yAxisLabel, chartStyle, dateLabelFormat, fadeIn,
-                   uniformXYScale, gridlines});
+                   uniformXYScale, gridlines, dataOffset});
   },
 
   /**

--- a/src/stores/data-sets.ts
+++ b/src/stores/data-sets.ts
@@ -94,9 +94,14 @@ export const Datasets = {
 
   getGPSPositionTimeData(name: string, timeRange?: TimeRange) {
     const dataSet = (PositionTimeDataSets as any)[name] as Dataset;
+    let dataOffset = 0;
     let filteredDataSet = Array.isArray(dataSet) ? [...dataSet] : dataSet;
     if (timeRange) {
       if (timeRange.from) {
+        const offsetIndex = filteredDataSet.findIndex(d => (d.Date as Date) >= timeRange.from!);
+        if (offsetIndex > 0) {
+          dataOffset = offsetIndex;
+        }
         filteredDataSet = filteredDataSet.filter(d => (d.Date as Date) >= timeRange.from!);
       }
       if (timeRange.to) {
@@ -110,7 +115,7 @@ export const Datasets = {
         }
       }
     }
-    return filteredDataSet;
+    return {data: filteredDataSet, dataOffset};
   },
 
 };


### PR DESCRIPTION
This PR adds an offset to the returned dataset in `getGPSPositionTimeData` which can be stored in the chart data store as a new `dataOffset` field.  This is needed when displaying GPS position over time points that include a min/max date range.  The point colors need to be based on the position in the original dataset not their position in the filtered dataset. - the offset is used to get the position in the original dataset  This is so, for example, point 4000 in the original dataset always displays with the same color even if it is point 0 in a filtered dataset.

Can be tested here:
http://geocode-app.concord.org/branch/gps-color-fixes/index.html

![Pasted Image at 2021_03_23_18_55 pm](https://user-images.githubusercontent.com/5126913/112336346-3fd8be80-8c7a-11eb-8f78-e1abc7e35fb0.png)

![Pasted Image at 2021_03_23_18_57 pm](https://user-images.githubusercontent.com/5126913/112336363-436c4580-8c7a-11eb-9703-fa6b7d37d627.png)
