### PR TITLE
Always show scrollbars to prevent block shake

### DIFF
--- a/src/components/blockly-container.tsx
+++ b/src/components/blockly-container.tsx
@@ -101,7 +101,8 @@ export default class BlocklyContainer extends React.Component<IProps, IState> {
         startScale: 0.8,
         maxScale: 2,
         minScale: 0.2
-      }
+      },
+      scrollbars: true
     };
 
     if (hideToolbox) {


### PR DESCRIPTION
This PR fixes the block shake bug that appears in GeoCoder.  The previous approach of using scrollbars did not work as LARA prevents scrollbars in iframes.  Instead, this solution is very simple.
  
The shaking occurred when the following happened:
- GeoCoder was displayed in a small view port such that the Blockly workspace was not wide enough to fit some of our larger blocks.  At the same time, we were hiding the Blockly toolbox was hidden (and as a side effect the trashcan and scrollbars were also hidden).
- a program was loaded that contained blocks which did not fit in the provided Blockly workspace.
- Blockly  would shift back and forth between having the left edge of the block against the left edge of the workspace and having the right edge of the block against the right edge of the workspace (the shaking).

Solution:
- specify that the blockly workspace always has scrollbars.  When the blocks are loaded, scrollbars are added and Blockly can position the block freely in any position.

See gifs for before and after.
![shake](https://user-images.githubusercontent.com/5126913/112526862-a97ec880-8d5f-11eb-8bac-81df3f7a7e6a.gif)
![noshake](https://user-images.githubusercontent.com/5126913/112526874-ab488c00-8d5f-11eb-9d6c-9b4c1a7107eb.gif)
 
