### PR TITLE
feat: use low-resolution imagery during development [GEOCODE-49]

### DIFF
--- a/src/components/lava-coder/lava-coder-view.tsx
+++ b/src/components/lava-coder/lava-coder-view.tsx
@@ -42,6 +42,7 @@ export const LavaCoderView = observer(function LavaCoderView({ width, height, ma
   } = uiStore;
   const [lavaCoderElt, setLavaCoderElt] = useState<HTMLDivElement | null>(null);
   const mapLabels: Record<LavaMapType, string> = {
+    develop: "Develop",
     terrain: "Terrain",
     terrainWithLabels: "Labeled",
     street: "Street"
@@ -50,12 +51,12 @@ export const LavaCoderView = observer(function LavaCoderView({ width, height, ma
   const [showVentLocationPopup, setShowVentLocationPopup] = useState(false);
   const [cursor, setCursor] = useState("auto");
 
-  const viewer = useCesiumViewer(lavaCoderElt);
+  const viewer = useCesiumViewer(lavaCoderElt, mapType);
 
   const { cameraMode, setCameraMode, setDefaultCameraView, zoomIn, zoomOut } =
     useCameraControls(viewer, verticalExaggeration);
 
-  useWorldImagery(viewer, mapType);
+  const { replaceBaseLayer } = useWorldImagery();
 
   useVerticalExaggeration(viewer, verticalExaggeration);
 
@@ -110,6 +111,7 @@ export const LavaCoderView = observer(function LavaCoderView({ width, height, ma
 
   function toggleMapType() {
     const availableMapTypes = LavaMapTypes.filter(type => {
+      if (type === "develop") return false; // development map type is not available via toggle
       if (type === "terrain" && !showMapTypeTerrain) return false;
       if (type === "terrainWithLabels" && !showMapTypeLabeledTerrain) return false;
       if (type === "street" && !showMapTypeStreet) return false;
@@ -118,6 +120,7 @@ export const LavaCoderView = observer(function LavaCoderView({ width, height, ma
     const currMapIndex = availableMapTypes.indexOf(mapType);
     const nextMapType = availableMapTypes[(currMapIndex + 1) % availableMapTypes.length];
     uiStore.setMapType(nextMapType);
+    replaceBaseLayer(viewer, nextMapType);
   }
 
   function togglePlaceVentMode() {

--- a/src/components/lava-coder/use-cesium-viewer.ts
+++ b/src/components/lava-coder/use-cesium-viewer.ts
@@ -8,7 +8,7 @@ import "@cesium/engine/Source/Widget/CesiumWidget.css";
 
 Ion.defaultAccessToken = process.env.CESIUM_ION_ACCESS_TOKEN;
 
-export function useCesiumViewer(container: Element | null, mapType: LavaMapType) {
+export function useCesiumViewer(container: Element | null, initialMapType: LavaMapType) {
   const viewer = useRef<CesiumWidget | null>(null);
   const [ , forceRefresh] = useState(false);
   const { createBaseLayer } = useWorldImagery();
@@ -17,11 +17,11 @@ export function useCesiumViewer(container: Element | null, mapType: LavaMapType)
 
   useEffect(() => {
     if (!baseLayer) {
-      createBaseLayer(mapType).then(layer => {
+      createBaseLayer(initialMapType).then(layer => {
         setBaseLayer(layer);
       });
     }
-  }, [baseLayer, createBaseLayer, mapType]);
+  }, [baseLayer, createBaseLayer, initialMapType]);
 
   useEffect(() => {
     if (!viewer.current && container && baseLayer && terrainProvider) {

--- a/src/components/lava-coder/use-cesium-viewer.ts
+++ b/src/components/lava-coder/use-cesium-viewer.ts
@@ -1,26 +1,39 @@
-import { CesiumWidget, Ion } from "@cesium/engine";
+import { CesiumWidget, ImageryLayer, Ion } from "@cesium/engine";
 import { useEffect, useRef, useState } from "react";
+import { LavaMapType } from "../../stores/ui-store";
 import { useTerrainProvider } from "./use-terrain-provider";
+import { useWorldImagery } from "./use-world-imagery";
 
 import "@cesium/engine/Source/Widget/CesiumWidget.css";
 
 Ion.defaultAccessToken = process.env.CESIUM_ION_ACCESS_TOKEN;
 
-export function useCesiumViewer(container: Element | null) {
+export function useCesiumViewer(container: Element | null, mapType: LavaMapType) {
   const viewer = useRef<CesiumWidget | null>(null);
   const [ , forceRefresh] = useState(false);
+  const { createBaseLayer } = useWorldImagery();
+  const [baseLayer, setBaseLayer] = useState<ImageryLayer | null>(null);
   const terrainProvider = useTerrainProvider();
 
   useEffect(() => {
-    if (container && terrainProvider && !viewer.current) {
+    if (!baseLayer) {
+      createBaseLayer(mapType).then(layer => {
+        setBaseLayer(layer);
+      });
+    }
+  }, [baseLayer, createBaseLayer, mapType]);
+
+  useEffect(() => {
+    if (!viewer.current && container && baseLayer && terrainProvider) {
       viewer.current = new CesiumWidget(container, {
         shouldAnimate: true,
+        baseLayer,
         terrainProvider
       });
       forceRefresh(prev => !prev);
     }
     return () => viewer.current?.destroy();
-  }, [container, terrainProvider]);
+  }, [baseLayer, container, terrainProvider]);
 
   return viewer.current;
 }

--- a/src/components/lava-coder/use-world-imagery.ts
+++ b/src/components/lava-coder/use-world-imagery.ts
@@ -1,33 +1,53 @@
 import {
-  CesiumWidget, createWorldImageryAsync, ImageryLayer, ImageryProvider, IonWorldImageryStyle,
+  CesiumWidget, createWorldImageryAsync, ImageryLayer, ImageryProvider, IonImageryProvider, IonWorldImageryStyle,
   OpenStreetMapImageryProvider
 } from "@cesium/engine";
-import { useEffect } from "react";
+import { useCallback } from "react";
 import { LavaMapType } from "../../stores/ui-store";
 
-export function useWorldImagery(viewer: CesiumWidget | null, type: LavaMapType) {
-  useEffect(() => {
-    if (viewer) {
-      let imageryProviderPromise: Promise<ImageryProvider>;
-      if (type === "street") {
-        imageryProviderPromise = Promise.resolve(new OpenStreetMapImageryProvider({}));
-      } else {
-        const style: IonWorldImageryStyle = type === "terrainWithLabels"
-          ? IonWorldImageryStyle.AERIAL_WITH_LABELS
-          : IonWorldImageryStyle.AERIAL;
-        imageryProviderPromise = createWorldImageryAsync({ style });
-      }
+const imageryProviders: Partial<Record<LavaMapType, Promise<ImageryProvider>>> = {};
 
-      imageryProviderPromise.then((imageryProvider) => {
-        // Remove the old base layer
-        const oldBaseLayer = viewer.imageryLayers.get(0);
-        if (oldBaseLayer) {
-          viewer.imageryLayers.remove(oldBaseLayer);
-        }
-        const newBaseLayer = new ImageryLayer(imageryProvider);
-        // Add the new base layer at the bottom of the layer stack
-        viewer.imageryLayers.add(newBaseLayer, 0);
-      });
+function getImageryProvider(type: LavaMapType): Promise<ImageryProvider> {
+  if (!imageryProviders[type]) {
+    if (type === "develop") {
+      // Use lower-resolution imagery for development
+      imageryProviders[type] = IonImageryProvider.fromAssetId(3954); // Sentinel-2 imagery
     }
-  }, [type, viewer]);
+    else if (type === "street") {
+      imageryProviders[type] = Promise.resolve(new OpenStreetMapImageryProvider({}));
+    }
+    else {
+      // Bing maps is the default imagery provider in Cesium
+      const style: IonWorldImageryStyle = type === "terrainWithLabels"
+        ? IonWorldImageryStyle.AERIAL_WITH_LABELS
+        : IonWorldImageryStyle.AERIAL;
+      imageryProviders[type] = createWorldImageryAsync({ style });
+    }
+  }
+  return imageryProviders[type];
+}
+
+export function useWorldImagery() {
+
+  const createBaseLayer = useCallback(async (mapType: LavaMapType) => {
+    const imageryProvider = await getImageryProvider(mapType);
+    return new ImageryLayer(imageryProvider);
+  }, []);
+
+  const replaceBaseLayer = useCallback(async (viewer: CesiumWidget | null, mapType: LavaMapType) => {
+    if (!viewer) return;
+
+    const newBaseLayer = await createBaseLayer(mapType);
+    if (newBaseLayer) {
+      // Remove the old base layer
+      const oldBaseLayer = viewer.imageryLayers.get(0);
+      if (oldBaseLayer) {
+        viewer.imageryLayers.remove(oldBaseLayer);
+      }
+      // Add the new base layer at the bottom of the layer stack
+      viewer.imageryLayers.add(newBaseLayer, 0);
+    }
+  }, [createBaseLayer]);
+
+  return { createBaseLayer, replaceBaseLayer };
 }

--- a/src/components/lava-coder/use-world-imagery.ts
+++ b/src/components/lava-coder/use-world-imagery.ts
@@ -11,7 +11,8 @@ function getImageryProvider(type: LavaMapType): Promise<ImageryProvider> {
   if (!imageryProviders[type]) {
     if (type === "develop") {
       // Use lower-resolution imagery for development
-      imageryProviders[type] = IonImageryProvider.fromAssetId(3954); // Sentinel-2 imagery
+      const SENTINEL_2_IMAGERY_ASSET_ID = 3954;
+      imageryProviders[type] = IonImageryProvider.fromAssetId(SENTINEL_2_IMAGERY_ASSET_ID);
     }
     else if (type === "street") {
       imageryProviders[type] = Promise.resolve(new OpenStreetMapImageryProvider({}));

--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -1,11 +1,13 @@
 import { types } from "mobx-state-tree";
+import { isLocalhost } from "../utilities/js-utils";
 import { UIAuthorSettings, UIAuthorSettingsProps } from "./stores";
 
 const km3ToM3 = 1000000; // 1 km^3 = 1000000 m^3
 
-export const LavaMapTypes = ["terrain", "terrainWithLabels", "street"] as const;
+export const LavaMapTypes = ["develop", "terrain", "terrainWithLabels", "street"] as const;
 export const LavaMapTypeStrings = LavaMapTypes.map((type) => type.toString());
 export type LavaMapType = typeof LavaMapTypes[number];
+const kDefaultMapType: LavaMapType = isLocalhost() ? "develop" : "terrain";
 
 const UIStore = types.model("UI", {
   showOptionsDialog: true,
@@ -49,7 +51,7 @@ const UIStore = types.model("UI", {
   // whether to include street in the map type options
   showMapTypeStreet: true,
   // current map type
-  mapType: types.optional(types.enumeration(LavaMapTypes), "terrain"),
+  mapType: types.optional(types.enumeration(LavaMapTypes), kDefaultMapType),
   // vertical exaggeration (1 = normal, 2 = 2x, 3 = 3x, etc)
   verticalExaggeration: 1,
   // number of hundreds of pulses for each eruption. The actual number of pulses will be 100x this one.

--- a/src/utilities/js-utils.ts
+++ b/src/utilities/js-utils.ts
@@ -1,0 +1,7 @@
+export function isLocalhost() {
+  return (
+    typeof window !== "undefined" &&
+    (window.location.hostname === "localhost" ||
+      window.location.hostname === "127.0.0.1")
+  );
+}


### PR DESCRIPTION
[[GEOCODE-49](https://concord-consortium.atlassian.net/browse/GEOCODE-49)] Reduce use of Bing map imagery during development

For our free Cesium account, there is a quota for how many Bing imagery sessions we can use in a month, which we have exceeded for the month of May. With this PR, imagery defaults to lower-resolution imagery with a different quota during development so that we don't chew up our monthly Bing quota as quickly.

[GEOCODE-49]: https://concord-consortium.atlassian.net/browse/GEOCODE-49?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ