### PR TITLE
Geocode-82 Display error when vent location is off island.

### DIFF
--- a/src/blockly-blocks/lava/block-simulate-lava.js
+++ b/src/blockly-blocks/lava/block-simulate-lava.js
@@ -99,6 +99,7 @@ function getNumberValidationFunction(fieldName, min, max) {
     }
 
     const numberValue = parseFloat(value);
+    // If numberValue is NaN, it might be a variable containing a number, so we don't know if it's invalid.
     if (!isNaN(numberValue) && (numberValue < min || numberValue > max)) {
       block.setWarningText(`${fieldName} must be between ${min} and ${max}`);
       return false;


### PR DESCRIPTION
Jira story: https://concord-consortium.atlassian.net/browse/GEOCODE-82

A bug in recent work on errors for the Set Vent Location block made me examine how we're handling errors and realize it could be improved. With this PR, we're now displaying warnings on the blockly blocks when we know a value won't work, in addition to throwing an error when trying to run a program that definitely won't work. We don't always know if a value won't work in advance, mostly because of variables, which could contain a legal value but might not.