### PR TITLE
feat: useCesiumClickEvent for handling clicks on map

### DIFF
--- a/src/components/lava-coder/lava-coder-view.tsx
+++ b/src/components/lava-coder/lava-coder-view.tsx
@@ -37,7 +37,8 @@ export function LavaCoderView({ width, height, margin }: IProps) {
   useLavaOverlay(viewer);
 
   useCesiumClickEvent(viewer, (latitude, longitude, elevation) => {
-    const elevationFeet = Math.round(elevation * 3.28084);
+    const kFeetPerMeter = 3.28084;
+    const elevationFeet = Math.round(elevation * kFeetPerMeter);
     // eslint-disable-next-line no-console
     console.log("Clicked at latitude:", round6(latitude), "longitude:", round6(longitude),
                 "elevation:", `${Math.round(elevation)}m = ${elevationFeet}ft`);

--- a/src/components/lava-coder/lava-coder-view.tsx
+++ b/src/components/lava-coder/lava-coder-view.tsx
@@ -6,7 +6,7 @@ import { useCesiumViewer } from "./use-cesium-viewer";
 import { useElevationData } from "./use-elevation-data";
 import { useHazardZones } from "./use-hazard-zones";
 import { useLavaOverlay } from "./use-lava-overlay";
-import { useVerticalExaggeration } from "./use-vertical-exaggeration";
+import { kNormalElevation, kVerticalExaggeration, useVerticalExaggeration } from "./use-vertical-exaggeration";
 import { useWorldImagery } from "./use-world-imagery";
 
 import "./lava-coder-view.scss";
@@ -16,10 +16,6 @@ interface IProps {
   height: number;
   margin: string;
 }
-
-const kNormalElevation = 1;
-// The vertical exaggeration factor for the terrain. This is used to make the terrain more visually distinct.
-const kVerticalExaggeration = 3;
 
 const round6 = (value: number) => Math.round(value * 1000000) / 1000000;
 

--- a/src/components/lava-coder/use-cesium-click-event.ts
+++ b/src/components/lava-coder/use-cesium-click-event.ts
@@ -1,0 +1,26 @@
+import { Cartographic, CesiumWidget, Math as CSMath, ScreenSpaceEventHandler, ScreenSpaceEventType } from "@cesium/engine";
+import { useEffect } from "react";
+
+type CartographicEventCallback = (latitude: number, longitude: number, elevation: number) => void;
+
+export function useCesiumClickEvent(viewer: CesiumWidget | null, onClick: CartographicEventCallback) {
+  useEffect(() => {
+    if (viewer) {
+      const handler = new ScreenSpaceEventHandler(viewer.scene.canvas);
+      handler.setInputAction((event: ScreenSpaceEventHandler.PositionedEvent) => {
+        const windowPosition = event.position;
+        if (windowPosition) {
+          const cartesian = viewer.scene.pickPosition(windowPosition);
+          if (cartesian) {
+            const cartographic = Cartographic.fromCartesian(cartesian);
+            const latitude = CSMath.toDegrees(cartographic.latitude);
+            const longitude = CSMath.toDegrees(cartographic.longitude);
+            const elevation = cartographic.height;
+            onClick(latitude, longitude, elevation);
+          }
+        }
+      }, ScreenSpaceEventType.LEFT_CLICK);
+      return () => handler.destroy();
+    }
+  }, [viewer, onClick]);
+}

--- a/src/components/lava-coder/use-cesium-viewer.ts
+++ b/src/components/lava-coder/use-cesium-viewer.ts
@@ -1,13 +1,6 @@
-import {
-  Cartesian3, CesiumWidget, createWorldTerrainAsync, Math as CSMath, ImageryLayer, Ion, KmlDataSource, Rectangle,
-  SingleTileImageryProvider, TerrainProvider
-} from "@cesium/engine";
-import { autorun } from "mobx";
+import { Cartesian3, CesiumWidget, Math as CSMath, Ion } from "@cesium/engine";
 import { useEffect, useRef, useState } from "react";
-import hazardZonesKml from "../../assets/Volcano_Lava_Flow_Hazard_Zones.kml";
-import { lavaElevations, lavaSimulation } from "../../stores/lava-simulation-store";
-import { maxLat, maxLong, minLat, minLong } from "./lava-constants";
-import { visualizeLava } from "./visualize-lava";
+import { useTerrainProvider } from "./use-terrain-provider";
 
 import "@cesium/engine/Source/Widget/CesiumWidget.css";
 
@@ -21,7 +14,6 @@ export function useCesiumViewer(container: Element | null) {
   const viewer = useRef<CesiumWidget | null>(null);
   const [ , forceRefresh] = useState(false);
   const terrainProvider = useTerrainProvider();
-  const lavaLayerRef = useRef<ImageryLayer | null>(null);
 
   useEffect(() => {
     if (container && terrainProvider && !viewer.current) {
@@ -44,27 +36,6 @@ export function useCesiumViewer(container: Element | null) {
     }
     return () => viewer.current?.destroy();
   }, [container, terrainProvider]);
-  
-  // Update the lava display
-  useEffect(() => {
-    return autorun(() => {
-      const { coveredCells, raster } = lavaSimulation;
-
-      if (!coveredCells || !lavaElevations || !raster || !widget.current) return;
-
-      const oldLayer = oldLavaLayerRef.current;
-      oldLavaLayerRef.current = lavaLayerRef.current;
-
-      const url = visualizeLava(raster, lavaElevations);
-      lavaLayerRef.current = ImageryLayer.fromProviderAsync(
-        SingleTileImageryProvider.fromUrl(url, {
-          rectangle: Rectangle.fromDegrees(minLong, minLat, maxLong, maxLat)
-        })
-      );
-      if (lavaLayerRef.current) widget.current.imageryLayers.add(lavaLayerRef.current);
-      if (oldLayer) widget.current.imageryLayers.remove(oldLayer, true);
-    });
-  }, []);
 
   return viewer.current;
 }

--- a/src/components/lava-coder/use-hazard-zones.ts
+++ b/src/components/lava-coder/use-hazard-zones.ts
@@ -1,0 +1,19 @@
+import { KmlDataSource } from "@cesium/engine";
+import { useEffect, useState } from "react";
+import hazardZonesKml from "../../assets/Volcano_Lava_Flow_Hazard_Zones.kml";
+
+export function useHazardZones() {
+  const [hazardZones, setHazardZones] = useState<KmlDataSource | null>(null);
+
+  useEffect(() => {
+    // Load and overlay the KML file
+    KmlDataSource.load(hazardZonesKml, { clampToGround: true }).then((dataSource) => {
+      setHazardZones(dataSource);
+      dataSource.show = false; // Initially hide the KML data
+    }).catch((error) => {
+      console.error("Failed to load KML file:", error);
+    });
+  }, []);
+
+  return hazardZones;
+}

--- a/src/components/lava-coder/use-hazard-zones.ts
+++ b/src/components/lava-coder/use-hazard-zones.ts
@@ -1,8 +1,8 @@
-import { KmlDataSource } from "@cesium/engine";
+import { CesiumWidget, KmlDataSource } from "@cesium/engine";
 import { useEffect, useState } from "react";
 import hazardZonesKml from "../../assets/Volcano_Lava_Flow_Hazard_Zones.kml";
 
-export function useHazardZones() {
+export function useHazardZones(viewer: CesiumWidget | null, showHazardZones: boolean, verticalExaggeration: number) {
   const [hazardZones, setHazardZones] = useState<KmlDataSource | null>(null);
 
   useEffect(() => {
@@ -14,6 +14,22 @@ export function useHazardZones() {
       console.error("Failed to load KML file:", error);
     });
   }, []);
+
+  useEffect(() => {
+    if (hazardZones) {
+      hazardZones.show = showHazardZones;
+    }
+  }, [hazardZones, showHazardZones]);
+
+  useEffect(() => {
+    if (viewer) {
+      // update hazard zones overlay when vertical exaggeration is changed
+      viewer.dataSources.removeAll();
+      if (hazardZones) {
+        viewer.dataSources.add(hazardZones);
+      }
+    }
+  }, [hazardZones, verticalExaggeration, viewer]);
 
   return hazardZones;
 }

--- a/src/components/lava-coder/use-lava-overlay.ts
+++ b/src/components/lava-coder/use-lava-overlay.ts
@@ -1,0 +1,34 @@
+import { CesiumWidget, ImageryLayer, Rectangle, SingleTileImageryProvider } from "@cesium/engine";
+import { autorun } from "mobx";
+import { useEffect, useRef } from "react";
+import { lavaElevations, lavaSimulation } from "../../stores/lava-simulation-store";
+import { visualizeLava } from "./visualize-lava";
+import { maxLat, maxLong, minLat, minLong } from "./lava-constants";
+
+export function useLavaOverlay(viewer: CesiumWidget | null) {
+  const lavaLayerRef = useRef<ImageryLayer | null>(null);
+  // Two layers are displayed to avoid flickering. A layer is only removed when it is the third oldest.
+  // This works as long as the lava always expands. If it ever contracts, this will display incorrectly.
+  const oldLavaLayerRef = useRef<ImageryLayer | null>(null);
+
+  // Update the lava display
+  useEffect(() => {
+    return autorun(() => {
+      const { coveredCells, raster } = lavaSimulation;
+
+      if (!coveredCells || !lavaElevations || !raster || !viewer) return;
+
+      const oldLayer = oldLavaLayerRef.current;
+      oldLavaLayerRef.current = lavaLayerRef.current;
+
+      const url = visualizeLava(raster, lavaElevations);
+      lavaLayerRef.current = ImageryLayer.fromProviderAsync(
+        SingleTileImageryProvider.fromUrl(url, {
+          rectangle: Rectangle.fromDegrees(minLong, minLat, maxLong, maxLat)
+        })
+      );
+      if (lavaLayerRef.current) viewer.imageryLayers.add(lavaLayerRef.current);
+      if (oldLayer) viewer.imageryLayers.remove(oldLayer, true);
+    });
+  }, [viewer]);
+}

--- a/src/components/lava-coder/use-lava-overlay.ts
+++ b/src/components/lava-coder/use-lava-overlay.ts
@@ -2,8 +2,8 @@ import { CesiumWidget, ImageryLayer, Rectangle, SingleTileImageryProvider } from
 import { autorun } from "mobx";
 import { useEffect, useRef } from "react";
 import { lavaElevations, lavaSimulation } from "../../stores/lava-simulation-store";
-import { visualizeLava } from "./visualize-lava";
 import { maxLat, maxLong, minLat, minLong } from "./lava-constants";
+import { visualizeLava } from "./visualize-lava";
 
 export function useLavaOverlay(viewer: CesiumWidget | null) {
   const lavaLayerRef = useRef<ImageryLayer | null>(null);

--- a/src/components/lava-coder/use-terrain-provider.ts
+++ b/src/components/lava-coder/use-terrain-provider.ts
@@ -1,0 +1,15 @@
+import { createWorldTerrainAsync, TerrainProvider } from "@cesium/engine";
+import { useEffect, useState } from "react";
+
+export function useTerrainProvider() {
+  const [terrainProvider, setTerrainProvider] = useState<TerrainProvider | null>(null);
+
+  useEffect(() => {
+    // Add Cesium World Terrain
+    createWorldTerrainAsync().then((provider) => {
+      setTerrainProvider(provider);
+    });
+  }, []);
+
+  return terrainProvider;
+}

--- a/src/components/lava-coder/use-vertical-exaggeration.ts
+++ b/src/components/lava-coder/use-vertical-exaggeration.ts
@@ -1,0 +1,22 @@
+import { CesiumWidget } from "@cesium/engine";
+import { useEffect, useState } from "react";
+
+const kNormalElevation = 1;
+// The vertical exaggeration factor for the terrain. This is used to make the terrain more visually distinct.
+const kVerticalExaggeration = 3;
+
+export function useVerticalExaggeration(viewer: CesiumWidget | null) {
+  const [verticalExaggeration, setVerticalExaggeration] = useState(kNormalElevation);
+
+  function toggleVerticalExaggeration() {
+    setVerticalExaggeration(prev => prev === kNormalElevation ? kVerticalExaggeration : kNormalElevation);
+  }
+
+  useEffect(() => {
+    if (viewer) {
+      viewer.scene.verticalExaggeration = verticalExaggeration;
+    }
+  }, [verticalExaggeration, viewer]);
+
+  return { toggleVerticalExaggeration, verticalExaggeration };
+}

--- a/src/components/lava-coder/use-vertical-exaggeration.ts
+++ b/src/components/lava-coder/use-vertical-exaggeration.ts
@@ -1,9 +1,9 @@
 import { CesiumWidget } from "@cesium/engine";
 import { useEffect, useState } from "react";
 
-const kNormalElevation = 1;
+export const kNormalElevation = 1;
 // The vertical exaggeration factor for the terrain. This is used to make the terrain more visually distinct.
-const kVerticalExaggeration = 3;
+export const kVerticalExaggeration = 3;
 
 export function useVerticalExaggeration(viewer: CesiumWidget | null) {
   const [verticalExaggeration, setVerticalExaggeration] = useState(kNormalElevation);

--- a/src/components/lava-coder/use-world-imagery.ts
+++ b/src/components/lava-coder/use-world-imagery.ts
@@ -1,0 +1,22 @@
+import { CesiumWidget, createWorldImageryAsync, ImageryLayer, IonWorldImageryStyle } from "@cesium/engine";
+import { useEffect } from "react";
+
+export function useWorldImagery(viewer: CesiumWidget | null, showLabels: boolean) {
+  useEffect(() => {
+    if (viewer) {
+      const style: IonWorldImageryStyle = showLabels
+        ? IonWorldImageryStyle.AERIAL_WITH_LABELS
+        : IonWorldImageryStyle.AERIAL;
+      createWorldImageryAsync({ style }).then((imageryProvider) => {
+        // Remove the old base layer
+        const oldBaseLayer = viewer.imageryLayers.get(0);
+        if (oldBaseLayer) {
+          viewer.imageryLayers.remove(oldBaseLayer);
+        }
+        const newBaseLayer = new ImageryLayer(imageryProvider);
+        // Add the new base layer at the bottom of the layer stack
+        viewer.imageryLayers.add(newBaseLayer, 0);
+      });
+    }
+  }, [showLabels, viewer]);
+}


### PR DESCRIPTION
[[GEOCODE-11](https://concord-consortium.atlassian.net/browse/GEOCODE-11)] Restrict vent locations to specific areas

The first step in implementing a UI for placing vents is to be able to receive click events on the map, which is what this PR provides. For now it just `console.log`'s the click location. There's also a little bit of refactoring of part of the Cesium code into separate hooks.

Note: There will be some conflicts between this PR and @tealefristoe's Molasses PR (#353). That PR should be merged before this one so that the conflicts can be resolved in this PR rather than making that one more complicated than it already is.

[GEOCODE-11]: https://concord-consortium.atlassian.net/browse/GEOCODE-11?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ