### PR TITLE
Geocode-95 More Lava Blocks

### DIFF
--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -20,12 +20,12 @@ context("Molasses Simulation", () => {
 
   describe('blocks', () => {
     it('verify correct blocks are present', () => {
-      // blocksTab.getTag('Volcano').should('be.visible');
+      blocksTab.getTag('Volcano').should('be.visible');
       blocksTab.getTag('Logic').should('be.visible');
-      // blocksTab.getTag('Loops').should('be.visible');
-      // blocksTab.getTag('Data').should('be.visible');
-      // blocksTab.getTag('Variables').should('be.visible');
-      // blocksTab.getTag('Functions').should('be.visible');
+      blocksTab.getTag('Loops').should('be.visible');
+      blocksTab.getTag('Data').should('be.visible');
+      blocksTab.getTag('Variables').should('be.visible');
+      blocksTab.getTag('Functions').should('be.visible');
 
       // blocksTab.getTag('Volcano').click();
       // blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -10,17 +10,24 @@ const modelOptions = new ModelOptions();
 const rightPanel = new RightPanel();
 
 context("Molasses Simulation", () => {
-  beforeEach(() => {
-    cy.visit("");
-    modelOptions.getModelOptionsMenu().click();
-    modelOptions.selectUnitOption('LavaCoder');
-    cy.wait(10000);
-    modelOptions.selectInitialCode('Molasses Location');
-    modelOptions.getModelOptionsMenu().click();
-  });
+  // beforeEach(() => {
+  //   cy.visit("");
+  //   modelOptions.getModelOptionsMenu().click();
+  //   modelOptions.selectUnitOption('LavaCoder');
+  //   cy.wait(10000);
+  //   modelOptions.selectInitialCode('Molasses Location');
+  //   modelOptions.getModelOptionsMenu().click();
+  // });
 
   describe('blocks', () => {
     it('verify correct blocks are present', () => {
+      cy.visit("");
+      modelOptions.getModelOptionsMenu().click();
+      modelOptions.selectUnitOption('LavaCoder');
+      cy.wait(10000);
+      modelOptions.selectInitialCode('Molasses Location');
+      modelOptions.getModelOptionsMenu().click();
+
       blocksTab.getTag('Volcano').should('be.visible');
       blocksTab.getTag('Logic').should('be.visible');
       blocksTab.getTag('Loops').should('be.visible');

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -7,78 +7,78 @@ const modelOptions = new ModelOptions();
 
 // need to convert Blockly strings because they have &nbsp; in the DOM
 // but when run thru Cypress, Cypress converts it so `contain` never matches
-function removeNBSP(text){
-    const re = new RegExp(String.fromCharCode(160), "g");
-    return text.replace(re, " ");
-}
+// function removeNBSP(text){
+//     const re = new RegExp(String.fromCharCode(160), "g");
+//     return text.replace(re, " ");
+// }
 
 context("Molasses Simulation", () => {
   beforeEach(() => {
     cy.visit("");
     modelOptions.getModelOptionsMenu().click();
     modelOptions.selectUnitOption('LavaCoder');
-    modelOptions.selectInitialCode('Molasses Location');
-    modelOptions.getModelOptionsMenu().click();
+    // modelOptions.selectInitialCode('Molasses Location');
+    // modelOptions.getModelOptionsMenu().click();
   });
 
   describe('blocks', () => {
     it('verify correct blocks are present', () => {
       blocksTab.getTag('Volcano').should('be.visible');
-      blocksTab.getTag('Logic').should('be.visible');
-      blocksTab.getTag('Loops').should('be.visible');
-      blocksTab.getTag('Data').should('be.visible');
-      blocksTab.getTag('Variables').should('be.visible');
-      blocksTab.getTag('Functions').should('be.visible');
+    //   blocksTab.getTag('Logic').should('be.visible');
+    //   blocksTab.getTag('Loops').should('be.visible');
+    //   blocksTab.getTag('Data').should('be.visible');
+    //   blocksTab.getTag('Variables').should('be.visible');
+    //   blocksTab.getTag('Functions').should('be.visible');
 
-      blocksTab.getTag('Volcano').click();
-      blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(0).text().then((text) => {
-          expect(removeNBSP(text)).to.containIgnoreCase("Compute and visualize lava flow with...");
-      });
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(1).text().then((text) => {
-          expect(removeNBSP(text)).to.containIgnoreCase("Set eruption volume");
-      });
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(2).text().then((text) => {
-          expect(removeNBSP(text)).to.containIgnoreCase("Set lava front height");
-      });
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(3).text().then((text) => {
-          expect(removeNBSP(text)).to.containIgnoreCase("Set vent location");
-      });
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(4).text().then((text) => {
-          expect(removeNBSP(text)).to.containIgnoreCase("Set flag location");
-      });
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(10).text().then((text) => {
-          expect(removeNBSP(text)).to.containIgnoreCase("Compute lava flow impact");
-      });
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(13).text().then((text) => {
-          expect(removeNBSP(text)).to.containIgnoreCase("Add data from flag");
-      });
+    //   blocksTab.getTag('Volcano').click();
+    //   blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(0).text().then((text) => {
+    //       expect(removeNBSP(text)).to.containIgnoreCase("Compute and visualize lava flow with...");
+    //   });
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(1).text().then((text) => {
+    //       expect(removeNBSP(text)).to.containIgnoreCase("Set eruption volume");
+    //   });
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(2).text().then((text) => {
+    //       expect(removeNBSP(text)).to.containIgnoreCase("Set lava front height");
+    //   });
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(3).text().then((text) => {
+    //       expect(removeNBSP(text)).to.containIgnoreCase("Set vent location");
+    //   });
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(4).text().then((text) => {
+    //       expect(removeNBSP(text)).to.containIgnoreCase("Set flag location");
+    //   });
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(10).text().then((text) => {
+    //       expect(removeNBSP(text)).to.containIgnoreCase("Compute lava flow impact");
+    //   });
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(13).text().then((text) => {
+    //       expect(removeNBSP(text)).to.containIgnoreCase("Add data from flag");
+    //   });
 
-      blocksTab.getTag('Data').click();
-      blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 13);
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(0).text().then((text) => {
-          expect(removeNBSP(text)).to.containIgnoreCase("Name");
-      });
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(1).text().then((text) => {
-          expect(removeNBSP(text)).to.containIgnoreCase("4");
-      });
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(2).text().then((text) => {
-          expect(removeNBSP(text)).to.containIgnoreCase("Range from");
-      });
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(6).text().then((text) => {
-          expect(removeNBSP(text)).to.containIgnoreCase("Latitude, Longitude");
-      });
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(8).text().then((text) => {
-          expect(removeNBSP(text)).to.containIgnoreCase("+");
-      });
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(9).text().then((text) => {
-          expect(removeNBSP(text)).to.containIgnoreCase("Create a data table");
-      });
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(10).text().then((text) => {
-          expect(removeNBSP(text)).to.containIgnoreCase("Create row in data table");
-      });
+    //   blocksTab.getTag('Data').click();
+    //   blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 13);
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(0).text().then((text) => {
+    //       expect(removeNBSP(text)).to.containIgnoreCase("Name");
+    //   });
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(1).text().then((text) => {
+    //       expect(removeNBSP(text)).to.containIgnoreCase("4");
+    //   });
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(2).text().then((text) => {
+    //       expect(removeNBSP(text)).to.containIgnoreCase("Range from");
+    //   });
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(6).text().then((text) => {
+    //       expect(removeNBSP(text)).to.containIgnoreCase("Latitude, Longitude");
+    //   });
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(8).text().then((text) => {
+    //       expect(removeNBSP(text)).to.containIgnoreCase("+");
+    //   });
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(9).text().then((text) => {
+    //       expect(removeNBSP(text)).to.containIgnoreCase("Create a data table");
+    //   });
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(10).text().then((text) => {
+    //       expect(removeNBSP(text)).to.containIgnoreCase("Create row in data table");
+    //   });
     });
   });
 });

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -17,18 +17,18 @@ context("Molasses Simulation", () => {
     cy.visit("");
     modelOptions.getModelOptionsMenu().click();
     modelOptions.selectUnitOption('LavaCoder');
-    // modelOptions.selectInitialCode('Molasses Location');
-    // modelOptions.getModelOptionsMenu().click();
+    modelOptions.selectInitialCode('Molasses Location');
+    modelOptions.getModelOptionsMenu().click();
   });
 
   describe('blocks', () => {
     it('verify correct blocks are present', () => {
       blocksTab.getTag('Volcano').should('be.visible');
-    //   blocksTab.getTag('Logic').should('be.visible');
-    //   blocksTab.getTag('Loops').should('be.visible');
-    //   blocksTab.getTag('Data').should('be.visible');
-    //   blocksTab.getTag('Variables').should('be.visible');
-    //   blocksTab.getTag('Functions').should('be.visible');
+      blocksTab.getTag('Logic').should('be.visible');
+      blocksTab.getTag('Loops').should('be.visible');
+      blocksTab.getTag('Data').should('be.visible');
+      blocksTab.getTag('Variables').should('be.visible');
+      blocksTab.getTag('Functions').should('be.visible');
 
     //   blocksTab.getTag('Volcano').click();
     //   blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -1,9 +1,13 @@
 
 import BlocksTab from "../../support/elements/BlocksTab";
+import DataTab from "../../support/elements/DataTab";
 import ModelOptions from "../../support/elements/ModelOptionPanel";
+import RightPanel from "../../support/elements/RightPanel";
 
 const blocksTab = new BlocksTab();
+const dataTab = new DataTab();
 const modelOptions = new ModelOptions();
+const rightPanel = new RightPanel();
 
 context("Molasses Simulation", () => {
   beforeEach(() => {
@@ -45,6 +49,18 @@ context("Molasses Simulation", () => {
       blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("+").should("exist");
       blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Create a data table").should("exist");
       blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Create row in data table").should("exist");
+    });
+
+    it('running the simulation updates the table', () => {
+      rightPanel.getDataTab().click();
+      cy.wait(10000);
+      blocksTab.runProgram();
+      blocksTab.getRunButton().contains("Run").should("exist");
+      dataTab.getDataTable().should("exist");
+      dataTab.getDataTableRows().should('have.length', 2);
+      dataTab.getDataTableContents().should('have.length', 6);
+      dataTab.getDataTableContents().eq(2).should("contain.text", "No");
+      dataTab.getDataTableContents().eq(5).should("contain.text", "Yes");
     });
   });
 });

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -20,16 +20,16 @@ context("Molasses Simulation", () => {
 
   describe('blocks', () => {
     it('verify correct blocks are present', () => {
-      blocksTab.getTag('Volcano').should('be.visible');
+      // blocksTab.getTag('Volcano').should('be.visible');
       blocksTab.getTag('Logic').should('be.visible');
-      blocksTab.getTag('Loops').should('be.visible');
-      blocksTab.getTag('Data').should('be.visible');
-      blocksTab.getTag('Variables').should('be.visible');
-      blocksTab.getTag('Functions').should('be.visible');
+      // blocksTab.getTag('Loops').should('be.visible');
+      // blocksTab.getTag('Data').should('be.visible');
+      // blocksTab.getTag('Variables').should('be.visible');
+      // blocksTab.getTag('Functions').should('be.visible');
 
-      blocksTab.getTag('Volcano').click();
-      blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
+      // blocksTab.getTag('Volcano').click();
+      // blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
+      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
       // blocksTab.getFlyout().find(blocksTab.getBlockTextEl())
       //   .contains("Compute and visualize lava flow with...").should("exist");
       // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set eruption volume").should("exist");

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -10,21 +10,12 @@ const modelOptions = new ModelOptions();
 const rightPanel = new RightPanel();
 
 context("Molasses Simulation", () => {
-  // beforeEach(() => {
-  //   cy.visit("");
-  //   modelOptions.getModelOptionsMenu().click();
-  //   modelOptions.selectUnitOption('LavaCoder');
-  //   cy.wait(10000);
-  //   modelOptions.selectInitialCode('Molasses Location');
-  //   modelOptions.getModelOptionsMenu().click();
-  // });
-
   describe('blocks', () => {
-    it('verify correct blocks are present', () => {
+    // TODO: Figure out how to run tests with cesium on github
+    it.skip('verify correct blocks are present', () => {
       cy.visit("");
       modelOptions.getModelOptionsMenu().click();
       modelOptions.selectUnitOption('LavaCoder');
-      cy.wait(10000);
       modelOptions.selectInitialCode('Molasses Location');
       modelOptions.getModelOptionsMenu().click();
 
@@ -35,42 +26,40 @@ context("Molasses Simulation", () => {
       blocksTab.getTag('Variables').should('be.visible');
       blocksTab.getTag('Functions').should('be.visible');
 
-      // blocksTab.getTag('Volcano').click();
-      // blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
-      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
-      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl())
-      //   .contains("Compute and visualize lava flow with...").should("exist");
-      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set eruption volume").should("exist");
-      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set lava front height").should("exist");
-      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set vent location").should("exist");
-      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set flag location").should("exist");
-      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Compute lava flow impact").should("exist");
-      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Add data from flag").should("exist");
+      blocksTab.getTag('Volcano').click();
+      blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl())
+        .contains("Compute and visualize lava flow with...").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set eruption volume").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set lava front height").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set vent location").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set flag location").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Compute lava flow impact").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Add data from flag").should("exist");
 
-      // blocksTab.getTag('Data').click();
-      // blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
-      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 13);
-      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Name").should("exist");
-      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("4").should("exist");
-      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Range from").should("exist");
-      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Latitude, Longitude").should("exist");
-      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("+").should("exist");
-      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Create a data table").should("exist");
-      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Create row in data table").should("exist");
+      blocksTab.getTag('Data').click();
+      blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 13);
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Name").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("4").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Range from").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Latitude, Longitude").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("+").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Create a data table").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Create row in data table").should("exist");
+
+      blocksTab.getRunButton().contains("Run").should("exist");
+      rightPanel.getDataTab().click();
+      // Sadly, we need to wait for cesium to load before we run the simulation
+      cy.wait(10000);
+      blocksTab.runProgram();
+      blocksTab.getRunButton().contains("Run").should("exist");
+      dataTab.getDataTable().should("exist");
+      dataTab.getDataTableRows().should('have.length', 2);
+      dataTab.getDataTableContents().should('have.length', 6);
+      dataTab.getDataTableContents().eq(2).should("contain.text", "No");
+      dataTab.getDataTableContents().eq(5).should("contain.text", "Yes");
     });
-
-    // it('running the simulation updates the table', () => {
-    //   blocksTab.getRunButton().contains("Run").should("exist");
-    //   rightPanel.getDataTab().click();
-    //   // Sadly, we need to wait for cesium to load
-    //   cy.wait(10000);
-    //   blocksTab.runProgram();
-    //   blocksTab.getRunButton().contains("Run").should("exist");
-    //   dataTab.getDataTable().should("exist");
-    //   dataTab.getDataTableRows().should('have.length', 2);
-    //   dataTab.getDataTableContents().should('have.length', 6);
-    //   dataTab.getDataTableContents().eq(2).should("contain.text", "No");
-    //   dataTab.getDataTableContents().eq(5).should("contain.text", "Yes");
-    // });
   });
 });

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -52,15 +52,17 @@ context("Molasses Simulation", () => {
     // });
 
     it('running the simulation updates the table', () => {
-      rightPanel.getDataTab().click();
-      cy.wait(10000);
-      blocksTab.runProgram();
       blocksTab.getRunButton().contains("Run").should("exist");
-      dataTab.getDataTable().should("exist");
-      dataTab.getDataTableRows().should('have.length', 2);
-      dataTab.getDataTableContents().should('have.length', 6);
-      dataTab.getDataTableContents().eq(2).should("contain.text", "No");
-      dataTab.getDataTableContents().eq(5).should("contain.text", "Yes");
+      rightPanel.getDataTab().click();
+      // Sadly, we need to wait for cesium to load
+      // cy.wait(10000);
+      // blocksTab.runProgram();
+      // blocksTab.getRunButton().contains("Run").should("exist");
+      // dataTab.getDataTable().should("exist");
+      // dataTab.getDataTableRows().should('have.length', 2);
+      // dataTab.getDataTableContents().should('have.length', 6);
+      // dataTab.getDataTableContents().eq(2).should("contain.text", "No");
+      // dataTab.getDataTableContents().eq(5).should("contain.text", "Yes");
     });
   });
 });

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -14,6 +14,7 @@ context("Molasses Simulation", () => {
     cy.visit("");
     modelOptions.getModelOptionsMenu().click();
     modelOptions.selectUnitOption('LavaCoder');
+    cy.wait(10000);
     modelOptions.selectInitialCode('Molasses Location');
     modelOptions.getModelOptionsMenu().click();
   });
@@ -28,7 +29,7 @@ context("Molasses Simulation", () => {
       blocksTab.getTag('Functions').should('be.visible');
 
       blocksTab.getTag('Volcano').click();
-      // blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
+      blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
       // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
       // blocksTab.getFlyout().find(blocksTab.getBlockTextEl())
       //   .contains("Compute and visualize lava flow with...").should("exist");

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -7,10 +7,10 @@ const modelOptions = new ModelOptions();
 
 // need to convert Blockly strings because they have &nbsp; in the DOM
 // but when run thru Cypress, Cypress converts it so `contain` never matches
-function removeNBSP(text){
-    const re = new RegExp(String.fromCharCode(160), "g");
-    return text.replace(re, " ");
-}
+// function removeNBSP(text){
+//     const re = new RegExp(String.fromCharCode(160), "g");
+//     return text.replace(re, " ");
+// }
 
 context("Molasses Simulation", () => {
   beforeEach(() => {
@@ -33,9 +33,9 @@ context("Molasses Simulation", () => {
       blocksTab.getTag('Volcano').click();
       blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
       blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(0).text().then((text) => {
-          expect(removeNBSP(text)).to.containIgnoreCase("Compute and visualize lava flow with...");
-      });
+      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(0).text().then((text) => {
+      //     expect(removeNBSP(text)).to.containIgnoreCase("Compute and visualize lava flow with...");
+      // });
     //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(1).text().then((text) => {
     //       expect(removeNBSP(text)).to.containIgnoreCase("Set eruption volume");
     //   });

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -1,4 +1,3 @@
-
 import BlocksTab from "../../support/elements/BlocksTab";
 import DataTab from "../../support/elements/DataTab";
 import ModelOptions from "../../support/elements/ModelOptionPanel";

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -27,7 +27,7 @@ context("Molasses Simulation", () => {
       blocksTab.getTag('Variables').should('be.visible');
       blocksTab.getTag('Functions').should('be.visible');
 
-      blocksTab.getTag('Volcano').click();
+      // blocksTab.getTag('Volcano').click();
       // blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
       // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
       // blocksTab.getFlyout().find(blocksTab.getBlockTextEl())

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -19,50 +19,50 @@ context("Molasses Simulation", () => {
   });
 
   describe('blocks', () => {
-    // it('verify correct blocks are present', () => {
-    //   blocksTab.getTag('Volcano').should('be.visible');
-    //   blocksTab.getTag('Logic').should('be.visible');
-    //   blocksTab.getTag('Loops').should('be.visible');
-    //   blocksTab.getTag('Data').should('be.visible');
-    //   blocksTab.getTag('Variables').should('be.visible');
-    //   blocksTab.getTag('Functions').should('be.visible');
+    it('verify correct blocks are present', () => {
+      blocksTab.getTag('Volcano').should('be.visible');
+      blocksTab.getTag('Logic').should('be.visible');
+      blocksTab.getTag('Loops').should('be.visible');
+      blocksTab.getTag('Data').should('be.visible');
+      blocksTab.getTag('Variables').should('be.visible');
+      blocksTab.getTag('Functions').should('be.visible');
 
-    //   blocksTab.getTag('Volcano').click();
-    //   blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl())
-    //     .contains("Compute and visualize lava flow with...").should("exist");
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set eruption volume").should("exist");
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set lava front height").should("exist");
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set vent location").should("exist");
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set flag location").should("exist");
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Compute lava flow impact").should("exist");
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Add data from flag").should("exist");
+      blocksTab.getTag('Volcano').click();
+      blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
+      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl())
+      //   .contains("Compute and visualize lava flow with...").should("exist");
+      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set eruption volume").should("exist");
+      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set lava front height").should("exist");
+      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set vent location").should("exist");
+      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set flag location").should("exist");
+      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Compute lava flow impact").should("exist");
+      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Add data from flag").should("exist");
 
-    //   blocksTab.getTag('Data').click();
-    //   blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 13);
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Name").should("exist");
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("4").should("exist");
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Range from").should("exist");
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Latitude, Longitude").should("exist");
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("+").should("exist");
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Create a data table").should("exist");
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Create row in data table").should("exist");
-    // });
-
-    it('running the simulation updates the table', () => {
-      blocksTab.getRunButton().contains("Run").should("exist");
-      rightPanel.getDataTab().click();
-      // Sadly, we need to wait for cesium to load
-      // cy.wait(10000);
-      // blocksTab.runProgram();
-      // blocksTab.getRunButton().contains("Run").should("exist");
-      // dataTab.getDataTable().should("exist");
-      // dataTab.getDataTableRows().should('have.length', 2);
-      // dataTab.getDataTableContents().should('have.length', 6);
-      // dataTab.getDataTableContents().eq(2).should("contain.text", "No");
-      // dataTab.getDataTableContents().eq(5).should("contain.text", "Yes");
+      // blocksTab.getTag('Data').click();
+      // blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
+      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 13);
+      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Name").should("exist");
+      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("4").should("exist");
+      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Range from").should("exist");
+      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Latitude, Longitude").should("exist");
+      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("+").should("exist");
+      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Create a data table").should("exist");
+      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Create row in data table").should("exist");
     });
+
+    // it('running the simulation updates the table', () => {
+    //   blocksTab.getRunButton().contains("Run").should("exist");
+    //   rightPanel.getDataTab().click();
+    //   // Sadly, we need to wait for cesium to load
+    //   cy.wait(10000);
+    //   blocksTab.runProgram();
+    //   blocksTab.getRunButton().contains("Run").should("exist");
+    //   dataTab.getDataTable().should("exist");
+    //   dataTab.getDataTableRows().should('have.length', 2);
+    //   dataTab.getDataTableContents().should('have.length', 6);
+    //   dataTab.getDataTableContents().eq(2).should("contain.text", "No");
+    //   dataTab.getDataTableContents().eq(5).should("contain.text", "Yes");
+    // });
   });
 });

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -28,8 +28,8 @@ context("Molasses Simulation", () => {
       blocksTab.getTag('Variables').should('be.visible');
       blocksTab.getTag('Functions').should('be.visible');
 
-      blocksTab.getTag('Volcano').click();
-      blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
+      // blocksTab.getTag('Volcano').click();
+      // blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
       // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
       // blocksTab.getFlyout().find(blocksTab.getBlockTextEl())
       //   .contains("Compute and visualize lava flow with...").should("exist");

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -28,7 +28,7 @@ context("Molasses Simulation", () => {
       blocksTab.getTag('Functions').should('be.visible');
 
       blocksTab.getTag('Volcano').click();
-      blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
+      // blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
       // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
       // blocksTab.getFlyout().find(blocksTab.getBlockTextEl())
       //   .contains("Compute and visualize lava flow with...").should("exist");

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -27,9 +27,9 @@ context("Molasses Simulation", () => {
       blocksTab.getTag('Variables').should('be.visible');
       blocksTab.getTag('Functions').should('be.visible');
 
-      // blocksTab.getTag('Volcano').click();
-      // blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
-      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
+      blocksTab.getTag('Volcano').click();
+      blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
       // blocksTab.getFlyout().find(blocksTab.getBlockTextEl())
       //   .contains("Compute and visualize lava flow with...").should("exist");
       // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set eruption volume").should("exist");

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -7,10 +7,10 @@ const modelOptions = new ModelOptions();
 
 // need to convert Blockly strings because they have &nbsp; in the DOM
 // but when run thru Cypress, Cypress converts it so `contain` never matches
-// function removeNBSP(text){
-//     const re = new RegExp(String.fromCharCode(160), "g");
-//     return text.replace(re, " ");
-// }
+function removeNBSP(text){
+    const re = new RegExp(String.fromCharCode(160), "g");
+    return text.replace(re, " ");
+}
 
 context("Molasses Simulation", () => {
   beforeEach(() => {
@@ -30,12 +30,12 @@ context("Molasses Simulation", () => {
       blocksTab.getTag('Variables').should('be.visible');
       blocksTab.getTag('Functions').should('be.visible');
 
-    //   blocksTab.getTag('Volcano').click();
-    //   blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(0).text().then((text) => {
-    //       expect(removeNBSP(text)).to.containIgnoreCase("Compute and visualize lava flow with...");
-    //   });
+      blocksTab.getTag('Volcano').click();
+      blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(0).text().then((text) => {
+          expect(removeNBSP(text)).to.containIgnoreCase("Compute and visualize lava flow with...");
+      });
     //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(1).text().then((text) => {
     //       expect(removeNBSP(text)).to.containIgnoreCase("Set eruption volume");
     //   });

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -1,0 +1,84 @@
+
+import BlocksTab from "../../support/elements/BlocksTab";
+import ModelOptions from "../../support/elements/ModelOptionPanel";
+
+const blocksTab = new BlocksTab();
+const modelOptions = new ModelOptions();
+
+// need to convert Blockly strings because they have &nbsp; in the DOM
+// but when run thru Cypress, Cypress converts it so `contain` never matches
+function removeNBSP(text){
+    const re = new RegExp(String.fromCharCode(160), "g");
+    return text.replace(re, " ");
+}
+
+context("Molasses Simulation", () => {
+  beforeEach(() => {
+    cy.visit("");
+    modelOptions.getModelOptionsMenu().click();
+    modelOptions.selectUnitOption('LavaCoder');
+    modelOptions.selectInitialCode('Molasses Location');
+    modelOptions.getModelOptionsMenu().click();
+  });
+
+  describe('blocks', () => {
+    it('verify correct blocks are present', () => {
+      blocksTab.getTag('Volcano').should('be.visible');
+      blocksTab.getTag('Logic').should('be.visible');
+      blocksTab.getTag('Loops').should('be.visible');
+      blocksTab.getTag('Data').should('be.visible');
+      blocksTab.getTag('Variables').should('be.visible');
+      blocksTab.getTag('Functions').should('be.visible');
+
+      blocksTab.getTag('Volcano').click();
+      blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(0).text().then((text) => {
+          expect(removeNBSP(text)).to.containIgnoreCase("Compute and visualize lava flow with...");
+      });
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(1).text().then((text) => {
+          expect(removeNBSP(text)).to.containIgnoreCase("Set eruption volume");
+      });
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(2).text().then((text) => {
+          expect(removeNBSP(text)).to.containIgnoreCase("Set lava front height");
+      });
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(3).text().then((text) => {
+          expect(removeNBSP(text)).to.containIgnoreCase("Set vent location");
+      });
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(4).text().then((text) => {
+          expect(removeNBSP(text)).to.containIgnoreCase("Set flag location");
+      });
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(10).text().then((text) => {
+          expect(removeNBSP(text)).to.containIgnoreCase("Compute lava flow impact");
+      });
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(13).text().then((text) => {
+          expect(removeNBSP(text)).to.containIgnoreCase("Add data from flag");
+      });
+
+      blocksTab.getTag('Data').click();
+      blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 13);
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(0).text().then((text) => {
+          expect(removeNBSP(text)).to.containIgnoreCase("Name");
+      });
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(1).text().then((text) => {
+          expect(removeNBSP(text)).to.containIgnoreCase("4");
+      });
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(2).text().then((text) => {
+          expect(removeNBSP(text)).to.containIgnoreCase("Range from");
+      });
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(6).text().then((text) => {
+          expect(removeNBSP(text)).to.containIgnoreCase("Latitude, Longitude");
+      });
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(8).text().then((text) => {
+          expect(removeNBSP(text)).to.containIgnoreCase("+");
+      });
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(9).text().then((text) => {
+          expect(removeNBSP(text)).to.containIgnoreCase("Create a data table");
+      });
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(10).text().then((text) => {
+          expect(removeNBSP(text)).to.containIgnoreCase("Create row in data table");
+      });
+    });
+  });
+});

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -5,13 +5,6 @@ import ModelOptions from "../../support/elements/ModelOptionPanel";
 const blocksTab = new BlocksTab();
 const modelOptions = new ModelOptions();
 
-// need to convert Blockly strings because they have &nbsp; in the DOM
-// but when run thru Cypress, Cypress converts it so `contain` never matches
-// function removeNBSP(text){
-//     const re = new RegExp(String.fromCharCode(160), "g");
-//     return text.replace(re, " ");
-// }
-
 context("Molasses Simulation", () => {
   beforeEach(() => {
     cy.visit("");
@@ -42,30 +35,16 @@ context("Molasses Simulation", () => {
       blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Compute lava flow impact").should("exist");
       blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Add data from flag").should("exist");
 
-    //   blocksTab.getTag('Data').click();
-    //   blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 13);
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(0).text().then((text) => {
-    //       expect(removeNBSP(text)).to.containIgnoreCase("Name");
-    //   });
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(1).text().then((text) => {
-    //       expect(removeNBSP(text)).to.containIgnoreCase("4");
-    //   });
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(2).text().then((text) => {
-    //       expect(removeNBSP(text)).to.containIgnoreCase("Range from");
-    //   });
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(6).text().then((text) => {
-    //       expect(removeNBSP(text)).to.containIgnoreCase("Latitude, Longitude");
-    //   });
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(8).text().then((text) => {
-    //       expect(removeNBSP(text)).to.containIgnoreCase("+");
-    //   });
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(9).text().then((text) => {
-    //       expect(removeNBSP(text)).to.containIgnoreCase("Create a data table");
-    //   });
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(10).text().then((text) => {
-    //       expect(removeNBSP(text)).to.containIgnoreCase("Create row in data table");
-    //   });
+      blocksTab.getTag('Data').click();
+      blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 13);
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Name").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("4").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Range from").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Latitude, Longitude").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("+").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Create a data table").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Create row in data table").should("exist");
     });
   });
 });

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -28,8 +28,8 @@ context("Molasses Simulation", () => {
       blocksTab.getTag('Functions').should('be.visible');
 
       blocksTab.getTag('Volcano').click();
-      blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
+      // blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
+      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
       // blocksTab.getFlyout().find(blocksTab.getBlockTextEl())
       //   .contains("Compute and visualize lava flow with...").should("exist");
       // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set eruption volume").should("exist");

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -27,8 +27,8 @@ context("Molasses Simulation", () => {
       blocksTab.getTag('Variables').should('be.visible');
       blocksTab.getTag('Functions').should('be.visible');
 
-      // blocksTab.getTag('Volcano').click();
-      // blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
+      blocksTab.getTag('Volcano').click();
+      blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
       // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
       // blocksTab.getFlyout().find(blocksTab.getBlockTextEl())
       //   .contains("Compute and visualize lava flow with...").should("exist");

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -19,37 +19,37 @@ context("Molasses Simulation", () => {
   });
 
   describe('blocks', () => {
-    it('verify correct blocks are present', () => {
-      blocksTab.getTag('Volcano').should('be.visible');
-      blocksTab.getTag('Logic').should('be.visible');
-      blocksTab.getTag('Loops').should('be.visible');
-      blocksTab.getTag('Data').should('be.visible');
-      blocksTab.getTag('Variables').should('be.visible');
-      blocksTab.getTag('Functions').should('be.visible');
+    // it('verify correct blocks are present', () => {
+    //   blocksTab.getTag('Volcano').should('be.visible');
+    //   blocksTab.getTag('Logic').should('be.visible');
+    //   blocksTab.getTag('Loops').should('be.visible');
+    //   blocksTab.getTag('Data').should('be.visible');
+    //   blocksTab.getTag('Variables').should('be.visible');
+    //   blocksTab.getTag('Functions').should('be.visible');
 
-      blocksTab.getTag('Volcano').click();
-      blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl())
-        .contains("Compute and visualize lava flow with...").should("exist");
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set eruption volume").should("exist");
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set lava front height").should("exist");
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set vent location").should("exist");
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set flag location").should("exist");
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Compute lava flow impact").should("exist");
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Add data from flag").should("exist");
+    //   blocksTab.getTag('Volcano').click();
+    //   blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl())
+    //     .contains("Compute and visualize lava flow with...").should("exist");
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set eruption volume").should("exist");
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set lava front height").should("exist");
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set vent location").should("exist");
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set flag location").should("exist");
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Compute lava flow impact").should("exist");
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Add data from flag").should("exist");
 
-      blocksTab.getTag('Data').click();
-      blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 13);
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Name").should("exist");
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("4").should("exist");
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Range from").should("exist");
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Latitude, Longitude").should("exist");
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("+").should("exist");
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Create a data table").should("exist");
-      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Create row in data table").should("exist");
-    });
+    //   blocksTab.getTag('Data').click();
+    //   blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 13);
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Name").should("exist");
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("4").should("exist");
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Range from").should("exist");
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Latitude, Longitude").should("exist");
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("+").should("exist");
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Create a data table").should("exist");
+    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Create row in data table").should("exist");
+    // });
 
     it('running the simulation updates the table', () => {
       rightPanel.getDataTab().click();

--- a/cypress/e2e/branch/molasses.cy.js
+++ b/cypress/e2e/branch/molasses.cy.js
@@ -33,27 +33,14 @@ context("Molasses Simulation", () => {
       blocksTab.getTag('Volcano').click();
       blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);
       blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).should('have.length', 17);
-      // blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(0).text().then((text) => {
-      //     expect(removeNBSP(text)).to.containIgnoreCase("Compute and visualize lava flow with...");
-      // });
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(1).text().then((text) => {
-    //       expect(removeNBSP(text)).to.containIgnoreCase("Set eruption volume");
-    //   });
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(2).text().then((text) => {
-    //       expect(removeNBSP(text)).to.containIgnoreCase("Set lava front height");
-    //   });
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(3).text().then((text) => {
-    //       expect(removeNBSP(text)).to.containIgnoreCase("Set vent location");
-    //   });
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(4).text().then((text) => {
-    //       expect(removeNBSP(text)).to.containIgnoreCase("Set flag location");
-    //   });
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(10).text().then((text) => {
-    //       expect(removeNBSP(text)).to.containIgnoreCase("Compute lava flow impact");
-    //   });
-    //   blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).eq(13).text().then((text) => {
-    //       expect(removeNBSP(text)).to.containIgnoreCase("Add data from flag");
-    //   });
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl())
+        .contains("Compute and visualize lava flow with...").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set eruption volume").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set lava front height").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set vent location").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Set flag location").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Compute lava flow impact").should("exist");
+      blocksTab.getFlyout().find(blocksTab.getBlockTextEl()).contains("Add data from flag").should("exist");
 
     //   blocksTab.getTag('Data').click();
     //   blocksTab.getFlyout().find(blocksTab.getBlockEl()).should('have.length', 7);

--- a/cypress/support/elements/DataTab.js
+++ b/cypress/support/elements/DataTab.js
@@ -1,6 +1,15 @@
 class DataTab {
-    getDataPanel(){
+    getDataPanel() {
         return cy.get('[data-test=Data-panel]');
+    }
+    getDataTable() {
+        return cy.get('.data-table');
+    }
+    getDataTableRows() {
+        return this.getDataTable().find('tbody tr');
+    }
+    getDataTableContents() {
+        return this.getDataTableRows().find('td');
     }
 }
 

--- a/src/assets/blockly-authoring/code/molasses-location.xml
+++ b/src/assets/blockly-authoring/code/molasses-location.xml
@@ -62,6 +62,26 @@
                             <next>
                               <block type="molasses_add_row" id="molasses_add_row2">
                                 <field name="flag">test4</field>
+                                <next>
+                                  <block type="molasses_compute_lava" id="molasses_compute_lava1">
+                                    <field name="flag">test4</field>
+                                    <next>
+                                      <block type="molasses_add_data" id="molasses_add_data1">
+                                        <field name="flag">test4</field>
+                                        <next>
+                                          <block type="molasses_compute_lava" id="molasses_compute_lava2">
+                                            <field name="flag">test</field>
+                                            <next>
+                                              <block type="molasses_add_data" id="molasses_add_data2">
+                                                <field name="flag">test</field>
+                                              </block>
+                                            </next>
+                                          </block>
+                                        </next>
+                                      </block>
+                                    </next>
+                                  </block>
+                                </next>
                               </block>
                             </next>
                           </block>

--- a/src/assets/blockly-authoring/code/molasses-location.xml
+++ b/src/assets/blockly-authoring/code/molasses-location.xml
@@ -35,27 +35,27 @@
                   </block>
                 </value>
                 <next>
-                  <block type="molasses_run_simulation" id="bIjG2)~K%-s0~0{5oaS|">
-                    <statement name="setters">
-                      <block type="molasses_lava_front" id="e]5S2t+{mK$OQv@cLO^t">
-                        <value name="molasses_lava_front">
-                          <block type="math_number" id=",b?)ZY24Ctp.#l6H#EG8">
-                            <field name="NUM">4</field>
-                          </block>
-                        </value>
-                        <next>
-                          <block type="molasses_vent_location" id="molasses_vent_location">
-                            <value name="molasses_vent_location">
-                              <block type="lat_long" id="vent_lat_long">
-                                <field name="lat_long">19.366,-155.740</field>
+                  <block type="molasses_create_table" id="molasses_create_table">
+                    <next>
+                      <block type="molasses_run_simulation" id="bIjG2)~K%-s0~0{5oaS|">
+                        <statement name="setters">
+                          <block type="molasses_lava_front" id="e]5S2t+{mK$OQv@cLO^t">
+                            <value name="molasses_lava_front">
+                              <block type="math_number" id=",b?)ZY24Ctp.#l6H#EG8">
+                                <field name="NUM">4</field>
                               </block>
                             </value>
+                            <next>
+                              <block type="molasses_vent_location" id="molasses_vent_location">
+                                <value name="molasses_vent_location">
+                                  <block type="lat_long" id="vent_lat_long">
+                                    <field name="lat_long">19.366,-155.740</field>
+                                  </block>
+                                </value>
+                              </block>
+                            </next>
                           </block>
-                        </next>
-                      </block>
-                    </statement>
-                    <next>
-                      <block type="molasses_create_table" id="molasses_create_table">
+                        </statement>
                         <next>
                           <block type="molasses_add_row" id="molasses_add_row1">
                             <field name="flag">test</field>

--- a/src/assets/blockly-authoring/code/molasses-location.xml
+++ b/src/assets/blockly-authoring/code/molasses-location.xml
@@ -43,6 +43,15 @@
                             <field name="NUM">4</field>
                           </block>
                         </value>
+                        <next>
+                          <block type="molasses_vent_location" id="molasses_vent_location">
+                            <value name="molasses_vent_location">
+                              <block type="lat_long" id="vent_lat_long">
+                                <field name="lat_long">19.366,-155.740</field>
+                              </block>
+                            </value>
+                          </block>
+                        </next>
                       </block>
                     </statement>
                     <next>
@@ -52,7 +61,7 @@
                             <field name="flag">test</field>
                             <next>
                               <block type="molasses_add_row" id="molasses_add_row2">
-                                <field name="flag">test2</field>
+                                <field name="flag">test4</field>
                               </block>
                             </next>
                           </block>

--- a/src/assets/blockly-authoring/code/molasses-location.xml
+++ b/src/assets/blockly-authoring/code/molasses-location.xml
@@ -42,7 +42,7 @@
                           <block type="molasses_lava_front" id="e]5S2t+{mK$OQv@cLO^t">
                             <value name="molasses_lava_front">
                               <block type="math_number" id=",b?)ZY24Ctp.#l6H#EG8">
-                                <field name="NUM">4</field>
+                                <field name="NUM">10</field>
                               </block>
                             </value>
                             <next>

--- a/src/assets/blockly-authoring/toolbox/molasses-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/molasses-toolbox.xml
@@ -5,6 +5,7 @@
     <block type="molasses_lava_front" />
     <block type="molasses_vent_location" />
     <block type="molasses_set_flag_location" />
+    <block type="molasses_compute_lava" />
   </category>
 
   <category name="Logic" colour="%{BKY_LOGIC_HUE}">

--- a/src/assets/blockly-authoring/toolbox/molasses-toolbox.xml
+++ b/src/assets/blockly-authoring/toolbox/molasses-toolbox.xml
@@ -6,6 +6,7 @@
     <block type="molasses_vent_location" />
     <block type="molasses_set_flag_location" />
     <block type="molasses_compute_lava" />
+    <block type="molasses_add_data" />
   </category>
 
   <category name="Logic" colour="%{BKY_LOGIC_HUE}">

--- a/src/blockly-blocks/lava/block-simulate-lava.ts
+++ b/src/blockly-blocks/lava/block-simulate-lava.ts
@@ -97,6 +97,14 @@ Blockly.Blocks.molasses_compute_lava = {
   }
 };
 
+Blockly.Blocks.molasses_add_data = {
+  init() {
+    basicInit(this, strings.ADD_DATA);
+    addFlagOptions(this, strings.AT_LOCATION);
+    this.appendDummyInput().appendField(strings.TO_TABLE);
+  }
+};
+
 interface GetAndValidateValueParams {
   block: Blockly.Block;
   // If validation fails, call block.setWarningText with the error message. Otherwise, call it with null.
@@ -258,6 +266,13 @@ javascriptGenerator.forBlock.molasses_add_row = function(block) {
 javascriptGenerator.forBlock.molasses_compute_lava = function(block) {
   const flag = block.getFieldValue('flag');
   return `
-  this.computeLavaFlow("${flag}");
+  this.computeLava("${flag}");
+  `;
+};
+
+javascriptGenerator.forBlock.molasses_add_data = function(block) {
+  const flag = block.getFieldValue('flag');
+  return `
+  this.addData("${flag}");
   `;
 };

--- a/src/blockly-blocks/lava/block-simulate-lava.ts
+++ b/src/blockly-blocks/lava/block-simulate-lava.ts
@@ -77,13 +77,23 @@ function getFlagOptions() {
   return options;
 }
 
+function addFlagOptions(block: Blockly.Block, label: string) {
+  block.appendDummyInput()
+    .appendField(label)
+    .appendField(new Blockly.FieldDropdown(getFlagOptions), "flag");
+}
+
 Blockly.Blocks.molasses_add_row = {
   init() {
     basicInit(this, strings.ADD_ROW, dataHue);
-    this.appendDummyInput()
-      .setAlign(RIGHT)
-      .appendField(strings.FOR_FLAG)
-      .appendField(new Blockly.FieldDropdown(getFlagOptions), "flag");
+    addFlagOptions(this, strings.FOR_FLAG);
+  }
+};
+
+Blockly.Blocks.molasses_compute_lava = {
+  init() {
+    basicInit(this, strings.COMPUTE_LAVA);
+    addFlagOptions(this, strings.AT_FLAG);
   }
 };
 
@@ -242,5 +252,12 @@ javascriptGenerator.forBlock.molasses_add_row = function(block) {
   const flag = block.getFieldValue('flag');
   return `
   this.addRowToTable("${flag}");
+  `;
+};
+
+javascriptGenerator.forBlock.molasses_compute_lava = function(block) {
+  const flag = block.getFieldValue('flag');
+  return `
+  this.computeLavaFlow("${flag}");
   `;
 };

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -143,21 +143,34 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
       lavaSimulation.addRowToTable(flag);
     });
 
-    addFunc("computeLavaFlow", (flagName: string) => {
+    addFunc("computeLava", (flagName: string) => {
       if (!flagName) {
         blocklyController.throwError("You must select a flag.");
         return;
       }
 
-      console.log(`--- looking for row for`, flagName);
       const row = lavaSimulation.dataTable?.rows.find(r => r.name === flagName);
-      console.log(` -- row`, row);
       if (!row) {
         blocklyController.throwError(`You must add a row for "${flagName}" before you can compute its lava flow.`);
         return;
       }
 
       row.setLavaDepth(lavaSimulation.lavaDepthAtPoint(row.latitude, row.longitude));
+    });
+
+    addFunc("addData", (flagName: string) => {
+      if (!flagName) {
+        blocklyController.throwError("You must select a flag.");
+        return;
+      }
+
+      const row = lavaSimulation.dataTable?.rows.find(r => r.name === flagName);
+      if (!row) {
+        blocklyController.throwError(`You must add a row for "${flagName}" before you can display its lava impact.`);
+        return;
+      }
+
+      row.setDisplayLava(true);
     });
 
     /** ==== Tephra simulation model setters ==== */

--- a/src/blockly/interpreter.ts
+++ b/src/blockly/interpreter.ts
@@ -143,6 +143,23 @@ const makeInterpreterFunc = (blocklyController: BlocklyController, store: IStore
       lavaSimulation.addRowToTable(flag);
     });
 
+    addFunc("computeLavaFlow", (flagName: string) => {
+      if (!flagName) {
+        blocklyController.throwError("You must select a flag.");
+        return;
+      }
+
+      console.log(`--- looking for row for`, flagName);
+      const row = lavaSimulation.dataTable?.rows.find(r => r.name === flagName);
+      console.log(` -- row`, row);
+      if (!row) {
+        blocklyController.throwError(`You must add a row for "${flagName}" before you can compute its lava flow.`);
+        return;
+      }
+
+      row.setLavaDepth(lavaSimulation.lavaDepthAtPoint(row.latitude, row.longitude));
+    });
+
     /** ==== Tephra simulation model setters ==== */
 
     addFunc("setModelParams", (params: ITephraModelParams) => {

--- a/src/components/lava-coder/data-table.scss
+++ b/src/components/lava-coder/data-table.scss
@@ -22,16 +22,13 @@
     height: 47px;
 
     &.flag {
-      width: 10%;
+      width: 20%;
     }
     &.name {
-      width: 40%;
-    }
-    &.lat-long {
-      width: 30%;
+      width: 50%;
     }
     &.lava {
-      width: 20%;
+      width: 30%;
     }
   }
 

--- a/src/components/lava-coder/data-table.tsx
+++ b/src/components/lava-coder/data-table.tsx
@@ -8,10 +8,10 @@ import "./data-table.scss";
 interface IDataTableRowProps {
   row?: DataRowType;
 }
-function DataTableRow({ row }: IDataTableRowProps) {
+const DataTableRow = observer(function DataTableRow({ row }: IDataTableRowProps) {
   const color = row ? flagColorInfo[row.color ?? ""]?.color ?? "#000" : "#000";
   const label = row?.label ?? "";
-  const lavaImpact = row?.lavaDepth
+  const lavaImpact = row?.displayLava && row.lavaDepth != null
     ? row.lavaDepth > 0 ? "Yes" : "No"
     : "";
 
@@ -29,7 +29,7 @@ function DataTableRow({ row }: IDataTableRowProps) {
       <td className="td-center">{lavaImpact}</td>
     </tr>
   );
-}
+});
 
 interface IDataTableProps {
   dataTable?: DataTableType;

--- a/src/components/lava-coder/data-table.tsx
+++ b/src/components/lava-coder/data-table.tsx
@@ -11,7 +11,6 @@ interface IDataTableRowProps {
 function DataTableRow({ row }: IDataTableRowProps) {
   const color = row ? flagColorInfo[row.color ?? ""]?.color ?? "#000" : "#000";
   const label = row?.label ?? "";
-  const latLong = row ? `${row.latitude ?? ""}°, ${row.longitude ?? ""}°` : "";
   const lavaImpact = row?.lavaDepth
     ? row.lavaDepth > 0 ? "Yes" : "No"
     : "";
@@ -27,7 +26,6 @@ function DataTableRow({ row }: IDataTableRowProps) {
         )}
       </td>
       <td className="td-left">{row?.name ?? ""}</td>
-      <td className="td-center">{latLong}</td>
       <td className="td-center">{lavaImpact}</td>
     </tr>
   );
@@ -46,7 +44,6 @@ export const DataTable = observer(function DataTable({ dataTable }: IDataTablePr
           <tr>
             <th className="flag">Flag</th>
             <th className="name">Flag Name</th>
-            <th className="lat-long">Lat/Long</th>
             <th className="lava">Lava Impact?</th>
           </tr>
         </thead>

--- a/src/models/data-table.ts
+++ b/src/models/data-table.ts
@@ -3,9 +3,7 @@ import { types } from "mobx-state-tree";
 export const DataRow = types.model("DataRow", {
   color: types.string,
   label: types.string,
-  latitude: types.number,
   lavaDepth: types.maybe(types.number),
-  longitude: types.number,
   name: types.string,
 })
 .actions(self => ({

--- a/src/models/data-table.ts
+++ b/src/models/data-table.ts
@@ -3,7 +3,9 @@ import { types } from "mobx-state-tree";
 export const DataRow = types.model("DataRow", {
   color: types.string,
   label: types.string,
+  latitude: types.number,
   lavaDepth: types.maybe(types.number),
+  longitude: types.number,
   name: types.string,
 })
 .actions(self => ({

--- a/src/models/data-table.ts
+++ b/src/models/data-table.ts
@@ -2,6 +2,7 @@ import { types } from "mobx-state-tree";
 
 export const DataRow = types.model("DataRow", {
   color: types.string,
+  displayLava: types.optional(types.boolean, false),
   label: types.string,
   latitude: types.number,
   lavaDepth: types.maybe(types.number),
@@ -9,6 +10,9 @@ export const DataRow = types.model("DataRow", {
   name: types.string,
 })
 .actions(self => ({
+  setDisplayLava(display: boolean) {
+    self.displayLava = display;
+  },
   setLavaDepth(depth: number) {
     self.lavaDepth = depth;
   }

--- a/src/stores/lava-simulation-store.ts
+++ b/src/stores/lava-simulation-store.ts
@@ -85,6 +85,17 @@ export const LavaSimulationStore = types
         }
       }
       return false;
+    },
+    lavaDepthAtPoint(latitude: number, longitude: number) {
+      if (!lavaElevations || !gridBounds) return 0;
+
+      const { east, north, south, west } = gridBounds;
+      const column = Math.floor((longitude - west) / (east - west) * lavaElevations[0].length);
+      const row = Math.floor((north - latitude) / (north - south) * lavaElevations.length);
+      if (row < 0 || row >= lavaElevations.length || column < 0 || column >= lavaElevations[0].length) {
+        return 0;
+      }
+      return lavaElevations[row][column];
     }
   }))
   .views((self) => ({

--- a/src/strings/blockly-blocks/lava/simulate-lava.ts
+++ b/src/strings/blockly-blocks/lava/simulate-lava.ts
@@ -6,4 +6,6 @@ export const SET_FLAG_LOCATION = "Set flag location";
 export const CREATE_TABLE = "Create a data table";
 export const ADD_ROW = "Create row in data table";
 export const FOR_FLAG = "For flag";
+export const COMPUTE_LAVA = "Compute lava flow impact";
+export const AT_FLAG = "At flag";
 export const SELECT_LOCATION = "<Select location>";

--- a/src/strings/blockly-blocks/lava/simulate-lava.ts
+++ b/src/strings/blockly-blocks/lava/simulate-lava.ts
@@ -8,4 +8,7 @@ export const ADD_ROW = "Create row in data table";
 export const FOR_FLAG = "For flag";
 export const COMPUTE_LAVA = "Compute lava flow impact";
 export const AT_FLAG = "At flag";
+export const ADD_DATA = "Add data from flag";
+export const AT_LOCATION = "at location";
+export const TO_TABLE = "to the data table";
 export const SELECT_LOCATION = "<Select location>";


### PR DESCRIPTION
Jira stories:
https://concord-consortium.atlassian.net/browse/GEOCODE-91
https://concord-consortium.atlassian.net/browse/GEOCODE-95
https://concord-consortium.atlassian.net/browse/GEOCODE-96

This PR addresses some requests that were made after the last round of table work. It also adds two new blocks, "Compute lava flow impact" and "Add data from flag", which are used to populate the table with more information about an eruption.

As part of this work, I tried adding some cypress tests for the LavaCoder simulation. Unfortunately, after many attempts, I was never able to get these tests to work on github, even though they worked locally. I suspect it has to do with loading cesium remotely, but I'm not sure. The error cypress reported (included below) is not very helpful. I'm keeping these tests in but skipping them because It would be great to add some tests for this sim.

```
CypressError: The following error originated from your application code, not from Cypress. It was caused by an unhandled promise rejection.

  > 

When Cypress detects uncaught errors originating from your application it will automatically fail the current test.
```