### PR TITLE
Save user data when changes are made to seismic store (180194849)

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -94,6 +94,7 @@ phone.addListener("initInteractive", (data: {
 
   onSnapshot(stores.unit, saveUserData);                   // MobX function called on every store change
   onSnapshot(stores.tephraSimulation, saveUserData);
+  onSnapshot(stores.seismicSimulation, saveUserData);
   onSnapshot(stores.blocklyStore, saveUserData);
   onSnapshot(stores.uiStore, saveUserData);
 });


### PR DESCRIPTION
This PR makes a small fix to ensure that we save user data when we detect a change to the seismic store.  Without this, seismic changes in the authoring dialog were not being saved to LARA when GeoCoder activities were being authored.

PT story:
https://www.pivotaltracker.com/n/projects/2441242/stories/180194849

Test branch:
https://geocode-app.concord.org/branch/fix-seismic-save-bug/index.html