### PR TITLE
feat: `Reload` button respects `unit` url parameter; vent location marker enhancements

### DIFF
--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -61,8 +61,7 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
         blocklyController.throwError("You must set a latitude and longitude for the vent location.");
         return;
       }
-      lavaSimulation.setVentLatitude(params.lat);
-      lavaSimulation.setVentLongitude(params.long);
+      lavaSimulation.setVentLocation(params.lat, params.long);
     });
 
     addFunc("runMolassesSimulation", () => {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -218,7 +218,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     this.blocklyController = new BlocklyController(this.stores);
   }
 
-  public componentDidMount() {
+  public parseQueryParams() {
     const unit = queryValue("unit");
     let hideModelOptions = queryValueBoolean("hide-model-options");
     if (unit === "Tephra") {
@@ -234,6 +234,10 @@ export class AppComponent extends BaseComponent<IProps, IState> {
       unitStore.setUnit(unit);
     }
     uiStore.setShowOptionsDialog(!hideModelOptions);
+  }
+
+  public componentDidMount() {
+    this.parseQueryParams();
 
     // Trigger the Enter key when pasting into Blockly HTML input fields
     window.addEventListener("paste", this.handlePaste);
@@ -380,6 +384,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
       // controllers, before reloading the initial application state
       reset();
       this.props.reload();
+      this.parseQueryParams();
     };
 
     const showReloadModal = () => this.setState({showingReloadModal: true});
@@ -540,7 +545,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                     />
                   }
                   { isLavaCoder &&
-                    <LavaCoderView width={mapWidth - 2 * simMargin.x} height={mapHeight} margin={simMarginStr} />
+                    <LavaCoderView width={mapWidth - 2 * simMargin.x} height={mapHeight} margin={simMarginStr} running={running} />
                   }
                   {
                     (isTephra || isLavaCoder) &&

--- a/src/components/buttons/icon-button.tsx
+++ b/src/components/buttons/icon-button.tsx
@@ -82,12 +82,12 @@ export default class IconButton extends PureComponent<IProps, IState> {
     return (
       <IconButtonContainer
         className={clsx(className, { active: this.props.isActive })}
-        onClick={onClick}
+        onClick={!disabled ? onClick : undefined}
         backgroundColor={backgroundColor}
         borderColor={borderColor}
         fontSize={fontSize}
-        hoverColor={hoverColor}
-        activeColor={activeColor}
+        hoverColor={!disabled ? hoverColor : backgroundColor || "white"}
+        activeColor={!disabled ? activeColor : backgroundColor || "white"}
         data-test={dataTest}
       >
         { children &&

--- a/src/components/lava-coder/lava-coder-view.tsx
+++ b/src/components/lava-coder/lava-coder-view.tsx
@@ -1,6 +1,6 @@
 import { reaction } from "mobx";
 import { observer } from "mobx-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import VentLocationMarkerIcon from "../../assets/lava-coder/location-marker.png";
 import { lavaSimulation } from "../../stores/lava-simulation-store";
 import { LavaMapType, LavaMapTypes, uiStore } from "../../stores/ui-store";
@@ -31,11 +31,13 @@ interface IProps {
   width: number;
   height: number;
   margin: string;
+  running: boolean;
 }
 
 const round6 = (value: number) => Math.round(value * 1000000) / 1000000;
 
-export const LavaCoderView = observer(function LavaCoderView({ width, height, margin }: IProps) {
+export const LavaCoderView = observer(function LavaCoderView({ width, height, margin, running }: IProps) {
+  const lastRunningTime = useRef(0);
   const {
     showPlaceVent, showMapType, showMapTypeTerrain, showMapTypeLabeledTerrain, showMapTypeStreet, mapType,
     verticalExaggeration
@@ -78,8 +80,21 @@ export const LavaCoderView = observer(function LavaCoderView({ width, height, ma
     );
   }, [handleCloseVentLocationPopup]);
 
-  const { ventLocation, setVentLocation } =
-    useVentLocationMarker(viewer, verticalExaggeration, handleOpenVentLocationPopup);
+  useEffect(() => {
+    return reaction(
+      () => lavaSimulation.resetCount,
+      () => handleCloseVentLocationPopup()
+    );
+  }, [handleCloseVentLocationPopup]);
+
+  // Update the last running time when the running state changes
+  if (running) lastRunningTime.current = Date.now();
+  // There can be a gap between the blockly running state and the lava simulation running state, which
+  // can result in flashing the vent location marker, so we enforce a delay after blockly running.
+  const isRunning = running ||
+                    (lastRunningTime.current > 0 && Date.now() - lastRunningTime.current < 1000) ||
+                    lavaSimulation.isRunning;
+  useVentLocationMarker({ viewer, verticalExaggeration, onClick: handleOpenVentLocationPopup, hide: isRunning });
 
   useElevationData();
 
@@ -104,12 +119,12 @@ export const LavaCoderView = observer(function LavaCoderView({ width, height, ma
                 "elevation:", `${Math.round(elevation)}m = ${elevationFeet}ft`,
                 "in hazard zone:", isInHazardZone);
     if (isPlaceVentMode && isInHazardZone) {
-      setVentLocation(latitude, longitude, elevation / verticalExaggeration);
+      lavaSimulation.setVentLocation(latitude, longitude, elevation / verticalExaggeration);
       setShowVentLocationPopup(true);
     }
     setIsPlaceVentMode(false);
     setCursor("auto");
-  }, [isPlaceVentMode, isPointInHazardZone, setVentLocation, verticalExaggeration]);
+  }, [isPlaceVentMode, isPointInHazardZone, verticalExaggeration]);
 
   useCesiumMouseEvents(viewer, handleMouseMove, handleClick);
 
@@ -177,7 +192,8 @@ export const LavaCoderView = observer(function LavaCoderView({ width, height, ma
       { isPlaceVentMode && <VentKey /> }
       <div className="lava-overlay-controls-bottom bottom-left-controls">
         {showPlaceVent && (
-          <LavaIconButton className="place-vent-button" label={"Place Vent"} onClick={() => togglePlaceVentMode()}>
+          <LavaIconButton className="place-vent-button" label={"Place Vent"} isActive={isPlaceVentMode}
+                          onClick={() => togglePlaceVentMode()} disabled={isRunning}>
             <PlaceVentMarkerIcon />
           </LavaIconButton>
         )}
@@ -191,7 +207,7 @@ export const LavaCoderView = observer(function LavaCoderView({ width, height, ma
       </div>
       <ProgressBar pulseCount={lavaSimulation.pulseCount} pulses={uiStore.pulsesPerEruption} />
       <ConcordAttribution />
-      <VentLocationPopup viewer={viewer} ventLocation={ventLocation} verticalExaggeration={verticalExaggeration}
+      <VentLocationPopup viewer={viewer} verticalExaggeration={verticalExaggeration}
                         show={showVentLocationPopup} onClose={handleCloseVentLocationPopup}/>
     </div>
   );

--- a/src/components/lava-coder/use-cesium-viewer.ts
+++ b/src/components/lava-coder/use-cesium-viewer.ts
@@ -13,7 +13,7 @@ export function useCesiumViewer(container: Element | null, initialMapType: LavaM
   const [ , forceRefresh] = useState(false);
   const { createBaseLayer } = useWorldImagery();
   const [baseLayer, setBaseLayer] = useState<ImageryLayer | null>(null);
-  const terrainProvider = useTerrainProvider();
+  const { terrainProvider } = useTerrainProvider();
 
   useEffect(() => {
     if (!baseLayer) {

--- a/src/components/lava-coder/use-terrain-provider.ts
+++ b/src/components/lava-coder/use-terrain-provider.ts
@@ -1,5 +1,5 @@
-import { createWorldTerrainAsync, TerrainProvider } from "@cesium/engine";
-import { useEffect, useState } from "react";
+import { Cartographic, createWorldTerrainAsync, sampleTerrainMostDetailed, TerrainProvider } from "@cesium/engine";
+import { useCallback, useEffect, useState } from "react";
 
 export function useTerrainProvider() {
   const [terrainProvider, setTerrainProvider] = useState<TerrainProvider | null>(null);
@@ -11,5 +11,16 @@ export function useTerrainProvider() {
     });
   }, []);
 
-  return terrainProvider;
+  const getElevation = useCallback(async (longitude: number, latitude: number): Promise<number> => {
+    if (!terrainProvider) {
+      throw new Error("Terrain provider is not initialized");
+    }
+
+    const cartographic = Cartographic.fromDegrees(longitude, latitude);
+    const [elevation] = await sampleTerrainMostDetailed(terrainProvider, [cartographic]);
+
+    return elevation.height;
+  }, [terrainProvider]);
+
+  return { getElevation, terrainProvider };
 }

--- a/src/components/lava-coder/vent-location-popup.scss
+++ b/src/components/lava-coder/vent-location-popup.scss
@@ -9,7 +9,7 @@ $control-label-color: #434343;
 
 .vent-location-popup {
   display: grid;
-  grid-template-columns: 45px 90px 42px;
+  grid-template-columns: 45px 80px 42px;
   position: absolute;
   color: $control-label-color;
   background-color: white;

--- a/src/stores/lava-simulation-store.ts
+++ b/src/stores/lava-simulation-store.ts
@@ -36,10 +36,16 @@ export const LavaSimulationStore = types
     pulseCount: 0,
   })
   .volatile((self) => ({
+    ventElevation: -1, // Used to store the vent elevation fetched from terrain
     coveredCells: 0,
     raster: null as AsciiRaster | null, // AsciiRaster
     worker: null as Worker | null,
     resetCount: 0 // Used to reset the camera when the simulation is reset
+  }))
+  .views(self => ({
+    get isRunning() {
+      return self.worker != null && self.pulseCount < uiStore.pulsesPerEruption;
+    }
   }))
   .actions((self) => ({
     countCoveredCells(grid: number[][]) {
@@ -57,11 +63,13 @@ export const LavaSimulationStore = types
     setTotalVolume(totalVolume: number) {
       self.totalVolume = totalVolume;
     },
-    setVentLatitude(ventLatitude: number) {
-      self.ventLatitude = ventLatitude;
+    setVentLocation(latitude: number, longitude: number, elevation = -1) {
+      self.ventLatitude = latitude;
+      self.ventLongitude = longitude;
+      self.ventElevation = elevation;
     },
-    setVentLongitude(ventLongitude: number) {
-      self.ventLongitude = ventLongitude;
+    setVentElevation(elevation: number) {
+      self.ventElevation = elevation;
     }
   }))
   .actions((self) => {
@@ -119,8 +127,7 @@ export const LavaSimulationStore = types
       self.setPulseCount(0);
       self.setResidual(defaultResidual);
       self.setTotalVolume(defaultEruptionVolume);
-      self.setVentLatitude(defaultVentLatitude);
-      self.setVentLongitude(defaultVentLongitude);
+      self.setVentLocation(defaultVentLatitude, defaultVentLongitude);
       self.coveredCells = 0;
       ++self.resetCount;
     }

--- a/src/stores/lava-simulation-store.ts
+++ b/src/stores/lava-simulation-store.ts
@@ -36,7 +36,7 @@ export const LavaSimulationStore = types
     pulseCount: 0,
   })
   .volatile((self) => ({
-    ventElevation: -1, // Used to store the vent elevation fetched from terrain
+    ventElevation: -1, // negative elevation means we haven't set it yet
     coveredCells: 0,
     raster: null as AsciiRaster | null, // AsciiRaster
     worker: null as Worker | null,


### PR DESCRIPTION
[[GEOCODE-51](https://concord-consortium.atlassian.net/browse/GEOCODE-51)] Reload button on LavaCoder should not reload to Tephra unit

- feat: reload button respects `unit` url parameter
- feat: hide vent location marker during simulation
- feat: Place Vent button disabled during simulation
- feat: vent location marker resets when reset button clicked
- feat: show initial/default vent location marker

While working on the `Reload` button behavior, I noticed that the vent location marker wasn't being reset correctly on reset/reload. This was because the vent location was being stored redundantly in the model and in state and only the model was being reset. While working on the vent location marker, requests came in from the project team to hide the vent location marker during the running of the simulation and to disable the `Place Vent` button during the simulation. And while working on those I noted a few other things along the way.

[GEOCODE-51]: https://concord-consortium.atlassian.net/browse/GEOCODE-51?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ