### PR TITLE
feat: add deployment link to Jira (START-1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,8 @@ jobs:
           prefix: geocode-app
           awsAccessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
           awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          deployRunUrl: https://models-resources.concord.org/geocode-app/__deployPath__/
           # Parameters to GHActions have to be strings, so a regular yaml array cannot
           # be used. Instead the `|` turns the following lines into a string
           topBranches: |


### PR DESCRIPTION
[START-1](https://concord-consortium.atlassian.net/browse/START-1)

Add `githubToken` and `deployRunUrl` to `.github/workflows/ci.yml`. This will allow the new version of `s3-deploy-action` to create a GitHub Deployment and set its `log_url` property, which will allow Jira to add a deployment link to associated Jira issues.

[START-1]: https://concord-consortium.atlassian.net/browse/START-1?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ