### PR TITLE
feat: enable standard cesium zoom controls (scroll wheel, pinch zoom)

### DIFF
--- a/src/components/lava-coder/use-camera-controls.ts
+++ b/src/components/lava-coder/use-camera-controls.ts
@@ -139,12 +139,17 @@ export function useCameraControls(viewer: CesiumWidget | null, verticalExaggerat
       // Set the initial camera view
       setDefaultCameraView();
 
-      // Disable the default camera controls
-      viewer.scene.screenSpaceCameraController.enableLook = false;
-      viewer.scene.screenSpaceCameraController.enableRotate = false;
-      viewer.scene.screenSpaceCameraController.enableTilt = false;
-      viewer.scene.screenSpaceCameraController.enableTranslate = false;
-      viewer.scene.screenSpaceCameraController.enableZoom = false;
+      const controller = viewer.scene.screenSpaceCameraController;
+
+      // Disable the default camera controls...
+      controller.enableLook = false;
+      controller.enableRotate = false;
+      controller.enableTilt = false;
+      controller.enableTranslate = false;
+      // ...except for zoom, which we enable and constrain
+      controller.enableZoom = true;
+      controller.minimumZoomDistance = kMinDistanceAboveTerrain;
+      controller.maximumZoomDistance = kMaxDistanceAboveTerrain;
     }
   }, [setDefaultCameraView, viewer]);
 


### PR DESCRIPTION
[[GEOCODE-97](https://concord-consortium.atlassian.net/browse/GEOCODE-97)] Allow mouse pad control for map zoom in/out

We were previously disabling all cesium-default controls for zoom and rotation in favor of our own. With this PR we re-enable the default zoom controls, while leaving the others disabled.

Note that it seems that on a device with both mouse and touch (e.g. a MacBook Pro), only the mouse is acknowledged, so for testing pinch zoom you have to use a touch-only device like a phone or tablet.

[GEOCODE-97]: https://concord-consortium.atlassian.net/browse/GEOCODE-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ