### PR TITLE
improve deformation block input values

### DIFF
--- a/src/blockly-blocks/deformation/block-deformation-create-sim.js
+++ b/src/blockly-blocks/deformation/block-deformation-create-sim.js
@@ -11,15 +11,17 @@ Blockly.Blocks['deformation-create-sim'] = {
       this.appendValueInput('direction1')
         .setAlign(Blockly.ALIGN_RIGHT)
         .appendField("direction (degrees)")
-        .setCheck(['Number'])
+        .setCheck(['Number', 'String'])
       this.appendDummyInput()
         .appendField("Set velocity of Plate 2 with")
       this.appendValueInput('speed2')
         .setAlign(Blockly.ALIGN_RIGHT)
         .appendField("speed (mm/yr)")
+        .setCheck(['Number'])
       this.appendValueInput('direction2')
         .setAlign(Blockly.ALIGN_RIGHT)
         .appendField("direction (degrees)")
+        .setCheck(['Number', 'String'])
       this.setColour(15)
       this.setPreviousStatement(false, null);
       this.setNextStatement(false, null);


### PR DESCRIPTION
This PR includes small improvements to the deformation block:
- speed field can only be a number block
- direction field can take number or string
- direction field can have value "North" or "South" which are converted to 0 and 180.
- show error message if invalid string is used in the direction field

This PR can be tested here:
https://geocode-app.concord.org/branch/deformation-block-updates/index.html