### PR TITLE
chore: cesium license compliance

### DIFF
--- a/src/components/lava-coder/concord-attribution.scss
+++ b/src/components/lava-coder/concord-attribution.scss
@@ -1,3 +1,12 @@
+// disable links on data attribution overlay so users aren't tempted to navigate away
+.cesium-credit-lightbox {
+  .cesium-credit-wrapper {
+    a {
+      pointer-events: none !important;
+    }
+  }
+}
+
 // overlay to prevent students from navigating away from the simulation
 .cesium-attribution-overlay {
   position: absolute;
@@ -14,7 +23,7 @@
   width: 220px;
   height: 28px;
   bottom: 0;
-  left: 140px;
+  left: 212px;
   background: rgba(255, 255, 255, 0.01); /* semi-transparent background */
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px); /* for Safari */

--- a/src/components/lava-coder/concord-attribution.tsx
+++ b/src/components/lava-coder/concord-attribution.tsx
@@ -1,12 +1,24 @@
+import { useEffect, useRef } from "react";
 import ConcordLogo from "../../assets/concord.png";
 
 import "./concord-attribution.scss";
 
 export function ConcordAttribution() {
+  const attributionRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    // hide cesium "upgrade for commercial use" link
+    const parent = attributionRef.current?.closest(".lava-coder-view");
+    const cesiumUpgradeTextContainer = parent?.querySelector<HTMLDivElement>(".cesium-credit-textContainer");
+    if (cesiumUpgradeTextContainer) {
+      cesiumUpgradeTextContainer.style.display = "none";
+    }
+  });
+
   return (
     <>
       <div className="cesium-attribution-overlay" aria-hidden="true" />
-      <div className="concord-attribution">
+      <div className="concord-attribution" ref={attributionRef}>
         <img src={ConcordLogo} alt="Concord Consortium Logo" />
         <span>Concord Consortium</span>
       </div>


### PR DESCRIPTION
[[GEOCODE-107](https://concord-consortium.atlassian.net/browse/GEOCODE-107)] Review/follow cesium library licensing terms

Details are in the story, but the upshot is that to be in compliance with the licensing terms we need to make the `data attribution` available. If we don't like the default cesium data attribution overlay we can design our own about box that contains the relevant information.

[GEOCODE-107]: https://concord-consortium.atlassian.net/browse/GEOCODE-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ