### PR TITLE
Show error if plate speed is not in range on user block

### DIFF
--- a/src/blockly-blocks/deformation/block-deformation-create-sim.js
+++ b/src/blockly-blocks/deformation/block-deformation-create-sim.js
@@ -90,8 +90,8 @@ Blockly.Blocks['deformation-create-sim'] = {
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
       this.setColour(15);
-   this.setTooltip("");
-   this.setHelpUrl("");
+      this.setTooltip("");
+      this.setHelpUrl("");
     }
   };
 

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -390,6 +390,10 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
     });
 
     addFunc("stepDeformationModel", (params: { year: number, plate_1_speed: number, plate_2_speed: number }) => {
+      if (params.plate_1_speed < 0 || params.plate_1_speed > seismicSimulation.deformMaxSpeed ||
+          params.plate_2_speed < 0 || params.plate_2_speed > seismicSimulation.deformMaxSpeed) {
+        return blocklyController.throwError(`Plate speed must be between 0 and ${seismicSimulation.deformMaxSpeed} mm/year`);
+      }
       seismicSimulation.setPlateVelocity(1, params.plate_1_speed, 0);
       seismicSimulation.setPlateVelocity(2, params.plate_2_speed, 180);
       seismicSimulation.setApparentYear(params.year);


### PR DESCRIPTION
This PR enforces a plate speed range (currently 0 - 50) when the user runs using an Increase Deformation by Deformation Rate block.  If a user specified value is outside the range, an error message is shown.

Can be tested here:
https://geocode-app.concord.org/branch/deformation-speed-range/index.html

![image](https://user-images.githubusercontent.com/5126913/132518610-da9f7049-fc94-4151-a0df-63e06fe1dbc9.png)
