### PR TITLE
Content scroll

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -50,7 +50,7 @@ const App = styled.div`
     flex-direction: row;
     height: 100vh;
     background-color: #ffffff;
-    min-width: 1100px;
+    min-width: 800px;
     overflow-x: auto;
 `;
 

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -50,7 +50,8 @@ const App = styled.div`
     flex-direction: row;
     height: 100vh;
     background-color: #ffffff;
-    overflow-x: hidden;
+    min-width: 1100px;
+    overflow-x: auto;
 `;
 
 const Row = styled.div`
@@ -71,6 +72,7 @@ const BottomBar = styled.div`
   display: flex;
   width: 100%;
   flex-direction: row;
+  position: relative;
 `;
 
 const TabsContainer = styled.div`
@@ -489,11 +491,11 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                 />
               </TabPanel>
             }
-            <RightTabBack
-              width={tabWidth}
-              backgroundcolor={this.getRightTabColor(currentRightTabType, unitName)}
-            />
             <BottomBar>
+              <RightTabBack
+                width={tabWidth}
+                backgroundcolor={this.getRightTabColor(currentRightTabType, unitName)}
+              />
               <TabsContainer>
                 <TabList>
                   { showConditions &&

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -50,7 +50,7 @@ const App = styled.div`
     flex-direction: row;
     height: 100vh;
     background-color: #ffffff;
-    min-width: 800px;
+    min-width: 900px;
     overflow-x: auto;
 `;
 

--- a/src/components/map/map-compass.tsx
+++ b/src/components/map/map-compass.tsx
@@ -9,8 +9,8 @@ const CompassContainer = styled.div`
   justify-content: center;
   align-items: center;
   position: absolute;
-  top: 19px;
-  right: 12px;
+  top: -10px;
+  right: -24px;
 `;
 
 const CompassText = styled.div`

--- a/src/components/map/map-component.tsx
+++ b/src/components/map/map-component.tsx
@@ -18,7 +18,6 @@ import { MapTriangulatedStrainLayer } from "./map-triangulated-strain-layer";
 import { OverlayControls } from "../overlay-controls";
 import { RulerDrawLayer } from "./layers/ruler-draw-layer";
 import { RightSectionTypes } from "../tabs";
-import CompassComponent from "./map-compass";
 import { SamplesCollectionModelType, SamplesLocationModelType } from "../../stores/samples-collections-store";
 import { RiskLevels } from "../montecarlo/monte-carlo";
 import { LatLngRegionDrawLayer } from "./layers/latlng-region-draw-layer";
@@ -377,7 +376,6 @@ export class MapComponent extends BaseComponent<IProps, IState>{
             onClose={this.handleDirectionToolClose}
           />
         }
-        <CompassComponent/>
       </CanvDiv>
     );
   }

--- a/src/components/map/map-key-button.tsx
+++ b/src/components/map/map-key-button.tsx
@@ -10,8 +10,8 @@ const KeyButtonContainer = styled.div`
   align-items: center;
   position: absolute;
   box-sizing: border-box;
-  top: 35px;
-  right: 38px;
+  top: 0;
+  right: 0;
   width: 71px;
   height: 34px;
   border-radius: 5px;

--- a/src/components/map/map-legend.tsx
+++ b/src/components/map/map-legend.tsx
@@ -15,8 +15,8 @@ const LegendContainer = styled.div`
   justify-content: flex-start;
   align-items: center;
   position: absolute;
-  top: 35px;
-  right: 38px;
+  top: 0;
+  right: 0;
   border-radius: 5px;
   background-color: white;
   border: solid 2px white;
@@ -68,11 +68,13 @@ export class LegendComponent extends BaseComponent<IProps, IState> {
       currentLegendType = secondaryPanel[currentLegendType];
     }
 
-    const legend = currentLegendType === "Tephra" ? <TephraLegendComponent onClick={onClick} /> :
-                    currentLegendType === "Risk" ? <RiskLegendComponent onClick={onClick} /> :
-                    currentLegendType === "Strain" ?
-                    <StrainLegendComponent onClick={onClick} colorMethod={colorMethod} /> :
-                    <GPSLegendComponent onClick={onClick} />;
+    const legend = currentLegendType === "Tephra"
+      ? <TephraLegendComponent onClick={onClick} />
+      : currentLegendType === "Risk"
+        ? <RiskLegendComponent onClick={onClick} />
+        : currentLegendType === "Strain"
+          ? <StrainLegendComponent onClick={onClick} colorMethod={colorMethod} />
+          : <GPSLegendComponent onClick={onClick} />;
     return (
       <LegendContainer data-test="key-container">
         { legend }

--- a/src/components/overlay-controls.tsx
+++ b/src/components/overlay-controls.tsx
@@ -10,6 +10,7 @@ import KeyButton from "./map/map-key-button";
 import { RightSectionTypes } from "./tabs";
 import { LegendComponent, LegendType } from "./map/map-legend";
 import { ColorMethod } from "../stores/seismic-simulation-store";
+import CompassComponent from "./map/map-compass";
 import "../css/overlay-controls.css";
 
 const kButtonColor = "white";
@@ -163,6 +164,7 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
                 colorMethod={strainMapColorMethod as ColorMethod}
               />
           }
+          <CompassComponent/>
         </div>
       </div>
     );

--- a/src/components/overlay-controls.tsx
+++ b/src/components/overlay-controls.tsx
@@ -1,12 +1,16 @@
 import * as React from "react";
+import { observer, inject } from "mobx-react";
+import { BaseComponent } from "./base";
 import RulerIcon from "../assets/map-icons/ruler.svg";
 import SetPointIcon from "../assets/map-icons/set-point.svg";
 import SetRegionIcon from "../assets/map-icons/set-region.svg";
 import IconButton from "./buttons/icon-button";
 import ExploreIcon from "../assets/map-icons/explore.svg";
+import KeyButton from "./map/map-key-button";
+import { RightSectionTypes } from "./tabs";
+import { LegendComponent, LegendType } from "./map/map-legend";
+import { ColorMethod } from "../stores/seismic-simulation-store";
 import "../css/overlay-controls.css";
-import { observer, inject } from "mobx-react";
-import { BaseComponent } from "./base";
 
 const kButtonColor = "white";
 const kButtonSelectedColor = "#cee6c9";
@@ -27,13 +31,24 @@ interface IProps {
   onCrossSectionClick: () => void;
   onReCenterClick: () => void;
   onDirectionClick: () => void;
+  panelType: RightSectionTypes;
 }
 
-interface IState {}
+interface IState {
+  showKey: boolean;
+}
 
 @inject("stores")
 @observer
 export class OverlayControls extends BaseComponent<IProps, IState> {
+  constructor(props: IProps) {
+    super(props);
+    const initialState: IState = {
+      showKey: true,
+    };
+    this.state = initialState;
+  }
+
   public render() {
     const { name: unitName } = this.stores.unit;
 
@@ -51,8 +66,14 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
       onCrossSectionClick,
       onReCenterClick,
       onDirectionClick,
-      isSelectingDirection } = this.props;
+      isSelectingDirection,
+      panelType } = this.props;
     const { hasErupted } = this.stores.tephraSimulation;
+    const { strainMapColorMethod } = this.stores.seismicSimulation;
+
+    const legendType: LegendType = isTephraUnit
+      ? (panelType !== RightSectionTypes.MONTE_CARLO ? "Tephra" : "Risk")
+      : "Strain";
 
     return (
       <div className="overlay-controls">
@@ -133,7 +154,26 @@ export class OverlayControls extends BaseComponent<IProps, IState> {
             dataTest={"directionb-button"}
           />}
         </div>
+        <div className="controls top right">
+          { this.state.showKey
+            ? <KeyButton onClick={this.handleKeySelect}/>
+            : <LegendComponent
+                onClick={this.handleKeyButtonSelect}
+                legendType={legendType}
+                colorMethod={strainMapColorMethod as ColorMethod}
+              />
+          }
+        </div>
       </div>
     );
   }
+
+  private handleKeySelect = () => {
+    this.setState({showKey: false});
+  }
+
+  private handleKeyButtonSelect = () => {
+    this.setState({showKey: true});
+  }
+
 }

--- a/src/components/overlay-controls.tsx
+++ b/src/components/overlay-controls.tsx
@@ -15,18 +15,18 @@ const kButtonSelectedHoverColor = "#b7dcad";
 const kButtonActiveColor = "#e6f2e4";
 
 interface IProps {
-    showRuler: boolean;
-    onRulerClick: () => void;
-    onSetPointClick: () => void;
-    onSetRegionClick: () => void;
-    isSelectingCrossSection: boolean;
-    isSelectingSetPoint: boolean;
-    isSelectingSetRegion: boolean;
-    isSelectingDirection: boolean;
-    showCrossSection: boolean;
-    onCrossSectionClick: () => void;
-    onReCenterClick: () => void;
-    onDirectionClick: () => void;
+  showRuler: boolean;
+  onRulerClick: () => void;
+  onSetPointClick: () => void;
+  onSetRegionClick: () => void;
+  isSelectingCrossSection: boolean;
+  isSelectingSetPoint: boolean;
+  isSelectingSetRegion: boolean;
+  isSelectingDirection: boolean;
+  showCrossSection: boolean;
+  onCrossSectionClick: () => void;
+  onReCenterClick: () => void;
+  onDirectionClick: () => void;
 }
 
 interface IState {}
@@ -34,106 +34,106 @@ interface IState {}
 @inject("stores")
 @observer
 export class OverlayControls extends BaseComponent<IProps, IState> {
-    public render() {
-        const { name: unitName } = this.stores.unit;
+  public render() {
+    const { name: unitName } = this.stores.unit;
 
-        const isTephraUnit = unitName === "Tephra";
-        const isSeismicUnit = unitName === "Seismic";
+    const isTephraUnit = unitName === "Tephra";
+    const isSeismicUnit = unitName === "Seismic";
 
-        const { showRuler,
-            onRulerClick,
-            onSetPointClick,
-            onSetRegionClick,
-            isSelectingCrossSection,
-            isSelectingSetPoint,
-            isSelectingSetRegion,
-            showCrossSection,
-            onCrossSectionClick,
-            onReCenterClick,
-            onDirectionClick,
-            isSelectingDirection } = this.props;
-        const { hasErupted } = this.stores.tephraSimulation;
+    const { showRuler,
+      onRulerClick,
+      onSetPointClick,
+      onSetRegionClick,
+      isSelectingCrossSection,
+      isSelectingSetPoint,
+      isSelectingSetRegion,
+      showCrossSection,
+      onCrossSectionClick,
+      onReCenterClick,
+      onDirectionClick,
+      isSelectingDirection } = this.props;
+    const { hasErupted } = this.stores.tephraSimulation;
 
-        return (
-            <div className="overlay-controls">
-                <div className="controls bottom left">
-                    <IconButton
-                        onClick={onReCenterClick}
-                        disabled={false}
-                        label={"Re-center"}
-                        hoverColor={kButtonHoverColor}
-                        activeColor={kButtonActiveColor}
-                        fill={"black"}
-                        dataTest={"Re-center-button"}
-                    />
-                    {isTephraUnit && <IconButton
-                        children={<RulerIcon />}
-                        onClick={onRulerClick}
-                        disabled={false}
-                        label={"Ruler"}
-                        backgroundColor={showRuler ? kButtonSelectedColor : kButtonColor}
-                        hoverColor={showRuler ? kButtonSelectedHoverColor : kButtonHoverColor}
-                        activeColor={kButtonActiveColor}
-                        fill={"black"}
-                        width={26}
-                        height={26}
-                        dataTest={"Ruler-button"}
-                    />}
-                    {isSeismicUnit && <IconButton
-                        children={<SetPointIcon />}
-                        onClick={onSetPointClick}
-                        disabled={false}
-                        label={"Set Point"}
-                        backgroundColor={isSelectingSetPoint ? kButtonSelectedColor : kButtonColor}
-                        hoverColor={isSelectingSetPoint ? kButtonSelectedHoverColor : kButtonHoverColor}
-                        activeColor={kButtonActiveColor}
-                        fill={"black"}
-                        width={16}
-                        height={16}
-                        dataTest={"Latlng-point-button"}
-                    />}
-                    {isSeismicUnit && <IconButton
-                        children={<SetRegionIcon />}
-                        onClick={onSetRegionClick}
-                        disabled={false}
-                        label={"Set Region"}
-                        backgroundColor={isSelectingSetRegion ? kButtonSelectedColor : kButtonColor}
-                        hoverColor={isSelectingSetRegion ? kButtonSelectedHoverColor : kButtonHoverColor}
-                        activeColor={kButtonActiveColor}
-                        fill={"black"}
-                        width={26}
-                        height={26}
-                        dataTest={"Latlng-region-button"}
-                    />}
-                </div>
-                <div className="controls bottom right">
-                    {(showCrossSection && hasErupted) && <IconButton
-                        dataTest={isSelectingCrossSection ? "drawing-cross-section" : "not-drawing-cross-section"}
-                        onClick={onCrossSectionClick}
-                        disabled={false}
-                        label={"Draw a cross section line"}
-                        backgroundColor={isSelectingCrossSection ? kButtonSelectedColor : kButtonColor}
-                        hoverColor={isSelectingCrossSection ? kButtonSelectedHoverColor : kButtonHoverColor}
-                        activeColor={kButtonActiveColor}
-                        fill={"black"}
-                        width={26}
-                        height={26}
-                    />}
-                    {isSeismicUnit && <IconButton
-                        onClick={onDirectionClick}
-                        children={<ExploreIcon />}
-                        disabled={false}
-                        label={"Direction"}
-                        backgroundColor={isSelectingDirection ? kButtonSelectedColor : kButtonColor}
-                        hoverColor={isSelectingDirection ? kButtonSelectedHoverColor : kButtonHoverColor}
-                        activeColor={kButtonActiveColor}
-                        fill={"black"}
-                        width={26}
-                        height={26}
-                        dataTest={"directionb-button"}
-                    />}
-                </div>
-            </div>
-        );
-    }
+    return (
+      <div className="overlay-controls">
+        <div className="controls bottom left">
+          <IconButton
+            onClick={onReCenterClick}
+            disabled={false}
+            label={"Re-center"}
+            hoverColor={kButtonHoverColor}
+            activeColor={kButtonActiveColor}
+            fill={"black"}
+            dataTest={"Re-center-button"}
+          />
+          {isTephraUnit && <IconButton
+            children={<RulerIcon />}
+            onClick={onRulerClick}
+            disabled={false}
+            label={"Ruler"}
+            backgroundColor={showRuler ? kButtonSelectedColor : kButtonColor}
+            hoverColor={showRuler ? kButtonSelectedHoverColor : kButtonHoverColor}
+            activeColor={kButtonActiveColor}
+            fill={"black"}
+            width={26}
+            height={26}
+            dataTest={"Ruler-button"}
+          />}
+          {isSeismicUnit && <IconButton
+            children={<SetPointIcon />}
+            onClick={onSetPointClick}
+            disabled={false}
+            label={"Set Point"}
+            backgroundColor={isSelectingSetPoint ? kButtonSelectedColor : kButtonColor}
+            hoverColor={isSelectingSetPoint ? kButtonSelectedHoverColor : kButtonHoverColor}
+            activeColor={kButtonActiveColor}
+            fill={"black"}
+            width={16}
+            height={16}
+            dataTest={"Latlng-point-button"}
+          />}
+          {isSeismicUnit && <IconButton
+            children={<SetRegionIcon />}
+            onClick={onSetRegionClick}
+            disabled={false}
+            label={"Set Region"}
+            backgroundColor={isSelectingSetRegion ? kButtonSelectedColor : kButtonColor}
+            hoverColor={isSelectingSetRegion ? kButtonSelectedHoverColor : kButtonHoverColor}
+            activeColor={kButtonActiveColor}
+            fill={"black"}
+            width={26}
+            height={26}
+            dataTest={"Latlng-region-button"}
+          />}
+        </div>
+        <div className="controls bottom right">
+          {(showCrossSection && hasErupted) && <IconButton
+            dataTest={isSelectingCrossSection ? "drawing-cross-section" : "not-drawing-cross-section"}
+            onClick={onCrossSectionClick}
+            disabled={false}
+            label={"Draw a cross section line"}
+            backgroundColor={isSelectingCrossSection ? kButtonSelectedColor : kButtonColor}
+            hoverColor={isSelectingCrossSection ? kButtonSelectedHoverColor : kButtonHoverColor}
+            activeColor={kButtonActiveColor}
+            fill={"black"}
+            width={26}
+            height={26}
+          />}
+          {isSeismicUnit && <IconButton
+            onClick={onDirectionClick}
+            children={<ExploreIcon />}
+            disabled={false}
+            label={"Direction"}
+            backgroundColor={isSelectingDirection ? kButtonSelectedColor : kButtonColor}
+            hoverColor={isSelectingDirection ? kButtonSelectedHoverColor : kButtonHoverColor}
+            activeColor={kButtonActiveColor}
+            fill={"black"}
+            width={26}
+            height={26}
+            dataTest={"directionb-button"}
+          />}
+        </div>
+      </div>
+    );
+  }
 }


### PR DESCRIPTION
This PR adds a min width to the app and horizontal scrollbars if the viewport width is smaller than the min width.  Changes include:
- a few components were moved from the `MapComponent` into `OverlayControls` so they could be better positioned
- I fixed the tabs in `OverlayControls`  which is why the diff looks so big

Note: I set the min width to 900, but we might go a little smaller to avoid scrollbars in LARA/AP in responsive view.  I'm waiting for feedback to make a final decision which will go into this PR.  In the meantime, I think the rest of the code can be reviewed.

Can test here:
https://geocode-app.concord.org/branch/content-scroll/index.html