### PR TITLE
Earthquakes

### DIFF
--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -82,6 +82,19 @@ const AuthoringMenu: React.SFC<IProps> = (props) => {
             <DatBoolean path="uiStore.showData" label="Show data?" key="showData" />
             <DatBoolean path="uiStore.showDeformation" label="Show deformation?" key="showDeformation" />
           </DatFolder>,
+
+          <DatFolder title="Deformation Model" key="deformationFolder" closed={false}>
+            <DatNumber path="seismicSimulation.deformationModelWidthKm" label="Model width (km)" key="deformationModelWidthKm"
+              min={0.1} max={100} step={0.1}/>
+            <DatBoolean path="seismicSimulation.deformationModelEnableEarthquakes" label="Enable earthquakes?" key="deformationModelEnableEarthquakes" />
+            <DatNumber path="seismicSimulation.deformationModelFrictionLow" label="Max displ. Low" key="deformationModelFrictionLow"
+              min={0.1} max={50} step={0.1}/>
+            <DatNumber path="seismicSimulation.deformationModelFrictionMedium" label="Max displ. Med" key="deformationModelFrictionMedium"
+              min={0.1} max={50} step={0.1}/>
+            <DatNumber path="seismicSimulation.deformationModelFrictionHigh" label="Max displ. High" key="deformationModelFrictionHigh"
+              min={0.1} max={50} step={0.1}/>
+            <DatBoolean path="seismicSimulation.deformationModelRainbowLines" label="Rainbow lines?" key="deformationModelRainbowLines" />
+          </DatFolder>,
         ]
       }
       {

--- a/src/components/deformation/deformation-model.tsx
+++ b/src/components/deformation/deformation-model.tsx
@@ -70,6 +70,9 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     const steps = 100;
     return this.modelWidth / steps;
   }
+  private get fadeOutTime() {
+    return this.stores.seismicSimulation.deformationModelEndStep / 10;
+  }
 
   public componentDidMount() {
     this.drawModel();
@@ -145,8 +148,8 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     const hSpeed = this.getRelativeHorizontalSpeed();
 
     // plates
-    if (year < 50000) {
-      const plateAlpha = initialPlateAlpha - (year / 50000) * initialPlateAlpha;
+    if (year < this.fadeOutTime) {
+      const plateAlpha = initialPlateAlpha - (year / this.fadeOutTime) * initialPlateAlpha;
       ctx.fillStyle = `rgba(255,58,58,${plateAlpha})`;
       ctx.beginPath();
       ctx.rect(modelMargin.left, modelMargin.top, this.modelWidth / 2, this.modelWidth + modelMargin.top);
@@ -217,9 +220,9 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     ctx.restore();
 
     // draw the fainter lines behind triangle that will fade
-    if (year < 50000) {
+    if (year < this.fadeOutTime) {
       ctx.save();
-      const alpha = 0.5 - (year / 50000) * 0.5;
+      const alpha = 0.5 - (year / this.fadeOutTime) * 0.5;
       ctx.lineWidth = 0.5;
       ctx.strokeStyle = `rgba(0,0,0,${alpha})`;
       horizontalLines.forEach(drawBzCurve);

--- a/src/components/deformation/deformation-model.tsx
+++ b/src/components/deformation/deformation-model.tsx
@@ -35,9 +35,6 @@ const stationBorderThickness = 2;
 const lineSpacing = 20;
 // should be in km
 const lockingDepth = 1;
-// for converting pixels to world distance
-// we want the area shown to be approx this size in each direction
-const distanceScale = 50;
 
 // angle between the plates vertically (into the Earth)
 const dip = deg2rad(90);
@@ -276,9 +273,10 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     ctx.fill();
 
     // Scale
+    const scaleKm = this.stores.seismicSimulation.deformationModelWidthKm / 10;
     ctx.lineWidth = 1;
-    const s1 = { x: modelMargin.left + this.modelWidth / 2 - this.worldToCanvas(5) - 10, y: modelMargin.top + 20 };
-    const s2 = { x: s1.x + this.worldToCanvas(5), y: s1.y };
+    const s1 = { x: modelMargin.left + this.modelWidth / 2 - this.worldToCanvas(scaleKm) - 10, y: modelMargin.top + 20};
+    const s2 = { x: s1.x + this.worldToCanvas(scaleKm), y: s1.y };
     ctx.beginPath();
     ctx.moveTo(s1.x, s1.y);
     ctx.lineTo(s2.x, s2.y);
@@ -293,7 +291,8 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     ctx.textAlign = "start";
     ctx.fillStyle = textColor;
     ctx.font = "13px Lato";
-    ctx.fillText(`5km`, s1.x, s1.y + 20);
+    const distanceLabel = scaleKm >= 1 ? `${scaleKm}km` : `${scaleKm * 1000}m`;
+    ctx.fillText(distanceLabel, s1.x, s1.y + 20);
     ctx.stroke();
   }
 
@@ -423,18 +422,17 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     return totalDisplacement;
   }
 
+  // pixel position, starting from 0 (left or top) to km
   private canvasToWorld(canvasPosition: number) {
-    // screen size affects pixel scale
-    // distanceScale is how many real-world units we want to show across the pixel grid
-    return canvasPosition / this.modelWidth *  distanceScale;
+    return canvasPosition / this.modelWidth *  this.stores.seismicSimulation.deformationModelWidthKm;
   }
 
   // GPS stations are positioned as a percentage 0-1 across the model area
   private percentToWorld(distancePercentage: number) {
-    return distancePercentage * distanceScale;
+    return distancePercentage * this.stores.seismicSimulation.deformationModelWidthKm;
   }
-  private worldToCanvas(distanceInRealUnits: number) {
-    return distanceInRealUnits / distanceScale * this.modelWidth;
+  private worldToCanvas(distanceInKm: number) {
+    return distanceInKm / this.stores.seismicSimulation.deformationModelWidthKm * this.modelWidth;
   }
 
   // Visual representation of the plate velocities based on student values

--- a/src/components/deformation/deformation-model.tsx
+++ b/src/components/deformation/deformation-model.tsx
@@ -29,6 +29,9 @@ const drawAreaColor = "#fff";
 const textColor = "#434343";
 const stationColor = "#98E643";
 const faultColor = "#ff9300";
+const rainbowColor = [
+  "#9400D3", "#4B0082", "#0000FF", "#00FF00", "#FF7F00", "#FF0000"
+];
 const initialPlateAlpha = .07;
 const stationBorderThickness = 2;
 
@@ -136,7 +139,8 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     ctx.lineWidth = 1;
     ctx.strokeStyle = textColor;
 
-    const { deformationModelStep: year, deformationModelEnableEarthquakes } = this.stores.seismicSimulation;
+    const { deformationModelStep: year, deformationModelEnableEarthquakes,
+      deformationModelRainbowLines } = this.stores.seismicSimulation;
     const vSpeed = this.getRelativeVerticalSpeed();     // mm/yr
     const hSpeed = this.getRelativeHorizontalSpeed();
 
@@ -199,8 +203,14 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
 
     ctx.strokeStyle = lineColor;
     const drawBzCurve = this.bzCurve(ctx);
-    horizontalLines.forEach(drawBzCurve);
+    horizontalLines.forEach((line, i) => {
+      if (deformationModelRainbowLines) {
+        ctx.strokeStyle = rainbowColor[Math.floor(i / 2) % rainbowColor.length];
+      }
+      drawBzCurve(line);
+    });
 
+    ctx.strokeStyle = lineColor;
     verticalLines.forEach(line => {
       ctx.beginPath();
       ctx.moveTo(line[0].x, line[0].y);

--- a/src/components/deformation/deformation-model.tsx
+++ b/src/components/deformation/deformation-model.tsx
@@ -136,7 +136,7 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     ctx.lineWidth = 1;
     ctx.strokeStyle = textColor;
 
-    const { deformationModelStep: year } = this.stores.seismicSimulation;
+    const { deformationModelStep: year, deformationModelEnableEarthquakes } = this.stores.seismicSimulation;
     const vSpeed = this.getRelativeVerticalSpeed();     // mm/yr
     const hSpeed = this.getRelativeHorizontalSpeed();
 
@@ -252,6 +252,14 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     ctx.fillText(`Year ${year.toLocaleString()}`,
       modelMargin.left + this.modelWidth - 10, modelMargin.top + this.modelWidth - 10);
     ctx.stroke();
+
+    if (deformationModelEnableEarthquakes) {
+      const numEarthquakes = this.getEarthquakes(year, vSpeed).count;
+      ctx.textAlign = "start";
+      ctx.fillText(`Earthquakes: ${numEarthquakes}`,
+        modelMargin.left + 10, modelMargin.top + this.modelWidth - 10);
+      ctx.stroke();
+    }
 
     ctx.font = "15px Lato";
     ctx.fillText("Fault", modelMargin.left + this.modelWidth / 2 - 10, modelMargin.top + this.modelWidth - 10);

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -19,6 +19,8 @@ const deformationSite3 = [0.2, 0.6];
 
 export type ColorMethod = "logarithmic" | "equalInterval";
 
+export const Friction = types.enumeration("type", ["low", "medium", "high"]);
+
 export const SeismicSimulationStore = types
   .model("seismicSimulation", {
     scenario: "Seismic CA",
@@ -31,6 +33,12 @@ export const SeismicSimulationStore = types
     deformationModelTotalClockTime: 5,  // seconds
 
     deformationModelWidthKm: 50,    // km
+
+    deformationModelEnableEarthquakes: false,
+    deformationModelFrictionCategory: types.optional(Friction, "low"),
+    deformationModelFrictionLow: 5,     // total plate motion before earthquake (km)
+    deformationModelFrictionMedium: 10,
+    deformationModelFrictionHigh: 20,
 
     deformSpeedPlate1: 0,     // mm/yr
     deformDirPlate1: 0,       // º from N
@@ -53,6 +61,16 @@ export const SeismicSimulationStore = types
   .views((self) => ({
     get deformationModelSpeed() {
       return self.deformationModelEndStep / self.deformationModelTotalClockTime;
+    },
+    get deformationModelMaxDisplacementBeforeEarthquake() {
+      switch (self.deformationModelFrictionCategory) {
+        case "low":
+          return self.deformationModelFrictionLow;
+        case "medium":
+          return self.deformationModelFrictionMedium;
+        case "high":
+          return self.deformationModelFrictionHigh;
+      }
     }
   }))
   .actions((self) => ({

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -3,6 +3,7 @@ import { parseOfflineUNAVCOData } from "../utilities/unavco-data";
 import strainCalc, { StationData, StrainOutput } from "../strain";
 import { Filter, Range } from "./data-sets";
 import Delaunator from "delaunator";
+import { SeismicSimulationAuthorSettings, SeismicSimulationAuthorSettingsProps } from "./stores";
 
 const minLat = 32;
 const maxLat = 42;
@@ -75,6 +76,17 @@ export const SeismicSimulationStore = types
       }
     }
   }))
+  .actions((self) => {
+    return {
+      loadAuthorSettingsData: (data: SeismicSimulationAuthorSettings) => {
+        Object.keys(data).forEach((key: SeismicSimulationAuthorSettingsProps) => {
+          // annoying `as any ... as any` is needed because we're mixing bool and non-bool props, which combine to never
+          // see https://github.com/microsoft/TypeScript/issues/31663
+          (self[key] as any) = data[key] as any;
+        });
+      },
+    };
+  })
   .actions((self) => ({
     showGPSStations(stations: StationData[] | string) {
       self.visibleGPSStationIds.clear();

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -40,6 +40,8 @@ export const SeismicSimulationStore = types
     deformationModelFrictionMedium: 10,
     deformationModelFrictionHigh: 20,
 
+    deformationModelRainbowLines: false,
+
     deformSpeedPlate1: 0,     // mm/yr
     deformDirPlate1: 0,       // º from N
     deformSpeedPlate2: 0,

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -26,9 +26,9 @@ export const SeismicSimulationStore = types
     selectedGPSStationId: types.maybe(types.string),
     showVelocityArrows: false,
 
-    deformationModelStep: 0,            // year
-    deformationModelSpeed: 100000,      // years / second
-    deformationModelEndStep: 500000,
+    deformationModelStep: 0,
+    deformationModelEndStep: 500000,    // years
+    deformationModelTotalClockTime: 5,  // seconds
 
     deformSpeedPlate1: 0,     // mm/yr
     deformDirPlate1: 0,       // º from N
@@ -47,6 +47,11 @@ export const SeismicSimulationStore = types
   .volatile(self => ({
     delaunayTriangles: [] as number[][][],
     delaunayTriangleStrains: [] as number[],
+  }))
+  .views((self) => ({
+    get deformationModelSpeed() {
+      return self.deformationModelEndStep / self.deformationModelTotalClockTime;
+    }
   }))
   .actions((self) => ({
     showGPSStations(stations: StationData[] | string) {

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -30,6 +30,8 @@ export const SeismicSimulationStore = types
     deformationModelEndStep: 500000,    // years
     deformationModelTotalClockTime: 5,  // seconds
 
+    deformationModelWidthKm: 50,    // km
+
     deformSpeedPlate1: 0,     // mm/yr
     deformDirPlate1: 0,       // º from N
     deformSpeedPlate2: 0,

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -64,6 +64,22 @@ export type TephraSimulationAuthorSettings = {
 };
 
 // props settable from authoring menu
+const seismicSimulationAuthorSettingsProps = tuple(
+  "deformationModelWidthKm",
+  "deformationModelEnableEarthquakes",
+  "deformationModelFrictionLow",
+  "deformationModelFrictionMedium",
+  "deformationModelFrictionHigh",
+  "deformationModelRainbowLines"
+);
+
+export type SeismicSimulationAuthorSettingsProps = typeof seismicSimulationAuthorSettingsProps[number];
+
+export type SeismicSimulationAuthorSettings = {
+  [key in SeismicSimulationAuthorSettingsProps]?: any;
+};
+
+// props settable from authoring menu
 const blocklyAuthorSettingsProps = tuple(
   "toolbox",
   "initialCodeTitle",
@@ -117,13 +133,14 @@ export type UIAuthorSettings = {
 const pick = (keys: string[]) => (o: any) => keys.reduce((a, e) => ({ ...a, [e]: o[e] }), {});
 
 // returns a selection of the properties of the store
-function getStoreSubstate(blocklyStoreProps: string[], tephraSimulationProps: string[], uiProps: string[]) {
+function getStoreSubstate(blocklyStoreProps: string[], tephraSimulationProps: string[],
+                          seismicSimulationProps: string[], uiProps: string[]) {
   return (): IStoreish => {
     return {
       unit: { name: stores.unit.name },
       blocklyStore: pick(blocklyStoreProps)(blocklyStore),
       tephraSimulation: pick(tephraSimulationProps)(tephraSimulation),
-      seismicSimulation: {},      // nothing to save yet
+      seismicSimulation: pick(seismicSimulationProps)(seismicSimulation),
       uiStore: pick(uiProps)(uiStore)
     };
   };
@@ -131,13 +148,16 @@ function getStoreSubstate(blocklyStoreProps: string[], tephraSimulationProps: st
 
 // gets the current stores state in a version appropriate for the authoring menu
 export const getAuthorableSettings =
-  getStoreSubstate(blocklyAuthorSettingsProps, tephraSimulationAuthorSettingsProps, uiAuthorSettingsProps);
+  getStoreSubstate(blocklyAuthorSettingsProps, tephraSimulationAuthorSettingsProps,
+    seismicSimulationAuthorSettingsProps, uiAuthorSettingsProps);
 // gets the current store state to be saved by an author
 export const getSavableStateAuthor =
-  getStoreSubstate(blocklyAuthorStateProps, tephraSimulationAuthorStateProps, uiAuthorSettingsProps);
-  // gets the current store state to be saved by a student (the above, plus anything like run state or tab state)
+  getStoreSubstate(blocklyAuthorStateProps, tephraSimulationAuthorStateProps,
+    seismicSimulationAuthorSettingsProps, uiAuthorSettingsProps);
+// gets the current store state to be saved by a student (the above, plus anything like run state or tab state)
 export const getSavableStateStudent =
-getStoreSubstate(blocklyStudentStateProps, tephraSimulationAuthorStateProps, uiAuthorSettingsProps);
+  getStoreSubstate(blocklyStudentStateProps, tephraSimulationAuthorStateProps,
+    seismicSimulationAuthorSettingsProps, uiAuthorSettingsProps);
 
 // makes state appropriate for saving to e.g. LARA. Changes keys or values as needed. Adds a version number
 export const serializeState = (state: IStoreish): SerializedState => {
@@ -171,10 +191,13 @@ export function updateStores(state: IStoreish) {
     pick(blocklyAuthorStateProps)(state.blocklyStore);
   const tephraSimulationStoreSettings: TephraSimulationAuthorSettings =
     pick(tephraSimulationAuthorStateProps)(state.tephraSimulation);
+  const seismicSimulationStoreSettings: SeismicSimulationAuthorSettings =
+    pick(seismicSimulationAuthorSettingsProps)(state.seismicSimulation);
   const uiStoreSettings: UIAuthorSettings = pick(uiAuthorSettingsProps)(state.uiStore);
 
   unitStore.setUnit(state.unit.name);
   blocklyStore.loadAuthorSettingsData(blocklyStoreSettings);
   tephraSimulation.loadAuthorSettingsData(tephraSimulationStoreSettings);
+  seismicSimulation.loadAuthorSettingsData(seismicSimulationStoreSettings);
   uiStore.loadAuthorSettingsData(uiStoreSettings);
 }


### PR DESCRIPTION
This adds earthquakes to the deformation model.

The underlying math changes ended up being fairly simple (after lots of changes):

* If two plates move past each other by a combined distance of "max displacement" given a certain "friction" level, set the vertical (sheer) displacement of every point on the line to that same max displacement, and re-set the displacement due to strain to zero.

In order to show this correctly, the drawing of the horizontal lines needed to be broken into two, one for the left side and one for the right.

The final model looks like so when running:

![2021-08-22 23 21 34](https://user-images.githubusercontent.com/35721/130650402-7ae11af6-09aa-4bf9-9b30-5e9dfa212568.gif)

The remainder of the PR cleans up some underlying magic numbers by putting them in the model (both for clarity and for later authoring), adds authoring, and adds the ability to use rainbow lines.

The model can be run at https://geocode-app.concord.org/branch/earthquakes/index.html, by selecting Seismic from the authoring menu, enabling earthquakes, and bringing in a block such as below:

<img width="1134" alt="Screen Shot 2021-08-24 at 12 03 32 PM" src="https://user-images.githubusercontent.com/35721/130650838-f6db1c49-b464-474a-b454-a0e3c704eefc.png">
