### PR TITLE
Geocode-65 Lat/Long Button Availability

### DIFF
--- a/cypress/e2e/smoke/block-panel-ui.cy.js
+++ b/cypress/e2e/smoke/block-panel-ui.cy.js
@@ -1,8 +1,10 @@
 import LeftPanel from "../../support/elements/LeftPanel";
 import BlocksTab from "../../support/elements/BlocksTab";
+import ModelOptions from "../../support/elements/ModelOptionPanel";
 
 const leftPanel = new LeftPanel;
 const blocksTab = new BlocksTab;
+const modelOptions = new ModelOptions;
 
 context("Blocks panel", () => {
     before(() => {
@@ -24,10 +26,13 @@ context("Blocks panel", () => {
         blocksTab.getResetButton().should('be.visible');
       });
       it('verify Run button switches to Pause after click and vice versa',()=>{
-          blocksTab.getRunButton().click();
-          blocksTab.getPauseButton().should('be.visible');
-          blocksTab.getPauseButton().click();
-          blocksTab.getRunButton().should('be.visible');
+        modelOptions.getModelOptionsMenu().click();
+        modelOptions.selectInitialCode("Nested loops");
+        cy.wait(100);
+        blocksTab.getRunButton().click();
+        blocksTab.getPauseButton().should('be.visible');
+        blocksTab.getPauseButton().click();
+        blocksTab.getRunButton().should('be.visible');
       });
     });
   });

--- a/src/blockly/blockly-controller.ts
+++ b/src/blockly/blockly-controller.ts
@@ -44,28 +44,36 @@ export class BlocklyController {
     this.parseVariables();
   };
 
-  @action
-  public run = () => {
+  private validateLoops = () => {
     // counting 'run from year...' blocks for deformation graph
     // if more than 3 blocks are being used, need to alert user and not run code
     const numberOfLoops = this.workspace.getBlocksByType("run-from-year-loop");
     if (numberOfLoops.length > 3) {
       this.throwError(DEFORMATION_SIMULATION_WARNING);
       this.stop();
-    } else {
-      this.stores.seismicSimulation.reset();
-      this.stores.lavaSimulation.reset();
-      const reset = () => {
-        this.setCode(this.code, this.workspace);
-      };
-      if (this.interpreterController) {
-        this.interpreterController.run(reset);
-        this.running = true;
-      }
-      this.stores.chartsStore.reset();
-      this.stores.samplesCollectionsStore.reset();
-      this.stores.blocklyStore.runClicked();
+      return false;
     }
+    return true;
+  };
+
+  @action
+  public run = () => {
+    if (!this.validateLoops()) return;
+    
+    this.stores.seismicSimulation.reset();
+    this.stores.lavaSimulation.reset();
+
+    const reset = () => {
+      this.setCode(this.code, this.workspace);
+    };
+    if (this.interpreterController && this.code) {
+      this.interpreterController.run(reset);
+      this.running = true;
+    }
+
+    this.stores.chartsStore.reset();
+    this.stores.samplesCollectionsStore.reset();
+    this.stores.blocklyStore.runClicked();
   };
 
   @action
@@ -117,11 +125,8 @@ export class BlocklyController {
    */
   @action
   public step = () => {
-    const numberOfLoops = this.workspace.getBlocksByType("run-from-year-loop");
-    if (numberOfLoops.length > 3) {
-      this.throwError(DEFORMATION_SIMULATION_WARNING);
-      this.stop();
-    } else {
+    if (!this.validateLoops()) return;
+
     this.steppingThroughBlock = true;
 
     // guard against infinite loops or a block failing to call endStep
@@ -137,7 +142,6 @@ export class BlocklyController {
       }
     };
     stepAsync();
-    }
   };
 
   // called by interpreted block code

--- a/src/components/lava-coder/lava-coder-view.tsx
+++ b/src/components/lava-coder/lava-coder-view.tsx
@@ -1,6 +1,6 @@
 import { reaction } from "mobx";
 import { observer } from "mobx-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { lavaSimulation } from "../../stores/lava-simulation-store";
 import { LavaMapType, LavaMapTypes, uiStore } from "../../stores/ui-store";
 import { AcresCovered } from "./acres-covered-box";
@@ -37,7 +37,6 @@ interface IProps {
 const round6 = (value: number) => Math.round(value * 1000000) / 1000000;
 
 export const LavaCoderView = observer(function LavaCoderView({ width, height, margin, running }: IProps) {
-  const lastRunningTime = useRef(0);
   const {
     showLatLongButton, showMapType, showMapTypeTerrain, showMapTypeLabeledTerrain, showMapTypeStreet, mapType,
     verticalExaggeration
@@ -84,14 +83,7 @@ export const LavaCoderView = observer(function LavaCoderView({ width, height, ma
     );
   }, [clearLatLong]);
 
-  // Update the last running time when the running state changes
-  if (running) lastRunningTime.current = Date.now();
-  // There can be a gap between the blockly running state and the lava simulation running state, which
-  // can result in flashing the vent location marker, so we enforce a delay after blockly running.
-  const isRunning = running ||
-                    (lastRunningTime.current > 0 && Date.now() - lastRunningTime.current < 1000) ||
-                    lavaSimulation.isRunning;
-  const latLongPopupMode = isLatLongMode && !isRunning
+  const latLongPopupMode = isLatLongMode && !running
                             ? uiStore.hasLatLongPoint ? "static" : "dynamic"
                             : undefined;
 
@@ -190,7 +182,7 @@ export const LavaCoderView = observer(function LavaCoderView({ width, height, ma
       <div className="lava-overlay-controls-bottom bottom-left-controls">
         {showLatLongButton && (
           <LavaIconButton className="lat-long-button" width={26} label={"Lat/Long"} isActive={isLatLongMode}
-                          onClick={() => toggleLatLongMode()} disabled={isRunning}>
+                          onClick={() => toggleLatLongMode()} disabled={running}>
             <LatLongIcon />
           </LavaIconButton>
         )}


### PR DESCRIPTION
Jira story: https://concord-consortium.atlassian.net/browse/GEOCODE-65

This PR tweaks when the Lat/Long button is disabled. Now that the eruption simulation blocks blockly program execution, all we need to do is check to see if the blockly program is running to determine if the button should be disabled.

A couple of additional improvements:
- Refactor code that blocks program execution when there are too many loops. (I'm not sure of the wisdom of this approach to blocking execution, but I at least wanted to clean up the code.)
- Don't run the program if there is no code to run. Previously, running an empty program would result in the blockly program executing indefinitely.