### PR TITLE
chore: update `dependencies-notes.md` with blockly version

### DIFF
--- a/dependencies-notes.md
+++ b/dependencies-notes.md
@@ -15,16 +15,16 @@ Notes on dependencies, particularly reasons for not updating to their latest ver
 
 ## Runtime Dependencies
 
-|Dependency          |Current |Latest  |Notes                                                                                   |
-|--------------------|--------|--------|----------------------------------------------------------------------------------------|
-|@pixi/react         |7.1.2   |8.0.1   |Requires pixi.js v8, React 19, and non-trivial migration                                |
-|blockly             |?       |11.2.2  |Minimized files in src/public have no version number. ¯\\_(ツ)_/¯                       |
-|color               |4.2.3   |5.0.0   |Compilation errors with v5                                                              |
-|js-interpreter      |1.4.6   |6.0.1   |v1.4.6 is deprecated; cypress test failures or compilation errors with newer versions.  |
-|mathjs              |12.4.3  |14.3.1  |v13 requires ES2020 browsers; would require polyfills.                                  |
-|pixi.js             |7.4.3   |8.9.1   |v8 requires non-trivial migration                                                       |
-|react               |17.0.2  |19.1.0  |React 18/19                                                                             |
-|react-dom           |17.0.2  |19.1.0  |React 18/19                                                                             |
-|react-leaflet       |2.8.0   |5.0.0   |v3 requires non-trivial migration; newer versions require React 18/19.                  |
-|react-tabs          |4.3.0   |6.1.0   |React 18/19                                                                             |
-|styled-components   |5.3.11  |6.1.17  |v6 requires non-trivial migration                                                       |
+|Dependency          |Current     |Latest  |Notes                                                                                   |
+|--------------------|------------|--------|----------------------------------------------------------------------------------------|
+|@pixi/react         |7.1.2       |8.0.1   |Requires pixi.js v8, React 19, and non-trivial migration                                |
+|blockly             |1.20190419.0|11.2.2  |[April 2019](https://github.com/google/blockly/releases/tag/1.20190419.0) release.      |
+|color               |4.2.3       |5.0.0   |Compilation errors with v5                                                              |
+|js-interpreter      |1.4.6       |6.0.1   |v1.4.6 is deprecated; cypress test failures or compilation errors with newer versions.  |
+|mathjs              |12.4.3      |14.3.1  |v13 requires ES2020 browsers; would require polyfills.                                  |
+|pixi.js             |7.4.3       |8.9.1   |v8 requires non-trivial migration                                                       |
+|react               |17.0.2      |19.1.0  |React 18/19                                                                             |
+|react-dom           |17.0.2      |19.1.0  |React 18/19                                                                             |
+|react-leaflet       |2.8.0       |5.0.0   |v3 requires non-trivial migration; newer versions require React 18/19.                  |
+|react-tabs          |4.3.0       |6.1.0   |React 18/19                                                                             |
+|styled-components   |5.3.11      |6.1.17  |v6 requires non-trivial migration                                                       |


### PR DESCRIPTION
Rather than being installed via npm like most libraries, the [blockly](https://github.com/google/blockly) library is simply included in the `geocode` project as minified files in `src/public`: `blockly_compressed.js`, `blocks_compressed.js`, `en.js`, and `javascript_compressed.js`. There is no version number associated with these files, so it was not obvious what version of the `blockly` library was in use. By cross-indexing the date the files were added to `geocode`, the release notes for `blockly` releases around that time, and looking for API changes documented in the release notes in the code itself, I was able to determine that we are using the [April 2019](https://github.com/google/blockly/releases/tag/1.20190419.0) release of the `blockly` library. This PR and the information added to the `dependencies-notes.md` document by this PR document this for use down the road when we want or need to update the `blockly` library.