### PR TITLE
feat: LavaCoder model option

### DIFF
--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -23,7 +23,7 @@ const AuthoringMenu: React.FC<IProps> = (props) => {
       <DatButton label={strings.MODEL_OPTIONS} onClick={props.toggleShowOptions}/>
       { props.expandOptionsDialog &&
         <DatSelect path="unit.name" label={strings.UNIT}
-          options={[strings.TEPHRA, strings.SEISMIC]} key="unit" />
+          options={[strings.TEPHRA, strings.SEISMIC, strings.LAVA_CODER]} key="unit" />
       }
       { (props.expandOptionsDialog && props.options.unit.name === strings.TEPHRA) &&
         [
@@ -106,6 +106,21 @@ const AuthoringMenu: React.FC<IProps> = (props) => {
             options={["none", "auto", "user"]} key="deformationModelEarthquakeControl" />,
 
           <DatBoolean path="uiStore.showSpeedControls" label={strings.SHOW_SPEED_CONTROLS} key="showSpeedControls" />,
+        ]
+      }
+
+      { (props.expandOptionsDialog && props.options.unit.name === strings.LAVA_CODER) &&
+        [
+          // <DatSelect path="blocklyStore.toolbox" label={strings.CODE_TOOLBOX}
+          //   options={BlocklyAuthoring.seismicToolboxes} key="toolbox" />,
+          // <DatSelect path="blocklyStore.initialCodeTitle" label={strings.INITIAL_CODE}
+          //   options={Object.keys(BlocklyAuthoring.code)} key="code" />,
+
+          <DatFolder title={strings.LEFT_TABS} key="leftTabsFolder" closed={false}>
+            <DatBoolean path="uiStore.showBlocks" label={strings.SHOW_BLOCKS} key="showBlocks" />
+            {/* <DatBoolean path="uiStore.showCode" label={strings.SHOW_CODE} key="showCode" /> */}
+            <DatBoolean path="uiStore.showData" label={strings.SHOW_DATA} key="showData" />
+          </DatFolder>,
         ]
       }
       {

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -10,7 +10,8 @@ import { UnitNameType } from "../stores/unit-store";
 enum SectionTypes {
   BLOCKS = "blocks",
   CODE = "code",
-  CONTROLS = "controls"
+  CONTROLS = "controls",
+  DATA = "data"
 }
 type TabInfo = {
   [tab in SectionTypes]: {
@@ -39,6 +40,12 @@ const kTabInfo: TabInfo = {
     backgroundColor: "#FFCA79",
     hoverBackgroundColor: "#FABF6E",
   },
+  data: {
+    name: "Data",
+    index: -1,
+    backgroundColor: "#BBD9FF",
+    hoverBackgroundColor: "#AECEFF",
+  }
 };
 
 enum RightSectionTypes {
@@ -63,6 +70,7 @@ const kRightTabInfo: RightTabInfo = {
   conditions: {
     name: "Conditions",
     unitDisplayName: {
+      LavaCoder: "LavaCoder",
       Tephra: "Conditions",
       Seismic: "Map"
     },
@@ -88,10 +96,12 @@ const kRightTabInfo: RightTabInfo = {
     backgroundColor: "#e6f2e4",
     hoverBackgroundColor: "#dae6d7",
     unitBackgroundColor: {
+      LavaCoder: "#cee6c9",
       Tephra: "#e6f2e4",
       Seismic: "#cee6c9"
     },
     unitHoverBackgroundColor: {
+      LavaCoder: "#c3dabd",
       Tephra: "#dae6d7",
       Seismic: "#c3dabd"
     },

--- a/src/stores/seismic-simulation-store.ts
+++ b/src/stores/seismic-simulation-store.ts
@@ -220,7 +220,7 @@ export const SeismicSimulationStore = types
       // Each vertex is returned as an index to an array of coordinates
       const mesh = new Delaunator(coords);
 
-      // filter trianges by removing those that have a vertex with an angle that is too small
+      // filter triangles by removing those that have a vertex with an angle that is too small
       const removeTriangles: number[] = [];
       const minAngleDeg = 5;
       const minAngleRad = minAngleDeg / 180 * Math.PI;

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -19,7 +19,7 @@ export interface IStore {
 }
 
 export interface IStoreish {
-  unit: {name: "Tephra" | "Seismic" };
+  unit: {name: "Tephra" | "Seismic" | "LavaCoder" };
   blocklyStore: any;
   tephraSimulation: any;
   seismicSimulation: any;
@@ -39,7 +39,7 @@ export const stores: IStore = {
   samplesCollectionsStore,
 };
 
-// this tuple syntx allows us to declare an array of strings and a type based on
+// this tuple syntax allows us to declare an array of strings and a type based on
 // that array at the same time.
 const tuple = <T extends string[]>(...args: T) => args;
 

--- a/src/stores/tephra-simulation-store.ts
+++ b/src/stores/tephra-simulation-store.ts
@@ -133,7 +133,7 @@ export const TephraSimulationStore = types
     const getVei = (mass: number, colHeight: number) => {
       // calculate the vei given the mass and the column height.
       // If the mass and column height were set by setting vei, these values will agree. If the user manually
-      // changes mass and column height, we must make our best guess. We take the averge and round towards the
+      // changes mass and column height, we must make our best guess. We take the average and round towards the
       // value given by mass.
       const massVEI =  Math.max(7, Math.min(15, Math.round(Math.log(mass) / Math.LN10))) - 7;
       let columnVEI = 1;

--- a/src/stores/unit-store.ts
+++ b/src/stores/unit-store.ts
@@ -5,7 +5,7 @@
 
 import { types } from "mobx-state-tree";
 
-export const UnitName = types.enumeration("type", ["Tephra", "Seismic"]);
+export const UnitName = types.enumeration("type", ["Tephra", "Seismic", "LavaCoder"]);
 export type UnitNameType = typeof UnitName.Type;
 
 export const UnitStore = types

--- a/src/strings/components/authoring-menu.ts
+++ b/src/strings/components/authoring-menu.ts
@@ -5,6 +5,7 @@ export const UNIT = "Unit";
 // chart names
 export const TEPHRA = "Tephra";
 export const SEISMIC = "Seismic";
+export const LAVA_CODER = "LavaCoder";
 
 // shared menu options
 export const CODE_TOOLBOX = "Code toolbox";


### PR DESCRIPTION
[GEOCODE-22](https://concord-consortium.atlassian.net/browse/GEOCODE-22)

- Implements the LavaCoder option in the `Model option` menu.
- When selected, shows the appropriate options.
- Shows appropriate tabs when corresponding model options are selected.
- Shows a white placeholder `<div>` where the model will reside.

[GEOCODE-22]: https://concord-consortium.atlassian.net/browse/GEOCODE-22?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ