### PR TITLE
Update Cypress wait times

### DIFF
--- a/cypress/integration/branch/data-panel.test.js
+++ b/cypress/integration/branch/data-panel.test.js
@@ -32,7 +32,7 @@ const dataTab = new DataTab
           modelOptions.selectInitialCode('Filtered Wind Data Collection');
           modelOptions.getModelOptionsMenu().click();
           blocksTab.runProgram();
-          cy.wait(1000)
+          cy.wait(2000)
           rightPanel.getDataTab().click();
         });
         it('verify direction v elevation graph is visible',()=>{

--- a/cypress/integration/branch/monte-carlo-panel.test.js
+++ b/cypress/integration/branch/monte-carlo-panel.test.js
@@ -21,7 +21,7 @@ before(() => {
     modelOptions.getModelOptionsMenu().click();
     blocksTab.setSpeedControl("fast")
     blocksTab.runProgram();
-    cy.wait(15000)
+    cy.wait(4000)
     rightPanel.getMonteCarloTab().click();
   });
 beforeEach(()=>{


### PR DESCRIPTION
This PR makes a couple of small improvements to the Cypress test wait times:
- when running the data tab test wait an additional second for the program to run.  I believe this was the cause of some of the failures I saw in the previous weeks.  App elements were missing because the program run was incomplete.
- reduce the wait time when running the monte carlo tests.  The wait time was 15 seconds.  I reduced it to 4 seconds.  The 15 seconds appeared to be based on using the standard program run speed, but we set the speed to "fast" and do not need to wait 15 seconds.