### PR TITLE
181021708: Rename *Strain-* components to *Deformation-*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Version 2.6.0 - release February 16, 2022
+### Features/Improvements:
+- dependency updates, documentation, cleanup.
+- [#180647562](https://www.pivotaltracker.com/story/show/180647562) - Project: Add webpack target and components for `report-item`.
+- [#180239682](https://www.pivotaltracker.com/story/show/180239682) - Seismic: Compute Strain Rate block.
+- [#181032483](https://www.pivotaltracker.com/story/show/181032483) - Seismic: Increase transparency on deformation build-up map
+- [#180411544](https://www.pivotaltracker.com/story/show/180411544) - Seismic: Adjust wording in deformation key
+- [#180411544](https://www.pivotaltracker.com/story/show/180239758) - Seismic: update deformation block
+- [#180361402](https://www.pivotaltracker.com/story/show/180239758) - Seismic: Rename *Strain-* components to *Deformation-*
+
 ## Version 2.5.0 - released November 4, 2021
 
 ### Features/Improvements

--- a/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/seismic-toolbox.xml
@@ -5,9 +5,9 @@
     <block type="seismic_sample_data"></block>
     <block type="seismic_filter_data"></block>
     <block type="graph_gps_position"></block>
-    <block type="seismic_compute_strain"></block>
-    <block type="seismic_render_strain_triangles"></block>
-    <block type="seismic_render_strain_labels"></block>
+    <block type="seismic_compute_deformation"></block>
+    <block type="seismic_render_deformation_triangles"></block>
+    <block type="seismic_render_deformation_labels"></block>
   </category>
 
   <category name="Deformation" colour="#B35F00">

--- a/src/blockly-blocks/blocks.js
+++ b/src/blockly-blocks/blocks.js
@@ -31,5 +31,5 @@ import "./tephra/block-calculate-tephra-vei-wind";
 import "./tephra/block-risk-level";
 import "./seismic/block-seismic-gps-stations";
 import "./seismic/block-seismic-graph-gps-position";
-import "./seismic/block-seismic-strain-rate";
+import "./seismic/block-seismic-deformation-buildup";
 import "./deformation/block-deformation-create-sim";

--- a/src/blockly-blocks/seismic/block-seismic-deformation-buildup.js
+++ b/src/blockly-blocks/seismic/block-seismic-deformation-buildup.js
@@ -1,4 +1,4 @@
-Blockly.Blocks['seismic_compute_strain'] = {
+Blockly.Blocks['seismic_compute_deformation'] = {
   init: function () {
     this.appendDummyInput()
       .appendField('Compute deformation build-up')
@@ -9,15 +9,15 @@ Blockly.Blocks['seismic_compute_strain'] = {
     this.setPreviousStatement(true, null)
     this.setNextStatement(true, null)
     this.setColour("#EB0000")
-    this.setTooltip('Compute strain rate')
+    this.setTooltip('Compute deformation rate')
     this.setHelpUrl('')
   }
 }
-Blockly.JavaScript['seismic_compute_strain'] = function (block) {
+Blockly.JavaScript['seismic_compute_deformation'] = function (block) {
   var value_stations = Blockly.JavaScript.valueToCode(block, 'stations', Blockly.JavaScript.ORDER_ATOMIC)
   var value_velocities = block.getFieldValue('velocities') === "TRUE";
 
-  var code = `computeStrainRate(${value_stations});`
+  var code = `computeDeformationBuildup(${value_stations});`
   // TODO: Change ORDER_NONE to the correct strength.
   return code;
 }
@@ -56,7 +56,7 @@ Blockly.JavaScript['seismic_equal_interval'] = function (block) {
   return [code, Blockly.JavaScript.ORDER_NONE]
 }
 
-Blockly.Blocks['seismic_render_strain_triangles'] = {
+Blockly.Blocks['seismic_render_deformation_triangles'] = {
   init: function () {
     this.appendDummyInput()
       .appendField('Color the map by deformation build-up')
@@ -69,12 +69,12 @@ Blockly.Blocks['seismic_render_strain_triangles'] = {
     this.setHelpUrl('')
   }
 }
-Blockly.JavaScript['seismic_render_strain_triangles'] = function (block) {
+Blockly.JavaScript['seismic_render_deformation_triangles'] = function (block) {
 
-  return  "renderStrainRate();";
+  return  "renderDeformationBuildup();";
 }
 
-Blockly.Blocks['seismic_render_strain_labels'] = {
+Blockly.Blocks['seismic_render_deformation_labels'] = {
   init: function () {
     this.appendDummyInput()
       .appendField('Show deformation build-up value')
@@ -86,7 +86,7 @@ Blockly.Blocks['seismic_render_strain_labels'] = {
     this.setHelpUrl('')
   }
 }
-Blockly.JavaScript['seismic_render_strain_labels'] = function (block) {
-  var code = "renderStrainRateLabels();";
+Blockly.JavaScript['seismic_render_deformation_labels'] = function (block) {
+  var code = "renderDeformationBuildupLabels();";
   return code;
 }

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -3,7 +3,7 @@ import { BlocklyController } from "./blockly-controller";
 import { IBlocklyWorkspace } from "../interfaces";
 import { IStore } from "../stores/stores";
 import { Datasets, Dataset, Filter, ProtoTimeRange, TimeRange } from "../stores/data-sets";
-import { StationData } from "../strain";
+import { StationData } from "../deformation";
 import { ColorMethod } from "../stores/seismic-simulation-store";
 const Interpreter = require("js-interpreter");
 
@@ -338,19 +338,19 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
                                     true, true, true, dataset.dataOffset);
     });
 
-    addFunc("computeStrainRate", (stations: StationData[]) => {
+    addFunc("computeDeformationBuildup", (stations: StationData[]) => {
       if (!stations || stations.length < 3) {
         blocklyController.throwError(`You must provide at least three GPS stations to compute deformation build-up.`);
       }
-      seismicSimulation.setStrainMapBounds(stations);
+      seismicSimulation.setDeformationMapBounds(stations);
     });
 
-    addFunc("renderStrainRate", (method: ColorMethod) => {
-      seismicSimulation.setRenderStrainMap("logarithmic");
+    addFunc("renderDeformationBuildup", (method: ColorMethod) => {
+      seismicSimulation.setRenderDeformationMap("logarithmic");
     });
 
-    addFunc("renderStrainRateLabels", () => {
-      seismicSimulation.renderStrainRateLabels();
+    addFunc("renderDeformationBuildupLabels", () => {
+      seismicSimulation.renderDeformationBuildupLabels();
     });
 
     addFunc("runDeformationModel", () => {

--- a/src/components/deformation/deformation-model.tsx
+++ b/src/components/deformation/deformation-model.tsx
@@ -455,7 +455,7 @@ export class DeformationModel extends BaseComponent<IProps, {}> {
     return distanceTravelledDueToEarthquakes + additionalDisplacement;
   }
 
-  // The main sheer-strain deformation model.
+  // The main sheer-deformation deformation model.
   // Calculations taken from PowerPoint linked here: https://www.pivotaltracker.com/story/show/174401018
   private calculateVerticalDisplacementWithoutEarthakes(px: number, vSpeed: number, year: number) {
     const verticalSlipRatemmYr = vSpeed / Math.PI *

--- a/src/components/icons.ts
+++ b/src/components/icons.ts
@@ -66,13 +66,13 @@ export function latLngIcon(label: string, anchorCorner: string = "top-left", cro
   return new DivIcon({ className: "div-icon", html });
 }
 
-export function strainLabelIcon(strain: number): DivIcon {
-    let strainText = `${Math.round(Math.abs(strain) * 100) / 100}`;
-    if (strainText.length < 4) {
-        strainText = `${Array(5 - strainText.length).join("&nbsp;")}${strainText}`;
+export function deformationLabelIcon(deformation: number): DivIcon {
+    let deformationText = `${Math.round(Math.abs(deformation) * 100) / 100}`;
+    if (deformationText.length < 4) {
+        deformationText = `${Array(5 - deformationText.length).join("&nbsp;")}${deformationText}`;
     }
-    const html = `<div class='strain-icon'>
-        ${strainText}
+    const html = `<div class='deformation-icon'>
+        ${deformationText}
     </div>`;
     return new DivIcon({ className: "div-icon", html });
 }

--- a/src/components/map/map-component.tsx
+++ b/src/components/map/map-component.tsx
@@ -14,7 +14,7 @@ import { BaseComponent, IBaseProps } from "../base";
 import { CrossSectionDrawLayer } from "./layers/cross-section-draw-layer";
 import { LocalToLatLng } from "../../utilities/coordinateSpaceConversion";
 import { MapTephraThicknessLayer } from "./map-tephra-thickness-layer";
-import { MapTriangulatedStrainLayer } from "./map-triangulated-strain-layer";
+import { MapTriangulatedDeformationLayer } from "./map-triangulated-deformation-layer";
 import { OverlayControls } from "../overlay-controls";
 import { RulerDrawLayer } from "./layers/ruler-draw-layer";
 import { RightSectionTypes } from "../tabs";
@@ -158,7 +158,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
 
     const {
       scenario: seismicScenario,
-      strainMapColorMethod,
+      deformationMapColorMethod,
     } = this.stores.seismicSimulation;
 
     const scenario = isTephraUnit ? tephraScenario : seismicScenario;
@@ -169,7 +169,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
 
     const legendType: LegendType = isTephraUnit ?
                         (panelType !== RightSectionTypes.MONTE_CARLO ? "Tephra" : "Risk") :
-                        "Strain";
+                        "Deformation";
 
     const {
       initialZoom,
@@ -340,8 +340,8 @@ export class MapComponent extends BaseComponent<IProps, IState>{
           {
             !isTephraUnit &&
             [
-              <MapTriangulatedStrainLayer
-                key="strain-layer"
+              <MapTriangulatedDeformationLayer
+                key="deformation-layer"
                 map={this.state.mapLeafletRef}
               />,
               <MapGPSStationsLayer
@@ -388,7 +388,7 @@ export class MapComponent extends BaseComponent<IProps, IState>{
           : <LegendComponent
               onClick={this.handleKeyButtonSelect}
               legendType={legendType}
-              colorMethod={strainMapColorMethod as ColorMethod}
+              colorMethod={deformationMapColorMethod as ColorMethod}
             />
         }
         { this.state.showDirection &&

--- a/src/components/map/map-deformation-legend.tsx
+++ b/src/components/map/map-deformation-legend.tsx
@@ -25,7 +25,7 @@ export const LegendTitleText = styled.div`
   text-align: center;
 `;
 
-export interface StrainRange {
+export interface DeformationRange {
   color: string;
   min: number;
   max: number | undefined;
@@ -35,17 +35,17 @@ const colors = ["#EEE270", "#FFBF4E", "#FF754B", "#E94E83", "#AE4ED3", "#7B58AE"
 const stepSize = (MAX_STRAIN - MIN_STRAIN) / buckets;
 const logStepSize = (MAX_LOG_STRAIN - MIN_LOG_STRAIN) / buckets;
 
-export const equalIntervalStrainRanges: StrainRange[] = [];
+export const equalIntervalDeformationRanges: DeformationRange[] = [];
 
 for (let i = 0; i < buckets; i++) {
-  equalIntervalStrainRanges.push({
+  equalIntervalDeformationRanges.push({
     color: colors[i],
     min: MIN_STRAIN + (stepSize * i),
     max: (i < buckets - 1) ? MIN_STRAIN + (stepSize * (i + 1)) : undefined
   });
 }
 
-export const logarithmicStrainRanges: StrainRange[] = [
+export const logarithmicDeformationRanges: DeformationRange[] = [
   {
     color: colors[0],
     min: 0,
@@ -90,7 +90,7 @@ interface IProps {
 
 interface IState {}
 
-export default class StrainLegendComponent extends PureComponent<IProps, IState> {
+export default class DeformationLegendComponent extends PureComponent<IProps, IState> {
   public static defaultProps = {
     onClick: undefined,
   };
@@ -98,7 +98,7 @@ export default class StrainLegendComponent extends PureComponent<IProps, IState>
   public render() {
     const { onClick, colorMethod } = this.props;
     const isLog = colorMethod === "logarithmic";
-    const ranges = isLog ? logarithmicStrainRanges : equalIntervalStrainRanges;
+    const ranges = isLog ? logarithmicDeformationRanges : equalIntervalDeformationRanges;
     const round = (val: number) => Math.round(val);
     return (
       <LegendContainer>

--- a/src/components/map/map-gps-stations-layer.tsx
+++ b/src/components/map/map-gps-stations-layer.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { inject, observer } from "mobx-react";
 import { Map as LeafletMap, LayerGroup, Marker, CircleMarker, Popup, MarkerProps, Polyline } from "react-leaflet";
 import { BaseComponent } from "../base";
-import { StationData } from "../../strain";
+import { StationData } from "../../deformation";
 import { LatLng } from "leaflet";
 import RawPositionTimeData from "../../assets/data/seismic/position-time-data";
 

--- a/src/components/map/map-legend.tsx
+++ b/src/components/map/map-legend.tsx
@@ -5,7 +5,7 @@ import styled from "styled-components";
 import IconButton from "../buttons/icon-button";
 import TephraLegendComponent from "./map-tephra-legend";
 import RiskLegendComponent from "./map-risk-legend";
-import StrainLegendComponent from "./map-strain-legend";
+import DeformationLegendComponent from "./map-deformation-legend";
 import GPSLegendComponent from "./map-gps-legend";
 import { ColorMethod } from "../../stores/seismic-simulation-store";
 
@@ -24,12 +24,12 @@ const LegendContainer = styled.div`
   padding-bottom: 5px;
 `;
 
-export type LegendType = "Tephra" | "Risk" | "Strain" | "GPS";
+export type LegendType = "Tephra" | "Risk" | "Deformation" | "GPS";
 
 const secondaryPanel = {
   Tephra: "Risk" as LegendType,
   Risk: "Tephra" as LegendType,
-  Strain: "GPS" as LegendType,
+  Deformation: "GPS" as LegendType,
   GPS: "Deformation" as LegendType
 };
 
@@ -61,7 +61,7 @@ export class LegendComponent extends BaseComponent<IProps, IState> {
     if (isTephraUnit) {
       currentLegendType = legendType === "Tephra" ? "Tephra" : "Risk";
     } else {
-      currentLegendType = legendType === "Strain" ? "Strain" : "GPS";
+      currentLegendType = legendType === "Deformation" ? "Deformation" : "GPS";
     }
 
     if (toggledToSecondary) {
@@ -70,8 +70,8 @@ export class LegendComponent extends BaseComponent<IProps, IState> {
 
     const legend = currentLegendType === "Tephra" ? <TephraLegendComponent onClick={onClick} /> :
                     currentLegendType === "Risk" ? <RiskLegendComponent onClick={onClick} /> :
-                    currentLegendType === "Strain" ?
-                    <StrainLegendComponent onClick={onClick} colorMethod={colorMethod} /> :
+                    currentLegendType === "Deformation" ?
+                    <DeformationLegendComponent onClick={onClick} colorMethod={colorMethod} /> :
                     <GPSLegendComponent onClick={onClick} />;
     return (
       <LegendContainer data-test="key-container">

--- a/src/components/map/map-triangulated-deformation-layer.tsx
+++ b/src/components/map/map-triangulated-deformation-layer.tsx
@@ -5,13 +5,13 @@ import "leaflet-kmz";
 
 import { inject, observer } from "mobx-react";
 import { BaseComponent } from "../base";
-import { StationData } from "../../strain";
+import { StationData } from "../../deformation";
 import "../../css/custom-leaflet-icons.css";
 import { LayerGroup, Polygon, Marker } from "react-leaflet";
-import { equalIntervalStrainRanges, logarithmicStrainRanges } from "./map-strain-legend";
+import { equalIntervalDeformationRanges, logarithmicDeformationRanges } from "./map-deformation-legend";
 import { ColorMethod } from "../../stores/seismic-simulation-store";
 import { divIcon } from "leaflet";
-import { strainLabelIcon } from "../icons";
+import { deformationLabelIcon } from "../icons";
 
 interface IProps {
   map: Leaflet.Map | null;
@@ -23,7 +23,7 @@ interface IState {
 
 @inject("stores")
 @observer
-export class MapTriangulatedStrainLayer extends BaseComponent<IProps, IState> {
+export class MapTriangulatedDeformationLayer extends BaseComponent<IProps, IState> {
 
   constructor(props: IProps) {
     super(props);
@@ -46,26 +46,26 @@ export class MapTriangulatedStrainLayer extends BaseComponent<IProps, IState> {
 
   public render() {
     const { map } = this.props;
-    const { delaunayTriangles, delaunayTriangleStrains, renderStrainMap, renderStrainLabels,
-      strainMapColorMethod } = this.stores.seismicSimulation;
+    const { delaunayTriangles, delaunayTriangleDeformations, renderDeformationMap, renderDeformationLabels,
+      deformationMapColorMethod } = this.stores.seismicSimulation;
     const { zoomLevel } = this.state;
 
-    const isLog = (strainMapColorMethod as ColorMethod) === "logarithmic";
+    const isLog = (deformationMapColorMethod as ColorMethod) === "logarithmic";
 
-    if (!map || (!renderStrainMap && !renderStrainLabels)) return null;
+    if (!map || (!renderDeformationMap && !renderDeformationLabels)) return null;
     const triangles = [];
     const labels = [];
     for (let i = 0; i < delaunayTriangles.length; i++) {
       const triangle = delaunayTriangles[i];
       const [p1, p2, p3] = triangle.map(p => Leaflet.latLng(p[0], p[1]));
 
-      const strain = delaunayTriangleStrains[i];
-      const ranges = isLog ? logarithmicStrainRanges : equalIntervalStrainRanges;
+      const deformation = delaunayTriangleDeformations[i];
+      const ranges = isLog ? logarithmicDeformationRanges : equalIntervalDeformationRanges;
 
-      const range = ranges.slice().reverse().find(r => strain > r.min);
+      const range = ranges.slice().reverse().find(r => deformation > r.min);
       let strokeColor = "#333";
       let fillColor = "none";
-      if (renderStrainMap) {
+      if (renderDeformationMap) {
         strokeColor = "#FFF";
         if (range) {
           fillColor = range.color;
@@ -83,7 +83,7 @@ export class MapTriangulatedStrainLayer extends BaseComponent<IProps, IState> {
         fillColor={fillColor}
       />);
 
-      if (renderStrainLabels) {
+      if (renderDeformationLabels) {
         // calculate the incenter of the triangle
         const perim1 = Math.sqrt(((p1.lat - p2.lat) ** 2) + ((p1.lng - p2.lng) ** 2));
         const perim2 = Math.sqrt(((p2.lat - p3.lat) ** 2) + ((p2.lng - p3.lng) ** 2));
@@ -99,8 +99,8 @@ export class MapTriangulatedStrainLayer extends BaseComponent<IProps, IState> {
         if (perimeter > minPerimSize
             && perim1 < largeSide && perim1 > smallSide && perim2 < largeSide
             && perim2 > smallSide  && perim3 < largeSide && perim3 > smallSide ) {
-          const text = strainLabelIcon(parseFloat(delaunayTriangleStrains[i].toFixed(1)));
-          labels.push(<Marker  key={`strain-label-${i}`}position={incenter} icon={text} />);
+          const text = deformationLabelIcon(parseFloat(delaunayTriangleDeformations[i].toFixed(1)));
+          labels.push(<Marker  key={`deformation-label-${i}`}position={incenter} icon={text} />);
         }
       }
     }

--- a/src/css/custom-leaflet-icons.css
+++ b/src/css/custom-leaflet-icons.css
@@ -180,6 +180,6 @@
   right: -6px;
 }
 
-.strain-icon {
+.deformation-icon {
   margin-left: -8px;
 }

--- a/src/deformation.ts
+++ b/src/deformation.ts
@@ -1,7 +1,7 @@
 
-// Calculate the max shear strain between three gps points
+// Calculate the max shear deformation between three gps points
 // Saul Amster 06/2020
-// Translated from GPS strain calculator--gps_strain_calculator_excel.v3.xls by Vince Cronin
+// Translated from GPS deformation calculator--gps_deformation_calculator_excel.v3.xls by Vince Cronin
 import * as math from "mathjs";
 import { area } from "d3";
 
@@ -18,7 +18,7 @@ const e2 = 0.006739497;
 const n = 0.00167922;
 
 // Input interfaces for typing the data
-export interface StrainInput {
+export interface DeformationInput {
     data: StationData[];
 }
 
@@ -35,9 +35,9 @@ export interface StationData {
     direction: number;                      // º from N
 }
 
-// This is all of the outputs of the algorithm. Currently only maxShearStrain is returned
+// This is all of the outputs of the algorithm. Currently only maxShearDeformation is returned
 // This interface is unused
-export interface StrainOutput {
+export interface DeformationOutput {
     secondInvariant: number;
 }
 
@@ -69,14 +69,14 @@ interface StationDataComputedValues {
     pseudoEasting: number;
 }
 
-// returns Max Shear Strain for the three data GPS stations inputed
-const strainCalc = (inputData: StrainInput): StrainOutput => {
+// returns Max Shear Deformation for the three data GPS stations inputed
+const deformationCalc = (inputData: DeformationInput): DeformationOutput => {
     const stationData: StationDataComputedValues[] = [];
     inputData.data.forEach(element => {
         stationData.push(calcStationData(element));
     });
-    const strainOutput = calculateStrainOutputData(inputData, stationData);
-    return strainOutput;
+    const deformationOutput = calculateDeformationOutputData(inputData, stationData);
+    return deformationOutput;
 };
 
 // returns populated StationDataComputedValues interface based on a single GPS station
@@ -153,9 +153,9 @@ function calcStationData(data: StationData): StationDataComputedValues {
     return output;
 }
 
-// returns calculated Max Shear Strain within the three GPS stations
+// returns calculated Max Shear Deformation within the three GPS stations
 // Uses mathjs for matrix manipulation
-function calculateStrainOutputData(inputData: StrainInput, calculatedData: StationDataComputedValues[]): StrainOutput {
+function calculateDeformationOutputData(inputData: DeformationInput, calculatedData: StationDataComputedValues[]): DeformationOutput {
     const utmZones: number[] = [];
     calculatedData.forEach((element: StationDataComputedValues) => {
         utmZones.push(element.utmZone);
@@ -243,15 +243,15 @@ function calculateStrainOutputData(inputData: StrainInput, calculatedData: Stati
                                 [eigenValues.get([0]), eigenValues.get([1])] :
                                 [eigenValues.get([1]), eigenValues.get([0])];
 
-    // const maximumIninitesimalShearStrain = 2 * Math.sqrt(Math.pow((m6[0][0] - m6[1][1]) / 2, 2) +
+    // const maximumIninitesimalShearDeformation = 2 * Math.sqrt(Math.pow((m6[0][0] - m6[1][1]) / 2, 2) +
     //                                         Math.pow(m6[1][1], 2));
-    // const areaStrain = correctedValues[0] + correctedValues[1];
+    // const areaDeformation = correctedValues[0] + correctedValues[1];
 
     // This returns values from 0 - 2e-6. We scale by 1e9 below, resulting in values 0-2000.
-    const strainSecondInvariant = Math.sqrt(correctedValues[0] ** 2 +  correctedValues[1] ** 2);
+    const deformationSecondInvariant = Math.sqrt(correctedValues[0] ** 2 +  correctedValues[1] ** 2);
 
-    const output: StrainOutput = {
-        secondInvariant: strainSecondInvariant * Math.pow(10, 9),
+    const output: DeformationOutput = {
+        secondInvariant: deformationSecondInvariant * Math.pow(10, 9),
 
         // these were old calculations that were included but are not currently
         // being used.
@@ -271,8 +271,8 @@ function calculateStrainOutputData(inputData: StrainInput, calculatedData: Stati
         // directionOfRotation: m5.get([2]) < 0 ? "clockwise" : "anit-clockwise",
         // maxHorizontalExtension: correctedValues[0],
         // minHorizontalExtension: correctedValues[1],
-        // maxShearStrain: maximumIninitesimalShearStrain * Math.pow(10, 9),
-        // areaStrain: areaStrain * Math.pow(10, 9),
+        // maxShearDeformation: maximumIninitesimalShearDeformation * Math.pow(10, 9),
+        // areaDeformation: areaDeformation * Math.pow(10, 9),
     };
 
     return output;
@@ -306,4 +306,4 @@ function average(data: number[]){
     return avg;
 }
 
-export default strainCalc;
+export default deformationCalc;

--- a/src/deformation.ts
+++ b/src/deformation.ts
@@ -155,7 +155,10 @@ function calcStationData(data: StationData): StationDataComputedValues {
 
 // returns calculated Max Shear Deformation within the three GPS stations
 // Uses mathjs for matrix manipulation
-function calculateDeformationOutputData(inputData: DeformationInput, calculatedData: StationDataComputedValues[]): DeformationOutput {
+function calculateDeformationOutputData(
+    inputData: DeformationInput,
+    calculatedData: StationDataComputedValues[]): DeformationOutput {
+
     const utmZones: number[] = [];
     calculatedData.forEach((element: StationDataComputedValues) => {
         utmZones.push(element.utmZone);

--- a/src/report-item/report-item.tsx
+++ b/src/report-item/report-item.tsx
@@ -13,8 +13,8 @@ interface Props {
 }
 
 const getBlockList = (interactiveState: SerializedState) => {
-  const { state } = interactiveState;
-  const initialCode = state.blocklyStore.initialXmlCode;
+  const state  = interactiveState.state || undefined;
+  const initialCode = state && state.blocklyStore && state.blocklyStore.initialXmlCode;
 
   if (initialCode) {
     try {

--- a/src/utilities/unavco-data.ts
+++ b/src/utilities/unavco-data.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 import * as RawVelocityDataSet from "../assets/data/seismic/cwu.final_nam14.vel";
-import { StationData } from "../strain";
+import { StationData } from "../deformation";
 
 /**
  * This method parses the offline UNAVCO velocity data found within "../../assets/data/cwu.snaps_nam14.vel"


### PR DESCRIPTION
We have changed the text labels of the block to use `Deformation build-up` instead of `Strain rate`, but we did not rename the variables or components behind the scenes.

Changes in this PR will make it easier for developers to find the correct blocks in the source code. All changes were made mechanically using a few search and replace string operations across all source files.

These changes are being done in their own PR because it is difficult to track file renaming in diffs. It will make code review easier to do them after the other changes are accepted.

[#181021708]
https://www.pivotaltracker.com/story/show/181021708