### PR TITLE
update the apparent year scale to a default value if the earthquake mode changes

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -670,6 +670,15 @@ export class AppComponent extends BaseComponent<IProps, IState> {
       authorMenuState.blocklyStore.toolbox = BlocklyAuthoring.seismicToolboxes[0];
     }
 
+    // update the apparent year scale to a default value if the earthquake mode changes
+    const { deformationModelEarthquakeControl } = this.stores.seismicSimulation;
+    const authoringEarthquakeControl = authorMenuState.seismicSimulation.deformationModelEarthquakeControl;
+    if (authorMenuState.unit.name === "Seismic" && deformationModelEarthquakeControl !== authoringEarthquakeControl) {
+      authorMenuState.seismicSimulation.deformationModelApparentYearScaling = authoringEarthquakeControl === "user"
+        ? .001
+        : 1;
+    }
+
     // the authored state from the authoring menu overwrites local state
     const mergedState = deepmerge(localState, authorMenuState);
     updateStores(mergedState);

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -674,9 +674,8 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     const { deformationModelEarthquakeControl } = this.stores.seismicSimulation;
     const authoringEarthquakeControl = authorMenuState.seismicSimulation.deformationModelEarthquakeControl;
     if (authorMenuState.unit.name === "Seismic" && deformationModelEarthquakeControl !== authoringEarthquakeControl) {
-      authorMenuState.seismicSimulation.deformationModelApparentYearScaling = authoringEarthquakeControl === "user"
-        ? .001
-        : 1;
+        authorMenuState.seismicSimulation.deformationModelApparentYearScaling =
+          authoringEarthquakeControl === "user" ? .001 : 1;
     }
 
     // the authored state from the authoring menu overwrites local state


### PR DESCRIPTION
This PR implements an updated request to update the apparent year scale in the model options when the author changes the earthquake mode.  We snap to 1 if the mode changes to `none` or `auto` and .001 if the mode changes to `user`.

Can test here:
https://geocode-app.concord.org/branch/year-scale/index.html


![image](https://user-images.githubusercontent.com/5126913/133278824-55999f2f-1f55-4987-b0bb-245af144c929.png)
