### PR TITLE
Geocode-84 Data Tab

### DIFF
--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -597,9 +597,14 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                 rightpanel={"true"}
                 data-test={this.getRightTabName(RightSectionTypes.DATA) + "-panel"}
               >
-                <div>
-                  <ChartPanel width={mapWidth} />
-                </div>
+                { isLavaCoder &&
+                  <LavaCoderView width={mapWidth - 2 * simMargin.x} height={mapHeight} margin={simMarginStr} running={running} />
+                }
+                { (isTephra || isSeismic) && (
+                  <div>
+                    <ChartPanel width={mapWidth} />
+                  </div>
+                )}
               </TabPanel>
             }
             {

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -332,6 +332,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     const tabWidth = Math.floor(width * .5);
     const mapWidth = Math.floor(width * .5);
     const mapHeight = height - 190;
+    const tableHeight = 203;
     const blocklyWidth = tabWidth - (blocklyMargin * 2);
     const logWidth = Math.floor(tabWidth * 0.95);
     const logHeight = Math.floor(height * .2);
@@ -339,6 +340,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
     const scenarioData = (Scenarios as {[key: string]: Scenario})[scenario];
     const simMargin = { x: 28, y: 25 };
     const simMarginStr = `${simMargin.y}px ${simMargin.x}px 0 ${simMargin.y}px`;
+    const lavaCoderWidth = mapWidth - 2 * simMargin.x;
 
     if (isTephra) {
       this.stores.tephraSimulation.setVolcano(scenarioData.centerLat, scenarioData.centerLng);
@@ -522,7 +524,7 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                     />
                   }
                   { isLavaCoder &&
-                    <LavaCoderView width={mapWidth - 2 * simMargin.x} height={mapHeight} margin={simMarginStr} running={running} />
+                    <LavaCoderView width={lavaCoderWidth} height={mapHeight} margin={simMarginStr} running={running} />
                   }
                   {
                     (isTephra || isLavaCoder) &&
@@ -598,7 +600,12 @@ export class AppComponent extends BaseComponent<IProps, IState> {
                 data-test={this.getRightTabName(RightSectionTypes.DATA) + "-panel"}
               >
                 { isLavaCoder &&
-                  <LavaCoderView width={mapWidth - 2 * simMargin.x} height={mapHeight} margin={simMarginStr} running={running} />
+                  <LavaCoderView
+                    height={mapHeight - tableHeight}
+                    margin={simMarginStr}
+                    running={running}
+                    width={lavaCoderWidth}
+                  />
                 }
                 { (isTephra || isSeismic) && (
                   <div>

--- a/src/components/authoring-menu.tsx
+++ b/src/components/authoring-menu.tsx
@@ -119,6 +119,9 @@ const AuthoringMenu: React.FC<IProps> = (props) => {
 
           <DatFolder title={strings.LEFT_TABS} key="leftTabsFolder" closed={false}>
             <DatBoolean path="uiStore.showBlocks" label={strings.SHOW_BLOCKS} key="showBlocks" />
+          </DatFolder>,
+          <DatFolder title={strings.RIGHT_TABS} key="rightTabsFolder" closed={false}>
+            <DatBoolean path="uiStore.showConditions" label={strings.SHOW_MAP} key="showMap" />
             <DatBoolean path="uiStore.showData" label={strings.SHOW_DATA} key="showData" />
           </DatFolder>,
 

--- a/src/components/lava-coder/use-terrain-provider.ts
+++ b/src/components/lava-coder/use-terrain-provider.ts
@@ -13,7 +13,7 @@ export function useTerrainProvider() {
 
   const getElevation = useCallback(async (longitude: number, latitude: number): Promise<number> => {
     if (!terrainProvider) {
-      throw new Error("Terrain provider is not initialized");
+      return 0;
     }
 
     const cartographic = Cartographic.fromDegrees(longitude, latitude);

--- a/src/strings/components/authoring-menu.ts
+++ b/src/strings/components/authoring-menu.ts
@@ -21,6 +21,7 @@ export const SHOW_CONTROLS = "Show controls?";
 export const RIGHT_TABS = "Right Tabs";
 export const SHOW_CONDITIONS = "Show conditions?";
 export const SHOW_DATA = "Show data?";
+export const SHOW_MAP = "Show map?";
 
 // shared additional options
 export const SHOW_SPEED_CONTROLS = "Show Speed Controls?";
@@ -51,7 +52,6 @@ export const SHOW_DEMO_CHARTS = "Show Demo Charts?";
 export const SHOW_RISK_DIAMONDS = "Show Risk Diamonds?";
 
 // seismic right tab options
-export const SHOW_MAP = "Show map?";
 export const SHOW_DEFORMATION_Q = "Show deformation?";
 
 // deformation model options


### PR DESCRIPTION
Jira story: https://concord-consortium.atlassian.net/browse/GEOCODE-84

This PR fleshes out the data tab for LavaCoder by displaying a smaller version of the map, leaving space for the table. It also adds an option for showing the map in the authoring tools and cleans up the categories for LavaCoder a bit.