### PR TITLE
fix: model defaults for pulse count and vertical exaggeration

### DIFF
--- a/src/stores/ui-store.ts
+++ b/src/stores/ui-store.ts
@@ -59,9 +59,9 @@ const UIStore = types.model("UI", {
   // current map type
   mapType: types.optional(types.enumeration(LavaMapTypes), defaultMapType),
   // vertical exaggeration (1 = normal, 2 = 2x, 3 = 3x, etc)
-  verticalExaggeration: 1,
+  verticalExaggeration: 3,
   // number of hundreds of pulses for each eruption. The actual number of pulses will be 100x this one.
-  hundredsOfPulsesPerEruption: 20,
+  hundredsOfPulsesPerEruption: 3,
   // minimum and maximum eruption volume in km^3
   minEruptionVolumeInKM: 1,
   maxEruptionVolumeInKM: 10000,


### PR DESCRIPTION
[[GEOCODE-77](https://concord-consortium.atlassian.net/browse/GEOCODE-77)] Set new default for number of pulses
[[GEOCODE-78](https://concord-consortium.atlassian.net/browse/GEOCODE-78)] Set new default for vertical exaggeration


[GEOCODE-77]: https://concord-consortium.atlassian.net/browse/GEOCODE-77?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GEOCODE-78]: https://concord-consortium.atlassian.net/browse/GEOCODE-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ