### PR TITLE
Update the apparent year scale default value to .001

### DIFF
--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -51,7 +51,7 @@ export const SeismicSimulationStore = types
     deformationModelShowYear: true,
 
     // changes the visible value for years passed, and when students step through years manually with blocks
-    deformationModelApparentYearScaling: 1,
+    deformationModelApparentYearScaling: .001,
 
     deformSpeedPlate1: 0,     // mm/yr
     deformDirPlate1: 0,       // º from N


### PR DESCRIPTION
This PR changes the apparent year scale default value in the seismic unit from 1 to .001.  This value is used by default in the model and in the authoring model options dialog where the user can change the value.

Can be tested here:
https://geocode-app.concord.org/branch/apparent-year-scale/index.html