### PR TITLE
Geocode-39 Area Covered Box

### DIFF
--- a/src/components/lava-coder/acres-covered-box.scss
+++ b/src/components/lava-coder/acres-covered-box.scss
@@ -1,0 +1,15 @@
+.acres-covered-box {
+  align-items: center;
+  background-color: #ddedff;
+  border: solid 2px white;
+  border-radius: 5px;
+  bottom: 50px;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  height: 47px;
+  justify-content: center;
+  position: absolute;
+  right: 11px;
+  width: 169px;
+}

--- a/src/components/lava-coder/acres-covered-box.scss
+++ b/src/components/lava-coder/acres-covered-box.scss
@@ -3,13 +3,21 @@
   background-color: #ddedff;
   border: solid 2px white;
   border-radius: 5px;
-  bottom: 50px;
+  bottom: 80px;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
   height: 47px;
   justify-content: center;
   position: absolute;
-  right: 11px;
+  right: 15px;
   width: 169px;
+
+  .acres-covered-label {
+    font-size: 16px;
+  }
+
+  .acres-covered-value {
+    font-size: 14px;
+  }
 }

--- a/src/components/lava-coder/acres-covered-box.tsx
+++ b/src/components/lava-coder/acres-covered-box.tsx
@@ -1,0 +1,15 @@
+import "./acres-covered-box.scss";
+
+interface AcresCoveredBoxProps {
+  acresCovered: number;
+}
+export function AcresCovered({ acresCovered }: AcresCoveredBoxProps) {
+  return (
+    <div className="acres-covered-box">
+      <div className="acres-covered-label">Total Area Covered:</div>
+      <div className="acres-covered-value">
+        {acresCovered.toLocaleString()} acres
+      </div>
+    </div>
+  );
+}

--- a/src/components/lava-coder/acres-covered-box.tsx
+++ b/src/components/lava-coder/acres-covered-box.tsx
@@ -1,15 +1,18 @@
+import { observer } from "mobx-react-lite";
+import { lavaSimulation } from "../../stores/lava-simulation-store";
+
 import "./acres-covered-box.scss";
 
-interface AcresCoveredBoxProps {
-  acresCovered: number;
-}
-export function AcresCovered({ acresCovered }: AcresCoveredBoxProps) {
+export const AcresCovered = observer(function AcresCovered() {
+  // Only display if the simulation is running or has completed.
+  if (!lavaSimulation.worker) return null;
+
   return (
     <div className="acres-covered-box">
       <div className="acres-covered-label">Total Area Covered:</div>
       <div className="acres-covered-value">
-        {acresCovered.toLocaleString()} acres
+        {Math.round(lavaSimulation.acresCovered).toLocaleString()} acres
       </div>
     </div>
   );
-}
+});

--- a/src/components/lava-coder/acres-covered-box.tsx
+++ b/src/components/lava-coder/acres-covered-box.tsx
@@ -1,4 +1,4 @@
-import { observer } from "mobx-react-lite";
+import { observer } from "mobx-react";
 import { lavaSimulation } from "../../stores/lava-simulation-store";
 
 import "./acres-covered-box.scss";

--- a/src/components/lava-coder/lava-coder-view.tsx
+++ b/src/components/lava-coder/lava-coder-view.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import VentLocationMarkerIcon from "../../assets/lava-coder/location-marker.png";
 import { lavaSimulation } from "../../stores/lava-simulation-store";
 import { LavaMapType, LavaMapTypes, uiStore } from "../../stores/ui-store";
+import { AcresCovered } from "./acres-covered-box";
 import { CompassHeading } from "./compass-heading";
 import { ConcordAttribution } from "./concord-attribution";
 import {
@@ -188,6 +189,7 @@ export const LavaCoderView = observer(function LavaCoderView({ width, height, ma
           </LavaIconButton>
         )}
       </div>
+      <AcresCovered />
       <ConcordAttribution />
       <VentLocationPopup viewer={viewer} ventLocation={ventLocation} verticalExaggeration={verticalExaggeration}
                         show={showVentLocationPopup} onClose={handleCloseVentLocationPopup}/>

--- a/src/components/lava-coder/lava-constants.ts
+++ b/src/components/lava-coder/lava-constants.ts
@@ -1,5 +1,6 @@
 export const kFeetPerMeter = 3.28084;
 export const kMetersPerFoot = 1 / kFeetPerMeter;
+export const kSquareMetersPerAcre = 4046.86;
 
 // Default eruption values
 // These values are hardcoded in full-toolbox.xml and possibly other toolboxes and should be kept in sync

--- a/src/stores/lava-simulation-store.ts
+++ b/src/stores/lava-simulation-store.ts
@@ -2,7 +2,7 @@ import { types } from "mobx-state-tree";
 import MolassesWorker from "../components/lava-coder/molasses.worker";
 import { AsciiRaster } from "../components/lava-coder/parse-ascii-raster";
 import {
-  defaultEruptionVolume, defaultResidual, defaultVentLatitude, defaultVentLongitude
+  defaultEruptionVolume, defaultResidual, defaultVentLatitude, defaultVentLongitude, kSquareMetersPerAcre
 } from "../components/lava-coder/lava-constants";
 import { LavaSimulationAuthorSettings, LavaSimulationAuthorSettingsProps } from "./stores";
 import { uiStore } from "./ui-store";
@@ -38,6 +38,16 @@ export const LavaSimulationStore = types
     raster: null as AsciiRaster | null, // AsciiRaster
     worker: null as Worker | null,
     resetCount: 0 // Used to reset the camera when the simulation is reset
+  }))
+  .views((self) => ({
+    get cellArea() {
+      return (self.raster?.header.cellsize ?? 60) ** 2; // Default cell size is 60 meters
+    }
+  }))
+  .views((self) => ({
+    get acresCovered() {
+      return self.coveredCells * self.cellArea / kSquareMetersPerAcre; // Convert square meters to acres
+    }
   }))
   .actions((self) => ({
     countCoveredCells(grid: number[][]) {


### PR DESCRIPTION
Jira story: https://concord-consortium.atlassian.net/browse/GEOCODE-39

This PR adds a box that displays the number of acres currently covered by lava. The box only appears when a simulation is running or after it has completed.

Design is in the second row here: https://app.zeplin.io/project/5d1a9a60dff09673c4391eaf/screen/67c8aeeecca5b7a3fd82baf8