### PR TITLE
Deformation blocks

### DIFF
--- a/src/assets/blockly-authoring/index.json
+++ b/src/assets/blockly-authoring/index.json
@@ -10,7 +10,8 @@
     "All Seismic": "./assets/blockly-authoring/toolbox/seismic-toolbox.xml",
     "Seismic: GPS": "./assets/blockly-authoring/toolbox/seismic-gps-toolbox.xml",
     "Seismic: GPS & Graph": "./assets/blockly-authoring/toolbox/seismic-gps-graph-toolbox.xml",
-    "Seismic: GPS & Deformation": "./assets/blockly-authoring/toolbox/seismic-gps-deformation-toolbox.xml"
+    "Seismic: GPS & Deformation": "./assets/blockly-authoring/toolbox/seismic-gps-deformation-toolbox.xml",
+    "Seismic: GPS & Earthquakes": "./assets/blockly-authoring/toolbox/seismic-gps-deformation-earthquakes-toolbox.xml"
   },
   "code": {
     "Basic": "./assets/blockly-authoring/code/basic-setup.xml",
@@ -33,6 +34,7 @@
     "All Seismic",
     "Seismic: GPS",
     "Seismic: GPS & Graph",
-    "Seismic: GPS & Deformation"
+    "Seismic: GPS & Deformation",
+    "Seismic: GPS & Earthquakes"
   ]
 }

--- a/src/assets/blockly-authoring/toolbox/seismic-gps-deformation-earthquakes-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/seismic-gps-deformation-earthquakes-toolbox.xml
@@ -8,7 +8,16 @@
   </category>
 
   <category name="Deformation" colour="15">
-    <block type="deformation-create-sim"></block>
+    <block type="deformation-year-loop"></block>
+    <block type="deformation-model-step"></block>
+    <block type="deformation-model-earthquake"></block>
+    <block type="deformation-model-get-deformation"></block>
+    <block type="deformation-model-get-max-deformation"></block>
+  </category>
+
+  <category name="Logic" colour="%{BKY_LOGIC_HUE}">
+    <block type="controls_if"></block>
+    <block type="value-logic-compare"></block>
   </category>
 
   <category name="Data" colour="130">

--- a/src/assets/blockly-authoring/toolbox/seismic-gps-deformation-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/seismic-gps-deformation-toolbox.xml
@@ -9,6 +9,8 @@
 
   <category name="Deformation" colour="15">
     <block type="deformation-create-sim"></block>
+    <block type="deformation-year-loop"></block>
+    <block type="deformation-model-step"></block>
   </category>
 
   <category name="Data" colour="130">

--- a/src/assets/blockly-authoring/toolbox/seismic-gps-deformation-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/seismic-gps-deformation-toolbox.xml
@@ -12,6 +12,13 @@
     <block type="deformation-year-loop"></block>
     <block type="deformation-model-step"></block>
     <block type="deformation-model-earthquake"></block>
+    <block type="deformation-model-get-deformation"></block>
+    <block type="deformation-model-get-max-deformation"></block>
+  </category>
+
+  <category name="Logic" colour="%{BKY_LOGIC_HUE}">
+    <block type="controls_if"></block>
+    <block type="value-logic-compare"></block>
   </category>
 
   <category name="Data" colour="130">

--- a/src/assets/blockly-authoring/toolbox/seismic-gps-deformation-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/seismic-gps-deformation-toolbox.xml
@@ -11,6 +11,7 @@
     <block type="deformation-create-sim"></block>
     <block type="deformation-year-loop"></block>
     <block type="deformation-model-step"></block>
+    <block type="deformation-model-earthquake"></block>
   </category>
 
   <category name="Data" colour="130">

--- a/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
@@ -14,6 +14,8 @@
 
   <category name="Deformation" colour="15">
     <block type="deformation-create-sim"></block>
+    <block type="deformation-year-loop"></block>
+    <block type="deformation-model-step"></block>
   </category>
 
   <category name="Data" colour="130">

--- a/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
@@ -16,6 +16,7 @@
     <block type="deformation-create-sim"></block>
     <block type="deformation-year-loop"></block>
     <block type="deformation-model-step"></block>
+    <block type="deformation-model-earthquake"></block>
   </category>
 
   <category name="Data" colour="130">

--- a/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
@@ -17,6 +17,13 @@
     <block type="deformation-year-loop"></block>
     <block type="deformation-model-step"></block>
     <block type="deformation-model-earthquake"></block>
+    <block type="deformation-model-get-deformation"></block>
+    <block type="deformation-model-get-max-deformation"></block>
+  </category>
+
+  <category name="Logic" colour="%{BKY_LOGIC_HUE}">
+    <block type="controls_if"></block>
+    <block type="value-logic-compare"></block>
   </category>
 
   <category name="Data" colour="130">

--- a/src/blockly-blocks/block-value-logic-compare.js
+++ b/src/blockly-blocks/block-value-logic-compare.js
@@ -1,0 +1,51 @@
+// This is another version of the built-in logic_compare block which allows us to pass in blocks that return code.
+// The value_compare block doesn't handle this well, because of the way our interpreter wraps the results of
+// code blocks.
+// Using the value-logic-compare block we can compare any block with the output "Number", and any pure number, and
+// mix-and-match as desired.
+
+Blockly.Blocks['value-logic-compare'] = {
+  init: function() {
+    this.appendValueInput("x")
+        .setCheck("Number")
+        .setAlign(Blockly.ALIGN_RIGHT);
+    this.appendDummyInput()
+        .appendField(new Blockly.FieldDropdown([
+          ["=", "equals"],
+          ["\u2260", "notEquals"],
+          ["<", "lessThan"],
+          ["\u2264", "lessThanOrEqual"],
+          [">", "greaterThan"],
+          ["\u2265", "greaterThanOrEqual"]]), "OP");
+    this.appendValueInput("y")
+        .setCheck("Number")
+        .setAlign(Blockly.ALIGN_RIGHT);
+    this.setInputsInline(true);
+
+    this.setOutput(true, 'Boolean');
+    this.setColour("%{BKY_LOGIC_HUE}");
+ this.setTooltip("");
+ this.setHelpUrl("");
+  }
+};
+
+Blockly.JavaScript['value-logic-compare'] = function(block) {
+  let x;
+  let y;
+  try {
+    x = Blockly.JavaScript.statementToCode(block, 'x');
+  } catch (e) {
+    x = Blockly.JavaScript.valueToCode(block, 'x', Blockly.JavaScript.ORDER_ATOMIC) || null;
+  }
+  try {
+    y = Blockly.JavaScript.statementToCode(block, 'y');
+  } catch (e) {
+    y = Blockly.JavaScript.valueToCode(block, 'y', Blockly.JavaScript.ORDER_ATOMIC) || null;
+  }
+
+  if (x === undefined || x === null || x === "") x = "null";
+  if (y === undefined || y === null || y === "") y= "null";
+  var operation = block.getFieldValue('OP');
+  var code = `${operation}({left: ${x}, right: ${y}})`;
+return [code, Blockly.JavaScript.ORDER_NONE];
+};

--- a/src/blockly-blocks/blocks.js
+++ b/src/blockly-blocks/blocks.js
@@ -6,6 +6,7 @@ import "./block-console-logger";
 import "./block-logprint";
 import "./block-stringconcat";
 import "./block-clear";
+import "./block-value-logic-compare";
 import "./tephra/block-add-volcano";
 import "./block-add-town";
 import "./tephra/block-set-wind-direction";

--- a/src/blockly-blocks/deformation/block-deformation-create-sim.js
+++ b/src/blockly-blocks/deformation/block-deformation-create-sim.js
@@ -38,3 +38,68 @@ Blockly.Blocks['deformation-create-sim'] = {
     code +='runDeformationModel();\n';
     return code;
   }
+
+  Blockly.Blocks['deformation-year-loop'] = {
+    init: function() {
+      this.appendDummyInput()
+          .appendField("Count with Years from 0 to ")
+          .appendField(new Blockly.FieldNumber(500, 0, 500000), "max_year")
+          .appendField("by")
+          .appendField(new Blockly.FieldDropdown([["1","1"], ["10","10"], ["20","20"]]), "year_step");
+      this.appendStatementInput("DO")
+          .setCheck(null);
+      this.setPreviousStatement(false, null);
+      this.setNextStatement(false, null);
+      this.setColour("%{BKY_LOOPS_HUE}");
+   this.setTooltip("Step through deformation model for a given number of years, with a given step size");
+   this.setHelpUrl("");
+    }
+  };
+
+  Blockly.JavaScript['deformation-year-loop'] = function(block) {
+    var number_max_year = block.getFieldValue('max_year');
+    var dropdown_year_step = block.getFieldValue('year_step');
+    var branch = Blockly.JavaScript.statementToCode(block, 'DO');
+
+    var code = '';
+
+    code += 'for (var year = ' + dropdown_year_step + '; ' +
+        'year <= ' + number_max_year + '; ' +
+        'year += ' + dropdown_year_step + ') {\n' +
+        branch +
+        '}\n';
+    return code;
+  };
+
+  Blockly.Blocks['deformation-model-step'] = {
+    init: function() {
+      this.appendDummyInput()
+          .appendField("Increase Deformation by deformation rate");
+      this.appendDummyInput()
+          .appendField("  calculated based on");
+      this.appendValueInput("speed1")
+          .setCheck("Number")
+          .setAlign(Blockly.ALIGN_RIGHT)
+          .appendField("Plate 1 speed");
+      this.appendValueInput("speed2")
+          .setCheck("Number")
+          .setAlign(Blockly.ALIGN_RIGHT)
+          .appendField("Plate 2 speed");
+      this.setPreviousStatement(true, null);
+      this.setNextStatement(true, null);
+      this.setColour(15);
+   this.setTooltip("");
+   this.setHelpUrl("");
+    }
+  };
+
+  Blockly.JavaScript['deformation-model-step'] = function(block) {
+    var value_speed1 = Blockly.JavaScript.valueToCode(block, 'speed1', Blockly.JavaScript.ORDER_ATOMIC) || 0;
+
+    var value_speed2 = Blockly.JavaScript.valueToCode(block, 'speed2', Blockly.JavaScript.ORDER_ATOMIC) || 0;
+
+    var code = `
+      stepDeformationModel({year: year, plate_1_speed: ${value_speed1}, plate_2_speed: ${value_speed2}});
+  `;
+  return code;
+  };

--- a/src/blockly-blocks/deformation/block-deformation-create-sim.js
+++ b/src/blockly-blocks/deformation/block-deformation-create-sim.js
@@ -124,3 +124,39 @@ Blockly.Blocks['deformation-create-sim'] = {
   `;
   return code;
   };
+
+  Blockly.Blocks['deformation-model-get-deformation'] = {
+    init: function() {
+      this.appendDummyInput()
+          .appendField("Deformation");
+      this.setOutput(true, 'Number');
+      this.setColour(15);
+   this.setTooltip("");
+   this.setHelpUrl("");
+    }
+  };
+
+  Blockly.JavaScript['deformation-model-get-deformation'] = function(block) {
+    var code = `getDeformation()`;
+  return [code, Blockly.JavaScript.ORDER_NONE];
+  };
+
+
+  Blockly.Blocks['deformation-model-get-max-deformation'] = {
+    init: function() {
+      this.appendDummyInput()
+          .appendField("Compute max deformation with")
+          .appendField(new Blockly.FieldDropdown([["low", "low"], ["medium", "medium"], ["high", "high"]]), "friction")
+          .appendField("friction");
+      this.setOutput(true, 'Number');
+      this.setColour(15);
+   this.setTooltip("");
+   this.setHelpUrl("");
+    }
+  };
+
+  Blockly.JavaScript['deformation-model-get-max-deformation'] = function(block) {
+    var friction = block.getFieldValue('friction');
+    var code = `getMaxDeformation("${friction}")`;
+  return [code, Blockly.JavaScript.ORDER_NONE];
+  };

--- a/src/blockly-blocks/deformation/block-deformation-create-sim.js
+++ b/src/blockly-blocks/deformation/block-deformation-create-sim.js
@@ -103,3 +103,24 @@ Blockly.Blocks['deformation-create-sim'] = {
   `;
   return code;
   };
+
+  Blockly.Blocks['deformation-model-earthquake'] = {
+    init: function() {
+      this.appendDummyInput()
+          .appendField("Trigger earthquake to release energy");
+      this.appendDummyInput()
+          .appendField("and set Deformation to 0");
+      this.setPreviousStatement(true, null);
+      this.setNextStatement(true, null);
+      this.setColour(15);
+   this.setTooltip("");
+   this.setHelpUrl("");
+    }
+  };
+
+  Blockly.JavaScript['deformation-model-earthquake'] = function(block) {
+    var code = `
+      triggerEarthquake();
+  `;
+  return code;
+  };

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -380,6 +380,10 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
       seismicSimulation.setApparentYear(params.year);
     });
 
+    addFunc("triggerEarthquake", () => {
+      seismicSimulation.triggerEarthquake();
+    });
+
     /** ==== Utility methods ==== */
 
     addFunc("log", (params) => {

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -400,6 +400,32 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
       return tephraSimulation.stringConcat(params.lv, params.rv);
     });
 
+    /** ==== value-equals allows us to feed in blocks with wrapped data outputs ==== */
+
+    addFunc("equals", (params: {left: any, right: any}) => {
+      return {toBoolean: () => params.left === params.right};
+    });
+
+    addFunc("notEquals", (params: {left: any, right: any}) => {
+      return {toBoolean: () => params.left !== params.right};
+    });
+
+    addFunc("greaterThan", (params: {left: any, right: any}) => {
+      return {toBoolean: () => params.left > params.right};
+    });
+
+    addFunc("greaterThanOrEqual", (params: {left: any, right: any}) => {
+      return {toBoolean: () => params.left >= params.right};
+    });
+
+    addFunc("lessThan", (params: {left: any, right: any}) => {
+      return {toBoolean: () => params.left < params.right};
+    });
+
+    addFunc("lessThanOrEqual", (params: {left: any, right: any}) => {
+      return {toBoolean: () => params.left <= params.right};
+    });
+
     /** ==== Used under the hood to control highlighting and stepping ==== */
 
     addFunc("startStep", (blockId: number) => {

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -373,6 +373,13 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
       }
       seismicSimulation.setPlateVelocity(params.plate, params.speed, params.direction);
     });
+
+    addFunc("stepDeformationModel", (params: { year: number, plate_1_speed: number, plate_2_speed: number }) => {
+      seismicSimulation.setPlateVelocity(1, params.plate_1_speed, 0);
+      seismicSimulation.setPlateVelocity(2, params.plate_2_speed, 180);
+      seismicSimulation.setApparentYear(params.year);
+    });
+
     /** ==== Utility methods ==== */
 
     addFunc("log", (params) => {

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -368,8 +368,8 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
     });
 
     addFunc("setPlateVelocity", (params: { plate: number, speed: number, direction: number }) => {
-      if (Math.abs(params.speed) > Math.abs(seismicSimulation.deformMaxSpeed)) {
-        return blocklyController.throwError(`Plate speed must be between ${-seismicSimulation.deformMaxSpeed} and ${seismicSimulation.deformMaxSpeed} mm/year`);
+      if (params.speed < 0 || params.speed > seismicSimulation.deformMaxSpeed) {
+        return blocklyController.throwError(`Plate speed must be between 0 and ${seismicSimulation.deformMaxSpeed} mm/year`);
       }
       seismicSimulation.setPlateVelocity(params.plate, params.speed, params.direction);
     });

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -384,6 +384,15 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
       seismicSimulation.triggerEarthquake();
     });
 
+    addFunc("getDeformation", () => {
+      const year = seismicSimulation.deformationModelStep - seismicSimulation.deformationModelUserEarthquakeLatestStep;
+      return {data: Math.abs(year * seismicSimulation.relativeVerticalSpeed) / 1e6};
+    });
+
+    addFunc("getMaxDeformation", (friction: "low" | "medium" | "high") => {
+      return {data: seismicSimulation.getDeformationModelMaxDisplacementBeforeEarthquakeGivenFriction(friction)};
+    });
+
     /** ==== Utility methods ==== */
 
     addFunc("log", (params) => {

--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -91,7 +91,6 @@ const AuthoringMenu: React.SFC<IProps> = (props) => {
             <DatNumber path="seismicSimulation.deformationModelApparentYearScaling" label="Apparent year scale" key="deformationModelApparentYearScaling"
               min={0.0001} max={1} step={0.0001}/>
             <DatBoolean path="seismicSimulation.deformationModelShowYear" label="Show years?" key="deformationModelShowYear" />
-            <DatBoolean path="seismicSimulation.deformationModelEnableEarthquakes" label="Enable earthquakes?" key="deformationModelEnableEarthquakes" />
             <DatNumber path="seismicSimulation.deformationModelFrictionLow" label="Max displ. Low friction" key="deformationModelFrictionLow"
               min={0.1} max={50} step={0.1}/>
             <DatNumber path="seismicSimulation.deformationModelFrictionMedium" label="Max displ. Med friction" key="deformationModelFrictionMedium"
@@ -100,6 +99,8 @@ const AuthoringMenu: React.SFC<IProps> = (props) => {
               min={0.1} max={50} step={0.1}/>
             <DatBoolean path="seismicSimulation.deformationModelRainbowLines" label="Rainbow lines?" key="deformationModelRainbowLines" />
           </DatFolder>,
+          <DatSelect path="seismicSimulation.deformationModelEarthquakeControl" label="Earthquakes"
+            options={["none", "auto", "user"]} key="deformationModelEarthquakeControl" />,
 
           <DatBoolean path="uiStore.showSpeedControls" label="Show Speed Controls?" key="showSpeedControls" />,
         ]

--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -100,6 +100,8 @@ const AuthoringMenu: React.SFC<IProps> = (props) => {
               min={0.1} max={50} step={0.1}/>
             <DatBoolean path="seismicSimulation.deformationModelRainbowLines" label="Rainbow lines?" key="deformationModelRainbowLines" />
           </DatFolder>,
+
+          <DatBoolean path="uiStore.showSpeedControls" label="Show Speed Controls?" key="showSpeedControls" />,
         ]
       }
       {

--- a/src/components/deformation/deformation-model.tsx
+++ b/src/components/deformation/deformation-model.tsx
@@ -144,9 +144,8 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     const { deformationModelStep: year, deformationModelEarthquakesEnabled,
       deformationModelRainbowLines, deformationModelWidthKm,
       deformationModelApparentWidthKm, deformationModelApparentYearScaling,
-      deformationModelShowYear } = this.stores.seismicSimulation;
-    const vSpeed = this.getRelativeVerticalSpeed();     // mm/yr
-    const hSpeed = this.getRelativeHorizontalSpeed();
+      deformationModelShowYear, relativeVerticalSpeed: vSpeed,
+      relativeHorizontalSpeed: hSpeed } = this.stores.seismicSimulation;
 
     // plates
     if (year < this.fadeOutTime) {
@@ -317,28 +316,6 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     const distanceLabel = labelScaleKm >= 1 ? `${labelScaleKm}km` : `${labelScaleKm * 1000}m`;
     ctx.fillText(distanceLabel, s1.x, s1.y + 20);
     ctx.stroke();
-  }
-
-  private getRelativeVerticalSpeed() {
-    const { deformSpeedPlate1, deformDirPlate1, deformSpeedPlate2, deformDirPlate2 } =
-      this.stores.seismicSimulation;
-
-    const plate1VerticalSpeed = Math.cos(deg2rad(deformDirPlate1)) * deformSpeedPlate1;
-    const plate2VerticalSpeed = Math.cos(deg2rad(deformDirPlate2)) * deformSpeedPlate2;
-
-    const relativeSpeed = plate1VerticalSpeed - plate2VerticalSpeed;
-    return relativeSpeed;
-  }
-
-  private getRelativeHorizontalSpeed() {
-    const { deformSpeedPlate1, deformDirPlate1, deformSpeedPlate2, deformDirPlate2 } =
-      this.stores.seismicSimulation;
-
-    const plate1HorizontalSpeed = Math.sin(deg2rad(deformDirPlate1)) * deformSpeedPlate1;
-    const plate2HorizontalSpeed = Math.sin(deg2rad(deformDirPlate2)) * deformSpeedPlate2;
-
-    const relativeSpeed = plate1HorizontalSpeed - plate2HorizontalSpeed;
-    return relativeSpeed;
   }
 
   // returns two lines, one on either side of the center line, so we can have clean breaks

--- a/src/components/deformation/deformation-model.tsx
+++ b/src/components/deformation/deformation-model.tsx
@@ -565,7 +565,7 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
       };
     } else if (deformationModelEarthquakeControl === "user") {
       // for user-defined earthquakes, the model maintains the count of earthquakes and the year of the last one.
-      // we just need to calculate the distanced the plates had traveled at the last earthquake
+      // we just need to calculate the distance the plates had traveled at the last earthquake
       const absSpeed = Math.abs(vSpeed);
       const distanceTravelledDueToEarthquakes = absSpeed * deformationModelUserEarthquakeLatestStep / 3e6;
       return {

--- a/src/components/deformation/deformation-model.tsx
+++ b/src/components/deformation/deformation-model.tsx
@@ -139,7 +139,7 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     ctx.lineWidth = 1;
     ctx.strokeStyle = textColor;
 
-    const { deformationModelStep: year, deformationModelEnableEarthquakes,
+    const { deformationModelStep: year, deformationModelEarthquakesEnabled,
       deformationModelRainbowLines, deformationModelWidthKm,
       deformationModelApparentWidthKm, deformationModelApparentYearScaling,
       deformationModelShowYear } = this.stores.seismicSimulation;
@@ -268,7 +268,7 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
       ctx.stroke();
     }
 
-    if (deformationModelEnableEarthquakes) {
+    if (deformationModelEarthquakesEnabled) {
       const numEarthquakes = this.getEarthquakes(year, vSpeed).count;
       ctx.textAlign = "start";
       ctx.fillText(`Earthquakes: ${numEarthquakes}`,
@@ -424,7 +424,7 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
   private calculateVerticalDisplacement(px: number, vSpeed: number, year: number) {
     let distanceTravelledDueToEarthquakes = 0;
     let yearsSinceEarthquake = year;
-    if (this.stores.seismicSimulation.deformationModelEnableEarthquakes) {
+    if (this.stores.seismicSimulation.deformationModelEarthquakesEnabled) {
       const earthquakes = this.getEarthquakes(year, vSpeed);
       const direction = px > 0 ? -1 : 1;
       distanceTravelledDueToEarthquakes = earthquakes.distanceTravelledDueToEarthquakes * direction;

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -43,6 +43,9 @@ export const SeismicSimulationStore = types
     deformationModelFrictionMedium: 10,
     deformationModelFrictionHigh: 20,
 
+    deformationModelUserEarthquakeCount: 0,
+    deformationModelUserEarthquakeLatestStep: 0,
+
     deformationModelRainbowLines: false,
     deformationModelShowYear: true,
 
@@ -113,6 +116,8 @@ export const SeismicSimulationStore = types
     },
     resetDeformationModel() {
       self.deformationModelStep = 0;
+      self.deformationModelUserEarthquakeCount = 0;
+      self.deformationModelUserEarthquakeLatestStep = 0;
     },
     setShowVelocityArrows(show: boolean) {
       self.showVelocityArrows = show;
@@ -244,6 +249,8 @@ export const SeismicSimulationStore = types
       self.selectedGPSStationId = undefined;
       self.showVelocityArrows = false;
       self.deformationModelStep = 0;
+      self.deformationModelUserEarthquakeCount = 0;
+      self.deformationModelUserEarthquakeLatestStep = 0;
       self.strainMapMinLat = -90;
       self.strainMapMinLng = -180;
       self.strainMapMaxLat = 90;
@@ -284,6 +291,13 @@ export const SeismicSimulationStore = types
     setApparentYear(year: number) {
       self.setDeformationStep(year / self.deformationModelApparentYearScaling);
     },
+    triggerEarthquake() {
+      if (self.deformationModelEarthquakeControl !== "user") {
+        return;
+      }
+      self.deformationModelUserEarthquakeCount++;
+      self.deformationModelUserEarthquakeLatestStep = self.deformationModelStep;
+    }
   }))
   .views((self) => ({
     get allGPSStations() {

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -316,7 +316,17 @@ export const SeismicSimulationStore = types
       }
       self.deformationModelUserEarthquakeCount++;
       self.deformationModelUserEarthquakeLatestStep = self.deformationModelStep;
-    }
+    },
+    getDeformationModelMaxDisplacementBeforeEarthquakeGivenFriction(friction: "low" | "medium" | "high") {
+      switch (friction) {
+        case "low":
+          return self.deformationModelFrictionLow;
+        case "medium":
+          return self.deformationModelFrictionMedium;
+        case "high":
+          return self.deformationModelFrictionHigh;
+      }
+    },
   }))
   .views((self) => ({
     get allGPSStations() {

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -21,6 +21,7 @@ const deformationSite3 = [0.2, 0.6];
 export type ColorMethod = "logarithmic" | "equalInterval";
 
 export const Friction = types.enumeration("type", ["low", "medium", "high"]);
+export const EarthquakeControl = types.enumeration("type", ["none", "auto", "user"]);
 
 export const SeismicSimulationStore = types
   .model("seismicSimulation", {
@@ -36,7 +37,7 @@ export const SeismicSimulationStore = types
     deformationModelWidthKm: 50,    // km
     deformationModelApparentWidthKm: 50,    // model width as indicated by the scale marker (km)
 
-    deformationModelEnableEarthquakes: false,
+    deformationModelEarthquakeControl: types.optional(EarthquakeControl, "none"),
     deformationModelFrictionCategory: types.optional(Friction, "low"),
     deformationModelFrictionLow: 5,     // total plate motion before earthquake (km)
     deformationModelFrictionMedium: 10,
@@ -79,6 +80,9 @@ export const SeismicSimulationStore = types
         case "high":
           return self.deformationModelFrictionHigh;
       }
+    },
+    get deformationModelEarthquakesEnabled() {
+      return self.deformationModelEarthquakeControl === "auto" || self.deformationModelEarthquakeControl === "user";
     }
   }))
   .actions((self) => {

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -4,6 +4,7 @@ import strainCalc, { StationData, StrainOutput } from "../strain";
 import { Filter, Range } from "./data-sets";
 import Delaunator from "delaunator";
 import { SeismicSimulationAuthorSettings, SeismicSimulationAuthorSettingsProps } from "./stores";
+import { deg2rad } from "../utilities/coordinateSpaceConversion";
 
 const minLat = 32;
 const maxLat = 42;
@@ -86,7 +87,25 @@ export const SeismicSimulationStore = types
     },
     get deformationModelEarthquakesEnabled() {
       return self.deformationModelEarthquakeControl === "auto" || self.deformationModelEarthquakeControl === "user";
-    }
+    },
+    get relativeVerticalSpeed() {   // mm/yr
+      const { deformSpeedPlate1, deformDirPlate1, deformSpeedPlate2, deformDirPlate2 } = this;
+
+      const plate1VerticalSpeed = Math.cos(deg2rad(deformDirPlate1)) * deformSpeedPlate1;
+      const plate2VerticalSpeed = Math.cos(deg2rad(deformDirPlate2)) * deformSpeedPlate2;
+
+      const relativeSpeed = plate1VerticalSpeed - plate2VerticalSpeed;
+      return relativeSpeed;
+    },
+    get relativeHorizontalSpeed() {   // mm/yr
+      const { deformSpeedPlate1, deformDirPlate1, deformSpeedPlate2, deformDirPlate2 } = this;
+
+      const plate1HorizontalSpeed = Math.sin(deg2rad(deformDirPlate1)) * deformSpeedPlate1;
+      const plate2HorizontalSpeed = Math.sin(deg2rad(deformDirPlate2)) * deformSpeedPlate2;
+
+      const relativeSpeed = plate1HorizontalSpeed - plate2HorizontalSpeed;
+      return relativeSpeed;
+    },
   }))
   .actions((self) => {
     return {

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -43,10 +43,10 @@ export const SeismicSimulationStore = types
     deformationModelFrictionHigh: 20,
 
     deformationModelRainbowLines: false,
-
-    deformationModelApparentYearScaling: 1,   // changes the visible value for years passed, and when students step
-                                              // through years manually with blocks
     deformationModelShowYear: true,
+
+    // changes the visible value for years passed, and when students step through years manually with blocks
+    deformationModelApparentYearScaling: 1,
 
     deformSpeedPlate1: 0,     // mm/yr
     deformDirPlate1: 0,       // º from N
@@ -105,11 +105,7 @@ export const SeismicSimulationStore = types
       self.selectedGPSStationId = id;
     },
     setDeformationStep(step: number) {
-      if (step > self.deformationModelEndStep) {
-        self.deformationModelStep = self.deformationModelEndStep;
-      } else {
-        self.deformationModelStep = step;
-      }
+      self.deformationModelStep = step;
     },
     resetDeformationModel() {
       self.deformationModelStep = 0;
@@ -260,7 +256,10 @@ export const SeismicSimulationStore = types
 
       const updateStep = () => {
         const dt = (window.performance.now() - startTime) / 1000;   // seconds since start
-        const step = Math.floor(dt * self.deformationModelSpeed);
+        let step = Math.floor(dt * self.deformationModelSpeed);
+        if (step > self.deformationModelEndStep) {
+          step = self.deformationModelEndStep;
+        }
         self.setDeformationStep(step);
         if (step < self.deformationModelEndStep) {
           window.requestAnimationFrame(updateStep);
@@ -270,7 +269,6 @@ export const SeismicSimulationStore = types
       window.requestAnimationFrame(updateStep);
     },
     setPlateVelocity(block: number, speed: number, direction: number) {
-      self.deformationModelStep = 0;
       if (block === 1) {
         self.deformSpeedPlate1 = speed;
         self.deformDirPlate1 = 180 - direction;
@@ -278,7 +276,10 @@ export const SeismicSimulationStore = types
         self.deformSpeedPlate2 = speed;
         self.deformDirPlate2 = 180 - direction;
       }
-    }
+    },
+    setApparentYear(year: number) {
+      self.setDeformationStep(year / self.deformationModelApparentYearScaling);
+    },
   }))
   .views((self) => ({
     get allGPSStations() {

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -67,7 +67,7 @@ export type TephraSimulationAuthorSettings = {
 const seismicSimulationAuthorSettingsProps = tuple(
   "deformationModelWidthKm",
   "deformationModelApparentWidthKm",
-  "deformationModelEnableEarthquakes",
+  "deformationModelEarthquakeControl",
   "deformationModelFrictionLow",
   "deformationModelFrictionMedium",
   "deformationModelFrictionHigh",


### PR DESCRIPTION
This adds the blockly code to set up a student-controlled deformation simulation with earthquakes.

This can be tested at https://geocode-app.concord.org/branch/deformation-blocks/index.html

To set this up:

1. Select unit Seismic and toolbox GPS & Earthquakes
2. Set the Apparent year scaling to 0.001 (you can type it in, though it sometimes takes a couple tries to put the decimal in the right place). This will make it so you see significant deformation at 500 years.
3. Set Earthquakes -> User
4. Add the speed control so the model runs faster. (If the speed control exists, the default starts at faster than if it doesn't exist).
5. Set up code as in the gif below:

![2021-08-30 16 37 46](https://user-images.githubusercontent.com/35721/131533254-fa9ab8c6-2a37-4387-b905-ff07c618fab5.gif)
