### PR TITLE
Earthquakes (scaled)

### DIFF
--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -90,6 +90,7 @@ const AuthoringMenu: React.SFC<IProps> = (props) => {
               min={0.01} max={100} step={0.01}/>
             <DatNumber path="seismicSimulation.deformationModelApparentYearScaling" label="Apparent year scale" key="deformationModelApparentYearScaling"
               min={0.0001} max={1} step={0.0001}/>
+            <DatBoolean path="seismicSimulation.deformationModelShowYear" label="Show years?" key="deformationModelShowYear" />
             <DatBoolean path="seismicSimulation.deformationModelEnableEarthquakes" label="Enable earthquakes?" key="deformationModelEnableEarthquakes" />
             <DatNumber path="seismicSimulation.deformationModelFrictionLow" label="Max displ. Low friction" key="deformationModelFrictionLow"
               min={0.1} max={50} step={0.1}/>

--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -86,6 +86,8 @@ const AuthoringMenu: React.SFC<IProps> = (props) => {
           <DatFolder title="Deformation Model" key="deformationFolder" closed={false}>
             <DatNumber path="seismicSimulation.deformationModelWidthKm" label="Model width (km)" key="deformationModelWidthKm"
               min={0.1} max={100} step={0.1}/>
+            <DatNumber path="seismicSimulation.deformationModelApparentWidthKm" label="Apparent width (km)" key="deformationModelApparentWidthKm"
+              min={0.01} max={100} step={0.01}/>
             <DatBoolean path="seismicSimulation.deformationModelEnableEarthquakes" label="Enable earthquakes?" key="deformationModelEnableEarthquakes" />
             <DatNumber path="seismicSimulation.deformationModelFrictionLow" label="Max displ. Low" key="deformationModelFrictionLow"
               min={0.1} max={50} step={0.1}/>

--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -88,6 +88,8 @@ const AuthoringMenu: React.SFC<IProps> = (props) => {
               min={0.1} max={100} step={0.1}/>
             <DatNumber path="seismicSimulation.deformationModelApparentWidthKm" label="Apparent width (km)" key="deformationModelApparentWidthKm"
               min={0.01} max={100} step={0.01}/>
+            <DatNumber path="seismicSimulation.deformationModelApparentYearScaling" label="Apparent year scale" key="deformationModelApparentYearScaling"
+              min={0.0001} max={1} step={0.0001}/>
             <DatBoolean path="seismicSimulation.deformationModelEnableEarthquakes" label="Enable earthquakes?" key="deformationModelEnableEarthquakes" />
             <DatNumber path="seismicSimulation.deformationModelFrictionLow" label="Max displ. Low" key="deformationModelFrictionLow"
               min={0.1} max={50} step={0.1}/>

--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -91,11 +91,11 @@ const AuthoringMenu: React.SFC<IProps> = (props) => {
             <DatNumber path="seismicSimulation.deformationModelApparentYearScaling" label="Apparent year scale" key="deformationModelApparentYearScaling"
               min={0.0001} max={1} step={0.0001}/>
             <DatBoolean path="seismicSimulation.deformationModelEnableEarthquakes" label="Enable earthquakes?" key="deformationModelEnableEarthquakes" />
-            <DatNumber path="seismicSimulation.deformationModelFrictionLow" label="Max displ. Low" key="deformationModelFrictionLow"
+            <DatNumber path="seismicSimulation.deformationModelFrictionLow" label="Max displ. Low friction" key="deformationModelFrictionLow"
               min={0.1} max={50} step={0.1}/>
-            <DatNumber path="seismicSimulation.deformationModelFrictionMedium" label="Max displ. Med" key="deformationModelFrictionMedium"
+            <DatNumber path="seismicSimulation.deformationModelFrictionMedium" label="Max displ. Med friction" key="deformationModelFrictionMedium"
               min={0.1} max={50} step={0.1}/>
-            <DatNumber path="seismicSimulation.deformationModelFrictionHigh" label="Max displ. High" key="deformationModelFrictionHigh"
+            <DatNumber path="seismicSimulation.deformationModelFrictionHigh" label="Max displ. High friction" key="deformationModelFrictionHigh"
               min={0.1} max={50} step={0.1}/>
             <DatBoolean path="seismicSimulation.deformationModelRainbowLines" label="Rainbow lines?" key="deformationModelRainbowLines" />
           </DatFolder>,

--- a/src/components/deformation/deformation-model.tsx
+++ b/src/components/deformation/deformation-model.tsx
@@ -141,7 +141,7 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
 
     const { deformationModelStep: year, deformationModelEnableEarthquakes,
       deformationModelRainbowLines, deformationModelWidthKm,
-      deformationModelApparentWidthKm } = this.stores.seismicSimulation;
+      deformationModelApparentWidthKm, deformationModelApparentYearScaling } = this.stores.seismicSimulation;
     const vSpeed = this.getRelativeVerticalSpeed();     // mm/yr
     const hSpeed = this.getRelativeHorizontalSpeed();
 
@@ -260,7 +260,8 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     }
     ctx.font = "15px Lato";
     ctx.textAlign = "end";
-    ctx.fillText(`Year ${year.toLocaleString()}`,
+    const apparentYear = Math.round(year * deformationModelApparentYearScaling);
+    ctx.fillText(`Year ${apparentYear.toLocaleString()}`,
       modelMargin.left + this.modelWidth - 10, modelMargin.top + this.modelWidth - 10);
     ctx.stroke();
 

--- a/src/components/deformation/deformation-model.tsx
+++ b/src/components/deformation/deformation-model.tsx
@@ -140,7 +140,8 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     ctx.strokeStyle = textColor;
 
     const { deformationModelStep: year, deformationModelEnableEarthquakes,
-      deformationModelRainbowLines } = this.stores.seismicSimulation;
+      deformationModelRainbowLines, deformationModelWidthKm,
+      deformationModelApparentWidthKm } = this.stores.seismicSimulation;
     const vSpeed = this.getRelativeVerticalSpeed();     // mm/yr
     const hSpeed = this.getRelativeHorizontalSpeed();
 
@@ -287,7 +288,7 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     ctx.fill();
 
     // Scale
-    const scaleKm = this.stores.seismicSimulation.deformationModelWidthKm / 10;
+    const scaleKm = deformationModelWidthKm / 10;
     ctx.lineWidth = 1;
     const s1 = { x: modelMargin.left + this.modelWidth / 2 - this.worldToCanvas(scaleKm) - 10, y: modelMargin.top + 20};
     const s2 = { x: s1.x + this.worldToCanvas(scaleKm), y: s1.y };
@@ -305,7 +306,8 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     ctx.textAlign = "start";
     ctx.fillStyle = textColor;
     ctx.font = "13px Lato";
-    const distanceLabel = scaleKm >= 1 ? `${scaleKm}km` : `${scaleKm * 1000}m`;
+    const labelScaleKm = deformationModelApparentWidthKm / 10;
+    const distanceLabel = labelScaleKm >= 1 ? `${labelScaleKm}km` : `${labelScaleKm * 1000}m`;
     ctx.fillText(distanceLabel, s1.x, s1.y + 20);
     ctx.stroke();
   }

--- a/src/components/deformation/deformation-model.tsx
+++ b/src/components/deformation/deformation-model.tsx
@@ -141,7 +141,8 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
 
     const { deformationModelStep: year, deformationModelEnableEarthquakes,
       deformationModelRainbowLines, deformationModelWidthKm,
-      deformationModelApparentWidthKm, deformationModelApparentYearScaling } = this.stores.seismicSimulation;
+      deformationModelApparentWidthKm, deformationModelApparentYearScaling,
+      deformationModelShowYear } = this.stores.seismicSimulation;
     const vSpeed = this.getRelativeVerticalSpeed();     // mm/yr
     const hSpeed = this.getRelativeHorizontalSpeed();
 
@@ -258,12 +259,14 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
       const textPositionAdjust = stationPoints[i].x < this.modelWidth / 2 ? -10 : 10;
       ctx.fillText(`Station ${i + 1}`, stationPoints[i].x + textPositionAdjust, stationPoints[i].y + 5);
     }
-    ctx.font = "15px Lato";
-    ctx.textAlign = "end";
-    const apparentYear = Math.round(year * deformationModelApparentYearScaling);
-    ctx.fillText(`Year ${apparentYear.toLocaleString()}`,
-      modelMargin.left + this.modelWidth - 10, modelMargin.top + this.modelWidth - 10);
-    ctx.stroke();
+    if (deformationModelShowYear) {
+      ctx.font = "15px Lato";
+      ctx.textAlign = "end";
+      const apparentYear = Math.round(year * deformationModelApparentYearScaling);
+      ctx.fillText(`Year ${apparentYear.toLocaleString()}`,
+        modelMargin.left + this.modelWidth - 10, modelMargin.top + this.modelWidth - 10);
+      ctx.stroke();
+    }
 
     if (deformationModelEnableEarthquakes) {
       const numEarthquakes = this.getEarthquakes(year, vSpeed).count;
@@ -274,6 +277,7 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     }
 
     ctx.font = "15px Lato";
+    ctx.textAlign = "end";
     ctx.fillText("Fault", modelMargin.left + this.modelWidth / 2 - 10, modelMargin.top + this.modelWidth - 10);
 
     // station dots

--- a/src/css/dat-gui.css
+++ b/src/css/dat-gui.css
@@ -11,3 +11,15 @@
 .react-dat-gui .cr .label-text {
   width: 55%;
 }
+
+.react-dat-gui .number .label-text {
+  width: 45%!important;
+}
+
+.react-dat-gui .number .slider {
+  width: 25%!important;
+}
+
+.react-dat-gui .number input {
+  width: 30%!important;
+}

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -46,6 +46,7 @@ export const SeismicSimulationStore = types
 
     deformationModelApparentYearScaling: 1,   // changes the visible value for years passed, and when students step
                                               // through years manually with blocks
+    deformationModelShowYear: true,
 
     deformSpeedPlate1: 0,     // mm/yr
     deformDirPlate1: 0,       // º from N

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -34,6 +34,7 @@ export const SeismicSimulationStore = types
     deformationModelTotalClockTime: 5,  // seconds
 
     deformationModelWidthKm: 50,    // km
+    deformationModelApparentWidthKm: 50,    // model width as indicated by the scale marker (km)
 
     deformationModelEnableEarthquakes: false,
     deformationModelFrictionCategory: types.optional(Friction, "low"),

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -44,6 +44,9 @@ export const SeismicSimulationStore = types
 
     deformationModelRainbowLines: false,
 
+    deformationModelApparentYearScaling: 1,   // changes the visible value for years passed, and when students step
+                                              // through years manually with blocks
+
     deformSpeedPlate1: 0,     // mm/yr
     deformDirPlate1: 0,       // º from N
     deformSpeedPlate2: 0,

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -73,6 +73,7 @@ const seismicSimulationAuthorSettingsProps = tuple(
   "deformationModelFrictionHigh",
   "deformationModelRainbowLines",
   "deformationModelApparentYearScaling",
+  "deformationModelShowYear",
 );
 
 export type SeismicSimulationAuthorSettingsProps = typeof seismicSimulationAuthorSettingsProps[number];

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -71,7 +71,8 @@ const seismicSimulationAuthorSettingsProps = tuple(
   "deformationModelFrictionLow",
   "deformationModelFrictionMedium",
   "deformationModelFrictionHigh",
-  "deformationModelRainbowLines"
+  "deformationModelRainbowLines",
+  "deformationModelApparentYearScaling",
 );
 
 export type SeismicSimulationAuthorSettingsProps = typeof seismicSimulationAuthorSettingsProps[number];

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -66,6 +66,7 @@ export type TephraSimulationAuthorSettings = {
 // props settable from authoring menu
 const seismicSimulationAuthorSettingsProps = tuple(
   "deformationModelWidthKm",
+  "deformationModelApparentWidthKm",
   "deformationModelEnableEarthquakes",
   "deformationModelFrictionLow",
   "deformationModelFrictionMedium",


### PR DESCRIPTION
This adds some scaling options to the model, such that the model author can pretend the width of the model is different from what it actually is, and the time scale is different.

One way to play with it is to set up a model such as in #255, run it, and then after it has run change

* The actual width of the model
* The apparent width of the mode
* The apparent year scaling

The first option will change the curvature of the lines and the shape of the triangle, as the actual simulation will have been run closer to or further from the fault line. The second two options will only change the scale label and the year label.

The year scaling will also come into play when users can step through the model year by year in code.

This also adds the ability to hide the year label altogether.

https://geocode-app.concord.org/branch/earthquakes-scaled/index.html