### PR TITLE
make tephra semi-transparent

### DIFF
--- a/src/components/map/map-tephra-thickness-layer.tsx
+++ b/src/components/map/map-tephra-thickness-layer.tsx
@@ -121,7 +121,10 @@ export class MapTephraThicknessLayer extends BaseComponent<IProps, IState> {
 
     private renderGeoJson(geojson: MultiPolygon[]) {
         let gradientIndex = 0;
-        return(geojson.map(multipolygon => {
+        return(geojson.map((multipolygon, i) => {
+            if (i < geojson.length - 1 && geojson[i + 1].coordinates.length > 0) {
+                geojson[i + 1].coordinates.forEach((item) => multipolygon.coordinates.push(item));
+            }
             return (<GeoJSON key={this.keyval++}
                 stroke={false}
                 fillOpacity={0.8}


### PR DESCRIPTION
This is a draft PR that attempts to use Michael's knocked out transparency rendering of the tephra thicknesses on the map.  The goal is to maintain consistent transparency across all thicknesses instead of layering one thickness area on top of another which results in area being relatively opaque.

From the UI spec:
![image](https://user-images.githubusercontent.com/5126913/112365330-c26e7780-8c94-11eb-8640-d03996d04196.png)

Result:
![image](https://user-images.githubusercontent.com/5126913/112356466-deb9e680-8c8b-11eb-88f9-bd5156d7c7a0.png)

The solution is very simple and is based on this example of cutting a polygon out of another polygon using GeoJSON:
https://gist.github.com/andrewharvey/971b9db1900a62efa7635f6a6d337ae7

For each tephra thickness (n), we cut out the shape(s) from the next thickness level (n + 1).  This is done by simply adding the (n + 1) shapes when drawing the (n) layer and allowing the GeoJSON fill method to do the rest.  This assumes that each tephra thickness shapes(s) is contained within the shape of the previous thickness.  This is where I am uncertain.  In practice this seems to be the case, but I'm not sure this is always true.  Will the (n + 1) shapes always be bounded by or contained within the (n) shapes?

Can test here:
http://geocode-app.concord.org/branch/semi-trans-tephra/index.html
