### PR TITLE
Fault orientation

### DIFF
--- a/src/assets/blockly-authoring/toolbox/seismic-gps-deformation-earthquakes-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/seismic-gps-deformation-earthquakes-toolbox.xml
@@ -13,6 +13,7 @@
     <block type="deformation-model-earthquake"></block>
     <block type="deformation-model-get-deformation"></block>
     <block type="deformation-model-get-max-deformation"></block>
+    <block type="deformation-boundary-orientation"></block>
   </category>
 
   <category name="Logic" colour="%{BKY_LOGIC_HUE}">

--- a/src/assets/blockly-authoring/toolbox/seismic-gps-deformation-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/seismic-gps-deformation-toolbox.xml
@@ -9,6 +9,7 @@
 
   <category name="Deformation" colour="#B35F00">
     <block type="deformation-create-sim"></block>
+    <block type="deformation-boundary-orientation"></block>
   </category>
 
   <category name="Data" colour="%{BKY_MATH_HUE}">

--- a/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
@@ -19,6 +19,7 @@
     <block type="deformation-model-earthquake"></block>
     <block type="deformation-model-get-deformation"></block>
     <block type="deformation-model-get-max-deformation"></block>
+    <block type="deformation-boundary-orientation"></block>
   </category>
 
   <category name="Logic" colour="%{BKY_LOGIC_HUE}">

--- a/src/blockly-blocks/deformation/block-deformation-create-sim.js
+++ b/src/blockly-blocks/deformation/block-deformation-create-sim.js
@@ -23,8 +23,8 @@ Blockly.Blocks['deformation-create-sim'] = {
         .appendField("direction (degrees)")
         .setCheck(['Number', 'String'])
       this.setColour("#B35F00")
-      this.setPreviousStatement(false, null);
-      this.setNextStatement(false, null);
+      this.setPreviousStatement(true, null);
+      this.setNextStatement(true, null);
     }
   };
 
@@ -50,8 +50,8 @@ Blockly.Blocks['deformation-create-sim'] = {
           .appendField(new Blockly.FieldDropdown([["1","1"], ["10","10"], ["20","20"]]), "year_step");
       this.appendStatementInput("DO")
           .setCheck(null);
-      this.setPreviousStatement(false, null);
-      this.setNextStatement(false, null);
+      this.setPreviousStatement(true, null);
+      this.setNextStatement(true, null);
       this.setColour("#B35F00")
       this.setTooltip("Step through deformation model for a given number of years, with a given step size");
       this.setHelpUrl("");
@@ -162,3 +162,22 @@ Blockly.Blocks['deformation-create-sim'] = {
     var code = `getMaxDeformation("${friction}")`;
   return [code, Blockly.JavaScript.ORDER_NONE];
   };
+
+  Blockly.Blocks['deformation-boundary-orientation'] = {
+    init: function () {
+      this.appendValueInput('orientation')
+        .setAlign(Blockly.ALIGN_RIGHT)
+        .appendField("Set boundary orientation")
+        .setCheck(['Number'])
+      this.setColour("#B35F00")
+      this.setPreviousStatement(true, null);
+      this.setNextStatement(true, null);
+    }
+  };
+
+  Blockly.JavaScript['deformation-boundary-orientation'] = function(plate) {
+    var value_orientation = Blockly.JavaScript.valueToCode(plate, 'orientation', Blockly.JavaScript.ORDER_ATOMIC) || 0;
+
+    var code = `setBoundaryOrientation(${value_orientation});\n`;
+    return code;
+  }

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -412,6 +412,10 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
       return {data: seismicSimulation.getDeformationModelMaxDisplacementBeforeEarthquakeGivenFriction(friction)};
     });
 
+    addFunc("setBoundaryOrientation", (angle: number) => {
+      seismicSimulation.setDeformationModelFaultAngle(angle);
+    });
+
     /** ==== Utility methods ==== */
 
     addFunc("log", (params) => {

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -413,6 +413,9 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
     });
 
     addFunc("setBoundaryOrientation", (angle: number) => {
+      if (angle < -90 || angle > 90) {
+        return blocklyController.throwError(`Boundary orientaion must be between -90º and 90º`);
+      }
       seismicSimulation.setDeformationModelFaultAngle(angle);
     });
 

--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -98,6 +98,8 @@ const AuthoringMenu: React.SFC<IProps> = (props) => {
             <DatNumber path="seismicSimulation.deformationModelFrictionHigh" label="Max displ. High friction" key="deformationModelFrictionHigh"
               min={0.1} max={50} step={0.1}/>
             <DatBoolean path="seismicSimulation.deformationModelRainbowLines" label="Rainbow lines?" key="deformationModelRainbowLines" />
+            <DatNumber path="seismicSimulation.deformationModelFaultAngle" label="Fault Angle (º)" key="deformationModelFaultAngle"
+              min={-90} max={90} step={1}/>
           </DatFolder>,
           <DatSelect path="seismicSimulation.deformationModelEarthquakeControl" label="Earthquakes"
             options={["none", "auto", "user"]} key="deformationModelEarthquakeControl" />,

--- a/src/components/deformation/deformation-model.tsx
+++ b/src/components/deformation/deformation-model.tsx
@@ -334,6 +334,7 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
       const points: Point[] = [];
 
       const start = line === 0 ? -overflow : this.modelWidth + overflow;
+      const totalSteps = line === 0 ? 50 : 51;
       let stepSize;
       let x;
 
@@ -343,7 +344,7 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
       // curve. Instead of some logarithmic equation for where to sample the points, this simply samples 20
       // evenly-spaced points across the 3/8ths of the model furthest from the fault, and 30 points in the nearest
       // eighth. Both lines work from the outside-in.
-      for (let step = 0; step < 50; step++) {
+      for (let step = 0; step < totalSteps; step++) {
         const direction = line === 0 ? 1 : -1;
         if (step < 20) {
           stepSize = threeEightsWidth / 20;

--- a/src/components/deformation/deformation-model.tsx
+++ b/src/components/deformation/deformation-model.tsx
@@ -25,6 +25,8 @@ const modelMargin = {
 };
 const minModelMargin = 20;
 
+const overflow = 200;   // amount to draw under the clipping to account for rotation
+
 const backgroundColor = "#e6f2e4";
 const lineColor = "#777";
 const drawAreaColor = "#fff";
@@ -134,8 +136,8 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     ctx.strokeStyle = faultColor;
     ctx.lineWidth = 3;
     ctx.setLineDash([20, 5]);
-    ctx.moveTo(modelMargin.left + (this.modelWidth / 2) - 1, modelMargin.top);
-    ctx.lineTo(modelMargin.left + (this.modelWidth / 2) - 1, this.modelWidth + modelMargin.top);
+    ctx.moveTo(modelMargin.left + (this.modelWidth / 2) - 1, modelMargin.top - overflow);
+    ctx.lineTo(modelMargin.left + (this.modelWidth / 2) - 1, this.modelWidth + modelMargin.top + (overflow * 2));
     ctx.stroke();
     ctx.setLineDash([]);
     ctx.lineWidth = 1;
@@ -152,13 +154,14 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
       const plateAlpha = initialPlateAlpha - (year / this.fadeOutTime) * initialPlateAlpha;
       ctx.fillStyle = `rgba(255,58,58,${plateAlpha})`;
       ctx.beginPath();
-      ctx.rect(modelMargin.left, modelMargin.top, this.modelWidth / 2, this.modelWidth + modelMargin.top);
+      ctx.rect(-overflow, -overflow,
+        (this.modelWidth / 2) + modelMargin.left + overflow, this.modelWidth + (overflow * 2));
       ctx.fill();
 
       ctx.fillStyle = `rgba(219,194,58,${plateAlpha})`;
       ctx.beginPath();
-      ctx.rect(modelMargin.left + (this.modelWidth / 2), modelMargin.top,
-        this.modelWidth / 2, this.modelWidth + modelMargin.top);
+      ctx.rect(modelMargin.left + (this.modelWidth / 2), -overflow,
+        (this.modelWidth / 2) + overflow, this.modelWidth + modelMargin.top + (overflow * 2));
       ctx.fill();
     }
 
@@ -190,9 +193,9 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     const verticalLines: Point[][] = [];
 
     // horizontal lines start below model and go beyond in case lines curve into model
-    const yBounds = [modelMargin.top - 200, modelMargin.top + this.modelWidth + 400];
+    const yBounds = [modelMargin.top - 200 - overflow, modelMargin.top + this.modelWidth + 400 + (overflow * 2)];
     // vertical lines remain vertical and can be clipped to frame
-    const xBounds = [modelMargin.left - 10, modelMargin.left + this.modelWidth + 20];
+    const xBounds = [modelMargin.left - overflow, modelMargin.left + this.modelWidth + (overflow * 2)];
 
     // form "horizontal" lines, one for each step vertically
     // (this is slightly inefficient, because they all have the same shape, but the calc is fast)
@@ -201,7 +204,7 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     }
     // form vertical lines, one for each step horizontally
     for (let x = xBounds[0]; x < xBounds[1]; x += lineSpacing) {
-      verticalLines.push(this.generateVerticalLine(x, modelMargin.top, hSpeed, year));
+      verticalLines.push(this.generateVerticalLine(x, -overflow, hSpeed, year));
     }
 
     ctx.strokeStyle = lineColor;
@@ -321,15 +324,16 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
   // returns two lines, one on either side of the center line, so we can have clean breaks
   // in the case of earthquakes
   private generateHorizontalLines(yOrigin: number, xOffset: number, relativeVerticalSpeed: number, year: number) {
+    const totalWidth = this.modelWidth + (overflow * 2);
     const center = this.modelWidth / 2;
-    const eighthWidth = (this.modelWidth / 8);
-    const threeEightsWidth = (this.modelWidth * 3 / 8);
+    const eighthWidth = (totalWidth / 8);
+    const threeEightsWidth = (totalWidth * 3 / 8);
     const lines: Point[][] = [];
 
     for (let line = 0; line < 2; line++) {
       const points: Point[] = [];
 
-      const start = line === 0 ? 0 : this.modelWidth;
+      const start = line === 0 ? -overflow : this.modelWidth + overflow;
       let stepSize;
       let x;
 
@@ -376,7 +380,7 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
 
     const newX = xOrigin - this.worldToCanvas(horizontalDisplacement);
 
-    const points: Point[] = [{x: newX, y: yOffset}, {x: newX, y: yOffset + this.modelWidth}];
+    const points: Point[] = [{x: newX, y: yOffset}, {x: newX, y: yOffset + this.modelWidth + (overflow * 2)}];
 
     return points;
   }

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -73,6 +73,15 @@ export const SeismicSimulationStore = types
     delaunayTriangleStrains: [] as number[],
   }))
   .views((self) => ({
+    get relativeDeformDirPlate1() {
+      // deformDirPlate1 and deformDirPlate2 are rotate 180 from user request, which is why we add instead of subtract
+      return self.deformDirPlate1 +  self.deformationModelFaultAngle;
+    },
+    get relativeDeformDirPlate2() {
+      return self.deformDirPlate2 +  self.deformationModelFaultAngle;
+    }
+  }))
+  .views((self) => ({
     get deformationModelSpeed() {
       return self.deformationModelEndStep / self.deformationModelTotalClockTime;
     },
@@ -90,19 +99,19 @@ export const SeismicSimulationStore = types
       return self.deformationModelEarthquakeControl === "auto" || self.deformationModelEarthquakeControl === "user";
     },
     get relativeVerticalSpeed() {   // mm/yr
-      const { deformSpeedPlate1, deformDirPlate1, deformSpeedPlate2, deformDirPlate2 } = this;
+      const { deformSpeedPlate1, relativeDeformDirPlate1, deformSpeedPlate2, relativeDeformDirPlate2 } = this;
 
-      const plate1VerticalSpeed = Math.cos(deg2rad(deformDirPlate1)) * deformSpeedPlate1;
-      const plate2VerticalSpeed = Math.cos(deg2rad(deformDirPlate2)) * deformSpeedPlate2;
+      const plate1VerticalSpeed = Math.cos(deg2rad(relativeDeformDirPlate1)) * deformSpeedPlate1;
+      const plate2VerticalSpeed = Math.cos(deg2rad(relativeDeformDirPlate2)) * deformSpeedPlate2;
 
       const relativeSpeed = plate1VerticalSpeed - plate2VerticalSpeed;
       return relativeSpeed;
     },
     get relativeHorizontalSpeed() {   // mm/yr
-      const { deformSpeedPlate1, deformDirPlate1, deformSpeedPlate2, deformDirPlate2 } = this;
+      const { deformSpeedPlate1, relativeDeformDirPlate1, deformSpeedPlate2, relativeDeformDirPlate2 } = this;
 
-      const plate1HorizontalSpeed = Math.sin(deg2rad(deformDirPlate1)) * deformSpeedPlate1;
-      const plate2HorizontalSpeed = Math.sin(deg2rad(deformDirPlate2)) * deformSpeedPlate2;
+      const plate1HorizontalSpeed = Math.sin(deg2rad(relativeDeformDirPlate1)) * deformSpeedPlate1;
+      const plate2HorizontalSpeed = Math.sin(deg2rad(relativeDeformDirPlate2)) * deformSpeedPlate2;
 
       const relativeSpeed = plate1HorizontalSpeed - plate2HorizontalSpeed;
       return relativeSpeed;

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -337,6 +337,9 @@ export const SeismicSimulationStore = types
           return self.deformationModelFrictionHigh;
       }
     },
+    setDeformationModelFaultAngle(angle: number) {
+      self.deformationModelFaultAngle = angle;
+    }
   }))
   .views((self) => ({
     get allGPSStations() {

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -37,6 +37,7 @@ export const SeismicSimulationStore = types
 
     deformationModelWidthKm: 50,    // km
     deformationModelApparentWidthKm: 50,    // model width as indicated by the scale marker (km)
+    deformationModelFaultAngle: 0,
 
     deformationModelEarthquakeControl: types.optional(EarthquakeControl, "none"),
     deformationModelFrictionCategory: types.optional(Friction, "low"),

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -74,6 +74,7 @@ const seismicSimulationAuthorSettingsProps = tuple(
   "deformationModelRainbowLines",
   "deformationModelApparentYearScaling",
   "deformationModelShowYear",
+  "deformationModelFaultAngle",
 );
 
 export type SeismicSimulationAuthorSettingsProps = typeof seismicSimulationAuthorSettingsProps[number];


### PR DESCRIPTION
@mklewandowski I realized I somehow never made this into a PR.

This implements fault rotation as a rotation of the entire canvas. This way the grid lines, stations and labels don't all need to have recalculated positions.

There is a little bit of fussy calculations when it comes to placing things like the plate labels, so that they don't rotate out of the square. I tried to keep it to a minimum. You can see how everything moves by opening the authoring and playing with the rotation slider.

Text position and orientation took a while of scratching my head to figure out. Basically, the entire canvas is rotation by xº around the center. Then, when placing the text, we rotate the entire canvas by -xº around the text's location, and then rotate it back.