### PR TITLE
add URL params to set unit and authoring controls visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The goal of GeoCode is to get students exploring geological threats using
 the practice of programming. In this case, we are using Blockly to generate
-code that runs a simple tephra distribution model.
+code that runs a simple tephra distribution model and seismic activity model.
 
 Students change eruption parameters using [Blockly](https://developers.google.com/blockly/).
 
@@ -192,8 +192,12 @@ Inside of your `package.json` file:
 2. `cypress run --headed --no-exit` will open cypress test runner when tests begin to run, and it will remain open when tests are finished running.
 3. `cypress run --spec 'cypress/integration/examples/smoke-test.js'` will point to a smoke-test file rather than running all of the test files for a project.
 
+## URL Parameters
+- hide-model-options: when included, the model options authoring dialog in the upper-right is hidden.
+- unit={name}: configure application for {unit}. Unit name can currently be set to `Seismic` or `Tephra` (e.g., `unit=Seismic`). Values are case sensitive.
+
 ## License
 
-GeoCode  Projects are Copyright 2018 (c) by the Concord Consortium and is distributed under the [MIT license](http://www.opensource.org/licenses/MIT).
+GeoCode is Copyright 2018 (c) by the Concord Consortium and is distributed under the [MIT license](http://www.opensource.org/licenses/MIT).
 
 See license.md for the complete license text.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8744,6 +8744,11 @@
         }
       }
     },
+    "filter-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz",
+      "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
+    },
     "finalhandler": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -14430,11 +14435,12 @@
       "integrity": "sha1-kX/TG3N5tT/UQeU2r2R1UuAefp4="
     },
     "query-string": {
-      "version": "6.8.3",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.8.3.tgz",
-      "integrity": "sha512-llcxWccnyaWlODe7A9hRjkvdCKamEKTh+wH8ITdTc3OhchaqUZteiSCX/2ablWHVrkVIe04dntnaZJ7BdyW0lQ==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-7.0.1.tgz",
+      "integrity": "sha512-uIw3iRvHnk9to1blJCG3BTc+Ro56CBowJXKmNNAm3RulvPBzWLRqKSiiDk+IplJhsydwtuNMHi8UGQFcCLVfkA==",
       "requires": {
         "decode-uri-component": "^0.2.0",
+        "filter-obj": "^1.1.0",
         "split-on-first": "^1.0.0",
         "strict-uri-encode": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -156,7 +156,7 @@
     "mobx-state-tree": "^3.9.0",
     "pixi.js": "^4.8.7",
     "prop-types": "^15.7.2",
-    "query-string": "^6.2.0",
+    "query-string": "^7.0.1",
     "react": "^16.8.6",
     "react-compound-slider": "^2.0.0",
     "react-dat-gui": "^3.0.0",

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -7,11 +7,10 @@ import { LogComponent } from "./log-component";
 import { CrossSectionComponent } from "./crosssection/cross-section-component";
 import * as Scenarios from "./../assets/maps/scenarios.json";
 import * as BlocklyAuthoring from "./../assets/blockly-authoring/index.json";
-
 import BlocklyContainer from "./blockly-container";
 import styled from "styled-components";
 import { StyledButton } from "./buttons/styled-button";
-import { SectionTypes, RightSectionTypes, TabInfo, kTabInfo, kRightTabInfo,
+import { SectionTypes, RightSectionTypes, kTabInfo, kRightTabInfo,
          TabBack, Tab, Tabs, TabList, TabPanel, RightTabBack, BottomTab } from "./tabs";
 import { js_beautify } from "js-beautify";
 import SyntaxHighlighter from "react-syntax-highlighter";
@@ -29,9 +28,12 @@ import { BlocklyController } from "../blockly/blockly-controller";
 import { HistogramPanel } from "./montecarlo/histogram-panel";
 import { PlateMovementPanel } from "./deformation/plate-movement-panel";
 import { uiStore } from "../stores/ui-store";
+import { unitStore } from "../stores/unit-store";
+import { blocklyStore } from "../stores/blockly-store";
 import { GPSStationTable } from "./gps-station-table";
 import { DeformationModel } from "./deformation/deformation-model";
 import { UnitNameType } from "../stores/unit-store";
+import { queryValue, queryValueBoolean } from "../utilities/url-query";
 
 interface IProps extends IBaseProps {}
 
@@ -158,6 +160,19 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     this.state = initialState;
 
     this.blocklyController = new BlocklyController(this.stores);
+  }
+
+  public componentDidMount() {
+    const unit = queryValue("unit");
+    const hideModelOptions = queryValueBoolean("hide-model-options");
+    uiStore.setShowOptionsDialog(!hideModelOptions);
+    if (unit === "Tephra") {
+      blocklyStore.setToolbox(BlocklyAuthoring.tephraToolboxes[0]);
+      unitStore.setUnit(unit);
+    } else if (unit === "Seismic") {
+      blocklyStore.setToolbox(BlocklyAuthoring.seismicToolboxes[0]);
+      unitStore.setUnit(unit);
+    }
   }
 
   public render() {
@@ -653,7 +668,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
       authorMenuState.blocklyStore.toolbox = BlocklyAuthoring.seismicToolboxes[0];
     }
 
-    // the the authored state from the authoring menu overwrites local state
+    // the authored state from the authoring menu overwrites local state
     const mergedState = deepmerge(localState, authorMenuState);
     updateStores(mergedState);
   }

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -164,15 +164,17 @@ export class AppComponent extends BaseComponent<IProps, IState> {
 
   public componentDidMount() {
     const unit = queryValue("unit");
-    const hideModelOptions = queryValueBoolean("hide-model-options");
-    uiStore.setShowOptionsDialog(!hideModelOptions);
+    let hideModelOptions = queryValueBoolean("hide-model-options");
     if (unit === "Tephra") {
       blocklyStore.setToolbox(BlocklyAuthoring.tephraToolboxes[0]);
       unitStore.setUnit(unit);
+      hideModelOptions = true;
     } else if (unit === "Seismic") {
       blocklyStore.setToolbox(BlocklyAuthoring.seismicToolboxes[0]);
       unitStore.setUnit(unit);
+      hideModelOptions = true;
     }
+    uiStore.setShowOptionsDialog(!hideModelOptions);
   }
 
   public render() {

--- a/src/stores/blockly-store.ts
+++ b/src/stores/blockly-store.ts
@@ -16,6 +16,9 @@ export const BlocklyStore = types
     setInitialXmlCode(xmlCode: string) {
       self.initialXmlCode = xmlCode;
     },
+    setToolbox(newToolbox: string) {
+      self.toolbox = newToolbox;
+    }
   }))
   .actions((self) => {
     return {

--- a/src/utilities/url-query.ts
+++ b/src/utilities/url-query.ts
@@ -1,0 +1,42 @@
+const queryString = require("query-string");
+
+/**
+ * Simplifies query-string library by only returning `string | undefined`, instead
+ * of `string | string[] | null | undefined`.
+ * @param prop
+ */
+export const queryValue = (prop: string): string | undefined => {
+  const query = queryString.parse(window.location.search);
+  const val = query[prop];
+  if (!val) return;
+  if (Array.isArray(val)) {
+    throw new Error(`May only have one query parameter for ${prop}. Found: ${val}`);
+  }
+  return val;
+};
+
+/**
+ * returns `true` if prop is present, or has any value except "false"
+ */
+export const queryValueBoolean = (prop: string): boolean => {
+  const query = queryString.parse(window.location.search, {parseBooleans: true});
+  const val = query[prop];
+  if (val === false) return false;
+  // if prop is present, it will be `null`, which we will count as `true`
+  return val !== undefined;
+};
+
+/**
+ * Append or modify a query parameter value, by default using `replaceState` to update in place
+ * without a reload or history push, but optionally with a reload.
+ */
+export const setQueryValue = (prop: string, value: any, reload = false) => {
+  const parsed = queryString.parse(location.search);
+  parsed[prop] = value;
+  const newQueryString = queryString.stringify(parsed);
+  if (reload) {
+    location.search = queryString.stringify(parsed);
+  } else {
+    window.history.replaceState(null, "", "?" + newQueryString);
+  }
+};


### PR DESCRIPTION
This PR adds two URL parameters that can be used to configure the initial simulation state.
- `hide-model-options`: when included, the model options authoring dialog in the upper-right is hidden.
- `unit={name}`: when included we configure the application for the specified unit. Unit name can currently be set to `Seismic` or `Tephra` (e.g., `unit=Seismic`). Values are case sensitive.

This PR can be tested with the following URLs...

No URL params:
https://geocode-app.concord.org/branch/set-seismic-from-url/index.html

Hide the model options:
https://geocode-app.concord.org/branch/set-seismic-from-url/index.html?hide-model-options

Set the unit to Seismic:
https://geocode-app.concord.org/branch/set-seismic-from-url/index.html?unit=Seismic

Hide the model options AND set the unit to Seismic
https://geocode-app.concord.org/branch/set-seismic-from-url/index.html?hide-model-options&unit=Seismic


