### PR TITLE
180411544 changes to increase deformation block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12540,6 +12540,16 @@
             "signal-exit": "^3.0.2"
           }
         },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -12555,6 +12565,7 @@
           "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
           "dev": true,
           "requires": {
+            "string-width": "^2.1.1",
             "strip-ansi": "^4.0.0"
           }
         }

--- a/src/blockly-blocks/deformation/block-deformation-create-sim.js
+++ b/src/blockly-blocks/deformation/block-deformation-create-sim.js
@@ -77,17 +77,23 @@ Blockly.Blocks['deformation-create-sim'] = {
   Blockly.Blocks['deformation-model-step'] = {
     init: function() {
       this.appendDummyInput()
-          .appendField("Increase Deformation by deformation rate");
+          .appendField("Increase Deformation by deformation build-up");
       this.appendDummyInput()
-          .appendField("  calculated based on");
+          .appendField("  calculated based on...");
       this.appendValueInput("speed1")
           .setCheck("Number")
           .setAlign(Blockly.ALIGN_RIGHT)
-          .appendField("Plate 1 speed");
+          .appendField("Plate 1 speed (mm/yr)");
+      this.appendDummyInput()
+          .setAlign(Blockly.ALIGN_RIGHT)
+          .appendField("direction (degrees) = 0");
       this.appendValueInput("speed2")
           .setCheck("Number")
           .setAlign(Blockly.ALIGN_RIGHT)
-          .appendField("Plate 2 speed");
+          .appendField("Plate 2 speed (mm/yr)");
+      this.appendDummyInput()
+          .setAlign(Blockly.ALIGN_RIGHT)
+          .appendField("direction (degrees) = 180");
       this.setPreviousStatement(true, null);
       this.setNextStatement(true, null);
       this.setColour("#B35F00")

--- a/src/blockly-blocks/seismic/block-seismic-strain-rate.js
+++ b/src/blockly-blocks/seismic/block-seismic-strain-rate.js
@@ -77,12 +77,12 @@ Blockly.JavaScript['seismic_render_strain_triangles'] = function (block) {
 Blockly.Blocks['seismic_render_strain_labels'] = {
   init: function () {
     this.appendDummyInput()
-      .appendField('Show strain rate value')
+      .appendField('Show deformation build-up value')
     this.setInputsInline(false)
     this.setPreviousStatement(true, null)
     this.setNextStatement(true, null)
     this.setColour("#EB0000")
-    this.setTooltip('Show strain rate value')
+    this.setTooltip('Show deformation build-up value')
     this.setHelpUrl('')
   }
 }

--- a/src/components/map/map-legend.tsx
+++ b/src/components/map/map-legend.tsx
@@ -30,7 +30,7 @@ const secondaryPanel = {
   Tephra: "Risk" as LegendType,
   Risk: "Tephra" as LegendType,
   Strain: "GPS" as LegendType,
-  GPS: "Strain" as LegendType
+  GPS: "Deformation" as LegendType
 };
 
 interface IProps extends IBaseProps {

--- a/src/components/map/map-strain-legend.tsx
+++ b/src/components/map/map-strain-legend.tsx
@@ -102,7 +102,7 @@ export default class StrainLegendComponent extends PureComponent<IProps, IState>
     const round = (val: number) => Math.round(val);
     return (
       <LegendContainer>
-        <LegendTitleText>Strain rate{isLog ? " (log)" : ""}</LegendTitleText>
+        <LegendTitleText>Deformation<br/>build-up (s<sup>-1</sup>)</LegendTitleText>
         <AbsoluteIcon
           width={28}
           height={28}


### PR DESCRIPTION


## Small text changes for three stories (identified in individual commit branches):

### Deformation Block:
- The title of this deformation block was changed to "Increase Deformation by deformation build up calculated based on..."
- Units of "(mm/yr)" was added to both input labels.
- Under Plate 1 Speed a line was added that says "direction (degrees) = 0". This shows users that the direction of the plate is locked in this direction.
-  Under Plate 2 Speed a line was added that says "direction (degrees) = 180". This shows users that the direction of the plate is locked in this direction.

<img width="271" alt="Screen Shot 2022-01-24 at 5 14 00 PM" src="https://user-images.githubusercontent.com/22908/150873833-838062a9-699c-445f-8f0f-97346233c8ba.png">

### Deformation key:
- The button that used to say "Show Strain' now reads "Show Deformation"
- The top of the deformation color key now reads to "Deformation build-up (s^-1)" with the -1 being superscript.
<img width="159" alt="Screen Shot 2022-01-24 at 5 12 07 PM" src="https://user-images.githubusercontent.com/22908/150873861-48b8dca2-f8be-4598-99ab-2849dde61a8b.png">
<img width="130" alt="Screen Shot 2022-01-24 at 5 11 53 PM" src="https://user-images.githubusercontent.com/22908/150873878-d8b2ceb0-7193-44ee-954a-ce5489b962d0.png">

### Show Deformation build-up value block
- The "show strain rate value" block has been renamed to "Show deformation build-up value".
<img width="196" alt="Screen Shot 2022-01-24 at 5 12 51 PM" src="https://user-images.githubusercontent.com/22908/150873916-5dec24cf-6937-48f4-9f6a-c74a8d73f811.png">


**Note:** I am not sure why package-lock.json changed this way. I am not worried about it, but it *is* curious.
**Note:** I will be renaming `Strain*` components next. Because moving and renaming files and imports often results in strange diffs, so I am bundling a few of them following the rewording.


