### PR TITLE
Geocode-28 Pulse Control

### DIFF
--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -51,7 +51,7 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
     /** ==== Molasses simulation functions ==== */
 
     addFunc("setMolassesEruptionVolume", (volume: number) => {
-      lavaSimulation.setTotalVolumeAndUpdatePulseVolume(volume);
+      lavaSimulation.setTotalVolume(volume);
     });
     addFunc("setMolassesLavaFront", (height: number) => {
       lavaSimulation.setResidual(height);

--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -132,8 +132,14 @@ const AuthoringMenu: React.FC<IProps> = (props) => {
               options={LavaMapTypeStrings} />
             <DatNumber path="uiStore.verticalExaggeration" label={strings.VERTICAL_EXAGGERATION} key="verticalExaggeration"
               min={1} max={5} step={1}/>
-            <DatNumber path="uiStore.pulsesPerEruption" label={strings.PULSES_PER_ERUPTION} key="pulsesPerEruption"
-              min={1} max={100} step={1}/>
+            <DatNumber
+              path="uiStore.hundredsOfPulsesPerEruption"
+              label={strings.PULSES_PER_ERUPTION}
+              key="pulsesPerEruption"
+              min={1}
+              max={100}
+              step={1}
+            />
           </DatFolder>,
 
           <DatFolder title={strings.CONDITIONS_OPTIONS} key="conditionsFolder" closed={false}>

--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -132,6 +132,8 @@ const AuthoringMenu: React.FC<IProps> = (props) => {
               options={LavaMapTypeStrings} />
             <DatNumber path="uiStore.verticalExaggeration" label={strings.VERTICAL_EXAGGERATION} key="verticalExaggeration"
               min={1} max={5} step={1}/>
+            <DatNumber path="uiStore.pulsesPerEruption" label={strings.PULSES_PER_ERUPTION} key="pulsesPerEruption"
+              min={1} max={100} step={1}/>
           </DatFolder>,
 
           <DatFolder title={strings.CONDITIONS_OPTIONS} key="conditionsFolder" closed={false}>

--- a/src/components/lava-coder/lava-constants.ts
+++ b/src/components/lava-coder/lava-constants.ts
@@ -4,7 +4,6 @@ export const kMetersPerFoot = 1 / kFeetPerMeter;
 // Default eruption values
 // These values are hardcoded in full-toolbox.xml and possibly other toolboxes and should be kept in sync
 export const defaultEruptionVolume = 200000000;
-export const defaultPulseVolume = 100000;
 export const defaultResidual = 5;
 export const defaultVentLatitude = 19.5;
 export const defaultVentLongitude = -155.565;

--- a/src/stores/lava-simulation-store.ts
+++ b/src/stores/lava-simulation-store.ts
@@ -2,9 +2,10 @@ import { types } from "mobx-state-tree";
 import MolassesWorker from "../components/lava-coder/molasses.worker";
 import { AsciiRaster } from "../components/lava-coder/parse-ascii-raster";
 import {
-  defaultEruptionVolume, defaultPulseVolume, defaultResidual, defaultVentLatitude, defaultVentLongitude
+  defaultEruptionVolume, defaultResidual, defaultVentLatitude, defaultVentLongitude
 } from "../components/lava-coder/lava-constants";
 import { LavaSimulationAuthorSettings, LavaSimulationAuthorSettingsProps } from "./stores";
+import { uiStore } from "./ui-store";
 
 // Saving the lava elevations in the MST model is very slow, so we save it separately.
 // But that means that when this is updated, another observable feature (like coveredCells or pulseCount) needs to be
@@ -30,7 +31,6 @@ export const LavaSimulationStore = types
     ventLatitude: defaultVentLatitude,
     ventLongitude: defaultVentLongitude,
     totalVolume: defaultEruptionVolume,
-    pulseVolume: defaultPulseVolume, // Standard for small eruption
     pulseCount: 0,
   })
   .volatile((self) => ({
@@ -53,11 +53,6 @@ export const LavaSimulationStore = types
     },
     setTotalVolume(totalVolume: number) {
       self.totalVolume = totalVolume;
-    },
-    setTotalVolumeAndUpdatePulseVolume(totalVolume: number) {
-      self.totalVolume = totalVolume;
-      // Update pulse volume to be proportional to the total volume
-      self.pulseVolume = totalVolume * defaultPulseVolume / defaultEruptionVolume;
     },
     setVentLatitude(ventLatitude: number) {
       self.ventLatitude = ventLatitude;
@@ -96,7 +91,7 @@ export const LavaSimulationStore = types
       };
 
       const parameters = {
-        pulseVolume: self.pulseVolume,
+        pulseVolume: self.totalVolume / uiStore.pulsesPerEruption,
         raster: self.raster,
         residual: self.residual,
         totalVolume: self.totalVolume,

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -149,6 +149,7 @@ const uiAuthorSettingsProps = tuple(
   "showMapTypeStreet",
   "mapType",
   "verticalExaggeration",
+  "pulsesPerEruption",
   "showEruptedVolume",
   "showLavaFrontHeight",
   "showVentLocation",

--- a/src/stores/stores.ts
+++ b/src/stores/stores.ts
@@ -149,7 +149,7 @@ const uiAuthorSettingsProps = tuple(
   "showMapTypeStreet",
   "mapType",
   "verticalExaggeration",
-  "pulsesPerEruption",
+  "hundredsOfPulsesPerEruption",
   "showEruptedVolume",
   "showLavaFrontHeight",
   "showVentLocation",

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -50,7 +50,7 @@ const UIStore = types.model("UI", {
   mapType: types.optional(types.enumeration(LavaMapTypes), "terrain"),
   // vertical exaggeration (1 = normal, 2 = 2x, 3 = 3x, etc)
   verticalExaggeration: 1,
-  // number of hundreds of pulses for each eruption. The actual of pulses will be 100x this one.
+  // number of hundreds of pulses for each eruption. The actual number of pulses will be 100x this one.
   hundredsOfPulsesPerEruption: 20,
   // show the erupted volume widget
   showEruptedVolume: true,

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -50,6 +50,8 @@ const UIStore = types.model("UI", {
   mapType: types.optional(types.enumeration(LavaMapTypes), "terrain"),
   // vertical exaggeration (1 = normal, 2 = 2x, 3 = 3x, etc)
   verticalExaggeration: 1,
+  // number of pulses for each eruption. The actual number is 100x this one.
+  pulsesPerEruption: 20,
   // show the erupted volume widget
   showEruptedVolume: true,
   // show the lava front height (residual) widget

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -50,8 +50,8 @@ const UIStore = types.model("UI", {
   mapType: types.optional(types.enumeration(LavaMapTypes), "terrain"),
   // vertical exaggeration (1 = normal, 2 = 2x, 3 = 3x, etc)
   verticalExaggeration: 1,
-  // number of pulses for each eruption. The actual number is 100x this one.
-  pulsesPerEruption: 20,
+  // number of hundreds of pulses for each eruption. The actual of pulses will be 100x this one.
+  hundredsOfPulsesPerEruption: 20,
   // show the erupted volume widget
   showEruptedVolume: true,
   // show the lava front height (residual) widget
@@ -63,6 +63,11 @@ const UIStore = types.model("UI", {
   leftTabIndex: 0,
   rightTabIndex: 0,
 })
+.views((self) => ({
+  get pulsesPerEruption() {
+    return self.hundredsOfPulsesPerEruption * 100;
+  }
+}))
 .actions((self) => ({
   setShowOptionsDialog(show: boolean) {
     self.showOptionsDialog = show;

--- a/src/strings/components/authoring-menu.ts
+++ b/src/strings/components/authoring-menu.ts
@@ -76,6 +76,7 @@ export const SHOW_MAP_TYPE_LABELED_TERRAIN = "Show labeled terrain map type?";
 export const SHOW_MAP_TYPE_STREET = "Show street map type?";
 export const INITIAL_MAP_TYPE = "Initial map type";
 export const VERTICAL_EXAGGERATION = "Vertical exaggeration";
+export const PULSES_PER_ERUPTION = "Hundreds of pulses per eruption";
 export const CONDITIONS_OPTIONS = "Conditions Options";
 export const SHOW_ERUPTED_VOLUME = "Show erupted volume?";
 export const SHOW_LAVA_FRONT_HEIGHT = "Show lava front height?";


### PR DESCRIPTION
Jira story: https://concord-consortium.atlassian.net/browse/GEOCODE-28

This PR adds a menu item that allows an author to control the number of pulses per eruption.