### PR TITLE
Fix y axis tick marks when not using uniform scale

### DIFF
--- a/src/components/charts/canvas-d3-scatter-chart.tsx
+++ b/src/components/charts/canvas-d3-scatter-chart.tsx
@@ -70,14 +70,14 @@ export class CanvasD3ScatterChart extends React.Component<IProps> {
     if (!this.canvasRef.current || !this.svgRef.current) return;
 
     const { chart } = this.props;
-    const { data, xAxisLabel, yAxisLabel, fadeIn, gridlines, dataOffset } = chart;
+    const { data, xAxisLabel, yAxisLabel, fadeIn, gridlines, dataOffset, uniformXYScale } = chart;
     const chartDimensions = this.calculateChartDimensions();
     const { width, height, chartWidth, chartHeight } = chartDimensions;
 
     const xRange = Number(chart.extent(0)[1]) - Number(chart.extent(0)[0]);
     const yRange = Number(chart.extent(1)[1]) - Number(chart.extent(1)[0]);
-    const xTicks = Math.floor(xRange / 100);
-    const yTicks = Math.floor(yRange / 100);
+    const xUniformTicks = Math.floor(xRange / 100);
+    const yUniformTicks = Math.floor(yRange / 100);
 
     const svgAxes = d3.select(this.svgRef.current)
       .attr("width", width)
@@ -94,12 +94,12 @@ export class CanvasD3ScatterChart extends React.Component<IProps> {
 
     function make_x_gridlines() {
       return d3.axisBottom(xScale)
-          .ticks(xTicks);
+          .ticks(xUniformTicks);
     }
 
     function make_y_gridlines() {
       return d3.axisLeft(yScale)
-          .ticks(yTicks);
+          .ticks(yUniformTicks);
     }
 
     if (gridlines) {
@@ -132,14 +132,14 @@ export class CanvasD3ScatterChart extends React.Component<IProps> {
           if (chart.dateLabelFormat === "%b" && date.getFullYear() === 1901) return "";
           return chart.toDateString()(date);
         }) :
-        d3.axisBottom(xScale).ticks(xTicks);
+        uniformXYScale ? d3.axisBottom(xScale).ticks(xUniformTicks) : d3.axisBottom(xScale).ticks;
     svgAxes.append("g")
       .attr("transform", "translate(0," + chartHeight + ")")
       .call(axisBottom);
 
     const axisLeft = chart.isDate(1) ?
       d3.axisLeft(yScale).tickFormat(chart.toDateString()) :
-      d3.axisLeft(yScale).ticks(yTicks);
+      uniformXYScale ? d3.axisLeft(yScale).ticks(yUniformTicks) : d3.axisLeft(yScale);
     svgAxes.append("g")
       .call(axisLeft);
 

--- a/src/components/charts/svg-d3-scatter-chart.tsx
+++ b/src/components/charts/svg-d3-scatter-chart.tsx
@@ -1,7 +1,6 @@
 import * as ReactFauxDOM from "react-faux-dom";
 import * as d3 from "d3";
 import { ChartType } from "../../stores/charts-store";
-import { union } from "lodash";
 
 type Scale = d3.ScaleLinear<number, number> | d3.ScaleTime<number, number>;
 

--- a/src/components/charts/svg-d3-scatter-chart.tsx
+++ b/src/components/charts/svg-d3-scatter-chart.tsx
@@ -1,6 +1,7 @@
 import * as ReactFauxDOM from "react-faux-dom";
 import * as d3 from "d3";
 import { ChartType } from "../../stores/charts-store";
+import { union } from "lodash";
 
 type Scale = d3.ScaleLinear<number, number> | d3.ScaleTime<number, number>;
 
@@ -45,11 +46,11 @@ export const SvgD3ScatterChart = (props: IProps) => {
   };
 
   const { chart } = props;
-  const { data, xAxisLabel, yAxisLabel, fadeIn, gridlines, dataOffset } = chart;
+  const { data, xAxisLabel, yAxisLabel, fadeIn, gridlines, dataOffset, uniformXYScale } = chart;
   const xRange = Number(chart.extent(0)[1]) - Number(chart.extent(0)[0]);
   const yRange = Number(chart.extent(1)[1]) - Number(chart.extent(1)[0]);
-  const xTicks = Math.floor(xRange / 100);
-  const yTicks = Math.floor(yRange / 100);
+  const xUniformTicks = Math.floor(xRange / 100);
+  const yUniformTicks = Math.floor(yRange / 100);
   const margin = {top: 15, right: 20, bottom: 43, left: 50};
   const chartDimensions = calculateChartDimensions(xRange, yRange);
   const { width, height, chartWidth, chartHeight } = chartDimensions;
@@ -71,12 +72,12 @@ export const SvgD3ScatterChart = (props: IProps) => {
 
   function make_x_gridlines() {
     return d3.axisBottom(xScale)
-        .ticks(xTicks);
+        .ticks(xUniformTicks);
   }
 
   function make_y_gridlines() {
     return d3.axisLeft(yScale)
-        .ticks(yTicks);
+        .ticks(yUniformTicks);
   }
 
   if (gridlines) {
@@ -105,14 +106,14 @@ export const SvgD3ScatterChart = (props: IProps) => {
   // add axes
   const axisBottom = chart.isDate(0) ?
       d3.axisBottom(xScale).tickFormat(chart.toDateString()) :
-      d3.axisBottom(xScale).ticks(xTicks);
+      uniformXYScale ? d3.axisBottom(xScale).ticks(xUniformTicks) : d3.axisBottom(xScale).ticks;
   svg.append("g")
     .attr("transform", "translate(0," + chartHeight + ")")
     .call(axisBottom);
 
   const axisLeft = chart.isDate(1) ?
     d3.axisLeft(yScale).tickFormat(chart.toDateString()) :
-    d3.axisLeft(yScale).ticks(yTicks);
+    uniformXYScale ? d3.axisLeft(yScale).ticks(yUniformTicks) : d3.axisLeft(yScale).ticks;
   svg.append("g")
     .call(axisLeft);
 

--- a/src/components/charts/svg-d3-scatter-chart.tsx
+++ b/src/components/charts/svg-d3-scatter-chart.tsx
@@ -35,13 +35,13 @@ export const SvgD3ScatterChart = (props: IProps) => {
     const _chart = props.chart;
     const _width = props.width;
     const _height = props.height;
-    const { uniformXYScale } = _chart;
+    const _uniformXYScale = _chart.uniformXYScale;
     const chartUsedWidth = _width - margin.left - margin.right;
     // adjust height if the x and y axes need to be scaled uniformly, base off of width
-    const chartUsedHeight = uniformXYScale
+    const chartUsedHeight = _uniformXYScale
       ? _yRange / _xRange * chartUsedWidth
       : _height - margin.top - margin.bottom;
-    const usedHeight = uniformXYScale ? chartUsedHeight + margin.top + margin.bottom : _height;
+    const usedHeight = _uniformXYScale ? chartUsedHeight + margin.top + margin.bottom : _height;
     return { width: _width, height: usedHeight, chartWidth: chartUsedWidth, chartHeight: chartUsedHeight};
   };
 


### PR DESCRIPTION
The tephra wind graph was using the tick marks designed for the uniform scale graphs in the seismic unit.  This resulted in 0 tick marks along the y axis for the tephra wind graph.  Instead, check if graph specifies uniform scaling.  If it does, use the evenly spaced tick marks designed for the seismic graph.  If not, revert to the old method of generating tick marks.